### PR TITLE
Add pb script directives for testing and variable extraction

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,6 +13,7 @@
     activeFile, activeRequest, activeFileVariables,
     envFile, userEnvFile, activeEnvironment, availableEnvironments,
     resolvedEnvVars, namedResults, dotenvVariables,
+    pbTestResults, pbGlobals,
     updateRequestInTree, addRequestToFile, deleteRequestFromFile,
     toggleFolder, markFileSaved, addToast,
     tabs, isPreview, pinTab, activateTab, closeTab, previewRequest,
@@ -21,10 +22,11 @@
   import {
     serializeHttpFile, substituteAll, parseEnvironmentFile,
     buildWorkspaceTree, createFileNode, getAllFileNodes,
+    executePbDirectives,
   } from './lib/parser';
   import { importPostmanCollection } from './lib/postman';
   import { importInsomniaExport } from './lib/insomnia';
-  import type { HttpRequest, HttpResponse, SubstitutionContext, RequestLocation, EnvironmentFile, TreeNode, ImportResult } from './lib/types';
+  import type { HttpRequest, HttpResponse, SubstitutionContext, RequestLocation, EnvironmentFile, TreeNode, ImportResult, PbTestResult } from './lib/types';
   import type { DiscoveredFile } from './lib/parser';
 
   import { open } from '@tauri-apps/plugin-dialog';
@@ -381,6 +383,7 @@
   async function sendRequest(request: HttpRequest) {
     isLoading.set(true);
     currentResponse.set(null);
+    pbTestResults.set([]);
     sentRequest = null;
 
     const ctx = getSubstitutionContext();
@@ -428,6 +431,44 @@
             response,
           },
         }));
+      }
+
+      // ── Execute pb directives ──
+      if (request.directives && request.directives.length > 0) {
+        const mergedVars: Record<string, string> = { ...$resolvedEnvVars, ...$pbGlobals };
+        for (const v of $activeFileVariables) mergedVars[v.key] = v.value;
+
+        const pbResult = executePbDirectives(
+          request.directives, response,
+          { url, method: request.method, headers, body },
+          mergedVars,
+        );
+
+        pbTestResults.set(pbResult.testResults);
+
+        // Apply set vars as named results so {{key}} resolves in later requests
+        if (Object.keys(pbResult.setVars).length > 0) {
+          namedResults.update(nr => {
+            const updated = { ...nr };
+            for (const [key, value] of Object.entries(pbResult.setVars)) {
+              // Store as a pseudo named result so substituteAll can pick it up.
+              // We also inject into env vars for simpler resolution.
+              updated[`__pb_${key}`] = {
+                request: { url, method: request.method, headers, body },
+                response,
+              };
+            }
+            return updated;
+          });
+          // Inject set vars into the environment so {{key}} works directly
+          resolvedEnvVars.update(ev => ({ ...ev, ...pbResult.setVars }));
+        }
+
+        // Apply global vars
+        if (Object.keys(pbResult.globalVars).length > 0) {
+          pbGlobals.update(g => ({ ...g, ...pbResult.globalVars }));
+          resolvedEnvVars.update(ev => ({ ...ev, ...pbResult.globalVars }));
+        }
       }
     } catch (e: any) {
       currentResponse.set({
@@ -642,7 +683,7 @@
           </div>
           <div class="divider" on:mousedown={onDividerDown} role="separator"></div>
           <div class="response-pane">
-            <ResponseViewer response={$currentResponse} loading={$isLoading} {sentRequest} />
+            <ResponseViewer response={$currentResponse} loading={$isLoading} {sentRequest} testResults={$pbTestResults} />
           </div>
         {:else}
           <div class="no-selection">

--- a/src/components/ResponseViewer.svelte
+++ b/src/components/ResponseViewer.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
-  import type { HttpResponse } from '../lib/types';
+  import type { HttpResponse, PbTestResult } from '../lib/types';
 
   export let response: HttpResponse | null = null;
   export let loading: boolean = false;
   export let sentRequest: { method: string; url: string; headers: Record<string, string>; body: string } | null = null;
+  export let testResults: PbTestResult[] = [];
 
-  let activeTab: 'body' | 'headers' | 'request' = 'body';
+  let activeTab: 'body' | 'headers' | 'request' | 'tests' = 'body';
+
+  $: passedCount = testResults.filter(t => t.passed).length;
+  $: failedCount = testResults.filter(t => !t.passed).length;
 
   function getStatusClass(status: number): string {
     if (status >= 200 && status < 300) return 'status-success';
@@ -126,6 +130,18 @@
           Request
         </button>
       {/if}
+      {#if testResults.length > 0}
+        <button
+          class="tab"
+          class:active={activeTab === 'tests'}
+          on:click={() => activeTab = 'tests'}
+        >
+          Tests
+          <span class="tab-count test-count" class:all-pass={failedCount === 0} class:has-fail={failedCount > 0}>
+            {passedCount}/{testResults.length}
+          </span>
+        </button>
+      {/if}
     </div>
 
     <!-- Content -->
@@ -146,6 +162,15 @@
         </div>
       {:else if activeTab === 'request' && sentRequest}
         <pre class="body-output">{formatRawRequest(sentRequest)}</pre>
+      {:else if activeTab === 'tests'}
+        <div class="test-results">
+          {#each testResults as result}
+            <div class="test-entry" class:pass={result.passed} class:fail={!result.passed}>
+              <span class="test-icon">{result.passed ? '\u2713' : '\u2717'}</span>
+              <span class="test-label">{result.label}</span>
+            </div>
+          {/each}
+        </div>
       {/if}
     </div>
   {/if}
@@ -379,4 +404,35 @@
     font-size: 12px;
     background: #FFFFFF;
   }
+
+  /* Test Results */
+  .test-count.all-pass { background: #3D8B4520; color: #3D8B45; }
+  .test-count.has-fail { background: #CC445520; color: #CC4455; }
+
+  .test-results {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    background: #DCDCE2;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .test-entry {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: #FFFFFF;
+    font-size: 12px;
+  }
+  .test-icon {
+    font-weight: 700;
+    font-size: 14px;
+    width: 18px;
+    text-align: center;
+  }
+  .test-entry.pass .test-icon { color: #3D8B45; }
+  .test-entry.fail .test-icon { color: #CC4455; }
+  .test-entry.pass .test-label { color: #4A4A58; }
+  .test-entry.fail .test-label { color: #CC4455; font-weight: 500; }
 </style>

--- a/src/lib/insomnia.ts
+++ b/src/lib/insomnia.ts
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import type { HttpMethod, HttpHeader, Variable, ConvertedFile, ImportResult } from './types';
+import type { HttpMethod, HttpHeader, HttpRequest, Variable, ConvertedFile, ImportResult } from './types';
 import { serializeHttpFile, extractVariableRefs } from './parser';
 
 // ─── Shared Types ──────────────────────────────────────────────────────────
@@ -205,7 +205,7 @@ function collectV5Files(
 function convertV5Request(
   item: V5Item,
   nameById: Map<string, string>,
-): { id: string; name: string; varName: null; method: HttpMethod; url: string; headers: HttpHeader[]; body: string } {
+): HttpRequest {
   const method = normalizeMethod(item.method ?? 'GET');
 
   // Build URL: replace :param with pathParameter values, then append query params
@@ -230,6 +230,7 @@ function convertV5Request(
     url,
     headers,
     body,
+    directives: [],
   };
 }
 
@@ -330,7 +331,7 @@ function collectV4Files(
 function convertV4Request(
   resource: V4Resource,
   nameById: Map<string, string>,
-): { id: string; name: string; varName: null; method: HttpMethod; url: string; headers: HttpHeader[]; body: string } {
+): HttpRequest {
   const method = normalizeMethod(resource.method ?? 'GET');
   const rawUrl = appendQueryParams(resource.url || 'https://', resource.parameters);
   const url = convertTemplateVars(rawUrl, nameById);
@@ -346,6 +347,7 @@ function convertV4Request(
     url,
     headers,
     body,
+    directives: [],
   };
 }
 

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,7 +1,8 @@
 import type {
   HttpRequest, HttpMethod, HttpHeader, Variable,
   EnvironmentFile, EnvironmentVariables, ProviderVariable,
-  NamedRequestResult,
+  NamedRequestResult, PbDirective, PbTestResult,
+  HttpResponse,
   TreeNode, FileNode, FolderNode,
 } from './types';
 
@@ -35,6 +36,9 @@ const COMMENT_RE = /^(#(?!##)|\/\/)/;
 
 /** Request variable name: # @name foo  or  // @name foo */
 const NAME_DIRECTIVE_RE = /^(?:#|\/\/)\s*@name\s+(\S+)\s*$/;
+
+/** Pb directive: # @pb.set("key", expr) or # @pb.global("key", expr) or # @pb.test(expr, "label") */
+const PB_DIRECTIVE_RE = /^(?:#|\/\/)\s*@pb\.(\w+)\((.+)\)\s*$/;
 
 /** Dynamic variable: {{$something ...}} */
 const DYNAMIC_VAR_RE = /\{\{\$(\w+)(?:\s+(.+?))?\}\}/g;
@@ -85,6 +89,7 @@ export function parseHttpFile(content: string): ParseResult {
   let currentUrl = '';
   let currentHeaders: HttpHeader[] = [];
   let currentBody: string[] = [];
+  let currentDirectives: PbDirective[] = [];
   let inBody = false;
   let hasRequest = false;
 
@@ -98,6 +103,7 @@ export function parseHttpFile(content: string): ParseResult {
         url: currentUrl,
         headers: currentHeaders,
         body: currentBody.join('\n').trim(),
+        directives: currentDirectives,
       });
     }
     currentName = '';
@@ -106,6 +112,7 @@ export function parseHttpFile(content: string): ParseResult {
     currentUrl = '';
     currentHeaders = [];
     currentBody = [];
+    currentDirectives = [];
     inBody = false;
     hasRequest = false;
   }
@@ -131,6 +138,14 @@ export function parseHttpFile(content: string): ParseResult {
       if (!currentName) {
         currentName = nameMatch[1]; // Use varName as display name fallback
       }
+      continue;
+    }
+
+    // ── Pb directives: # @pb.set(...), # @pb.test(...), # @pb.global(...) ──
+    const pbMatch = line.match(PB_DIRECTIVE_RE);
+    if (pbMatch) {
+      const directive = parsePbDirective(pbMatch[1], pbMatch[2]);
+      if (directive) currentDirectives.push(directive);
       continue;
     }
 
@@ -247,6 +262,24 @@ export function serializeHttpFile(requests: HttpRequest[], variables: Variable[]
     if (req.body.trim()) {
       parts.push('');
       parts.push(req.body);
+    }
+
+    // Pb directives
+    if (req.directives && req.directives.length > 0) {
+      parts.push('');
+      for (const d of req.directives) {
+        switch (d.type) {
+          case 'set':
+            parts.push(`# @pb.set("${d.key}", ${d.expr})`);
+            break;
+          case 'global':
+            parts.push(`# @pb.global("${d.key}", ${d.expr})`);
+            break;
+          case 'test':
+            parts.push(`# @pb.test(${d.expr}, "${d.label}")`);
+            break;
+        }
+      }
     }
   }
 
@@ -575,6 +608,216 @@ function getByPath(obj: any, path: string): any {
   return current;
 }
 
+// ─── Pb Directive Parsing ────────────────────────────────────────────────────
+
+/**
+ * Parse a raw directive call like `set("key", pb.response.body.$.token)` into
+ * a typed PbDirective. Returns null if the syntax is unrecognized.
+ */
+function parsePbDirective(action: string, argsRaw: string): PbDirective | null {
+  const args = argsRaw.trim();
+
+  if (action === 'set' || action === 'global') {
+    // pb.set("key", expr)  or  pb.global("key", expr)
+    const m = args.match(/^(["'])(.+?)\1\s*,\s*(.+)$/);
+    if (!m) return null;
+    return { type: action, key: m[2], expr: m[3].trim() };
+  }
+
+  if (action === 'test') {
+    // pb.test(expr, "label")
+    // Find the last quoted string as the label
+    const labelMatch = args.match(/,\s*(["'])(.+?)\1\s*$/);
+    if (!labelMatch) return null;
+    const expr = args.slice(0, args.lastIndexOf(labelMatch[0])).trim();
+    return { type: 'test', expr, label: labelMatch[2] };
+  }
+
+  return null;
+}
+
+// ─── Pb Expression Evaluator ────────────────────────────────────────────────
+
+interface PbEvalContext {
+  response: HttpResponse;
+  request: { url: string; method: string; headers: Record<string, string>; body: string };
+  variables: Record<string, string>;
+}
+
+/**
+ * Evaluate a pb expression like:
+ *   pb.response.status
+ *   pb.response.body.$.token
+ *   pb.response.headers.Content-Type
+ *   "some string"
+ *   123
+ *   null
+ *   pb.response.status == 200
+ *   pb.response.body.$.name != null
+ *   pb.response.body.$.items.length > 0
+ */
+export function evaluatePbExpression(expr: string, ctx: PbEvalContext): unknown {
+  const trimmed = expr.trim();
+
+  // ── Comparison operators ──
+  const compOps = ['==', '!=', '>=', '<=', '>', '<', ' contains ', ' startsWith ', ' endsWith '] as const;
+  for (const op of compOps) {
+    const idx = trimmed.indexOf(op);
+    if (idx !== -1) {
+      const left = evaluatePbExpression(trimmed.slice(0, idx), ctx);
+      const right = evaluatePbExpression(trimmed.slice(idx + op.length), ctx);
+      const leftStr = String(left);
+      const rightStr = String(right);
+      switch (op.trim()) {
+        case '==': return left == right || leftStr === rightStr;
+        case '!=': return left != right && leftStr !== rightStr;
+        case '>':  return Number(left) > Number(right);
+        case '<':  return Number(left) < Number(right);
+        case '>=': return Number(left) >= Number(right);
+        case '<=': return Number(left) <= Number(right);
+        case 'contains': return leftStr.includes(rightStr);
+        case 'startsWith': return leftStr.startsWith(rightStr);
+        case 'endsWith': return leftStr.endsWith(rightStr);
+      }
+    }
+  }
+
+  // ── Logical operators (&&, ||) ──
+  const andIdx = trimmed.indexOf('&&');
+  if (andIdx !== -1) {
+    return evaluatePbExpression(trimmed.slice(0, andIdx), ctx) &&
+           evaluatePbExpression(trimmed.slice(andIdx + 2), ctx);
+  }
+  const orIdx = trimmed.indexOf('||');
+  if (orIdx !== -1) {
+    return evaluatePbExpression(trimmed.slice(0, orIdx), ctx) ||
+           evaluatePbExpression(trimmed.slice(orIdx + 2), ctx);
+  }
+
+  // ── Negation ──
+  if (trimmed.startsWith('!')) {
+    return !evaluatePbExpression(trimmed.slice(1), ctx);
+  }
+
+  // ── Literals ──
+  if (trimmed === 'null') return null;
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+
+  // ── pb.response.* access ──
+  if (trimmed.startsWith('pb.response.')) {
+    const path = trimmed.slice('pb.response.'.length);
+    return resolvePbResponsePath(path, ctx.response);
+  }
+
+  // ── pb.request.* access ──
+  if (trimmed.startsWith('pb.request.')) {
+    const path = trimmed.slice('pb.request.'.length);
+    if (path === 'url') return ctx.request.url;
+    if (path === 'method') return ctx.request.method;
+    if (path === 'body') return ctx.request.body;
+    if (path.startsWith('headers.')) {
+      const hdrName = path.slice('headers.'.length);
+      const entry = Object.entries(ctx.request.headers).find(
+        ([k]) => k.toLowerCase() === hdrName.toLowerCase()
+      );
+      return entry ? entry[1] : null;
+    }
+    return null;
+  }
+
+  // ── Variable reference: {{varName}} ──
+  const varMatch = trimmed.match(/^\{\{(.+?)\}\}$/);
+  if (varMatch) {
+    return ctx.variables[varMatch[1]] ?? null;
+  }
+
+  // ── Fallback: treat as unresolved ──
+  return trimmed;
+}
+
+/** Resolve a path like "status", "body.$.token", "headers.Content-Type" against an HttpResponse. */
+function resolvePbResponsePath(path: string, response: HttpResponse): unknown {
+  if (path === 'status') return response.status;
+  if (path === 'statusText') return response.statusText;
+  if (path === 'body') return response.body;
+  if (path === 'time') return response.time;
+  if (path === 'size') return response.size;
+
+  if (path.startsWith('headers.')) {
+    const hdrName = path.slice('headers.'.length).toLowerCase();
+    const entry = Object.entries(response.headers).find(
+      ([k]) => k.toLowerCase() === hdrName
+    );
+    return entry ? entry[1] : null;
+  }
+
+  if (path.startsWith('body.$.')) {
+    const jsonPath = path.slice('body.$.'.length);
+    try {
+      const parsed = JSON.parse(response.body);
+      return getByPath(parsed, jsonPath) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+// ─── Pb Directive Executor ──────────────────────────────────────────────────
+
+export interface PbExecutionResult {
+  testResults: PbTestResult[];
+  setVars: Record<string, string>;
+  globalVars: Record<string, string>;
+}
+
+/**
+ * Execute all pb directives for a request after its response has been received.
+ */
+export function executePbDirectives(
+  directives: PbDirective[],
+  response: HttpResponse,
+  request: { url: string; method: string; headers: Record<string, string>; body: string },
+  variables: Record<string, string>,
+): PbExecutionResult {
+  const ctx: PbEvalContext = { response, request, variables };
+  const result: PbExecutionResult = { testResults: [], setVars: {}, globalVars: {} };
+
+  for (const d of directives) {
+    switch (d.type) {
+      case 'set': {
+        const value = evaluatePbExpression(d.expr, ctx);
+        const strValue = value == null ? '' : String(value);
+        result.setVars[d.key] = strValue;
+        // Make immediately available to subsequent directives
+        ctx.variables[d.key] = strValue;
+        break;
+      }
+      case 'global': {
+        const value = evaluatePbExpression(d.expr, ctx);
+        const strValue = value == null ? '' : String(value);
+        result.globalVars[d.key] = strValue;
+        ctx.variables[d.key] = strValue;
+        break;
+      }
+      case 'test': {
+        const value = evaluatePbExpression(d.expr, ctx);
+        result.testResults.push({ label: d.label, passed: !!value });
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
 // ─── Environment File Handling ──────────────────────────────────────────────
 
 /**
@@ -666,6 +909,7 @@ export function createEmptyRequest(name?: string): HttpRequest {
     url: 'https://',
     headers: [],
     body: '',
+    directives: [],
   };
 }
 

--- a/src/lib/postman.ts
+++ b/src/lib/postman.ts
@@ -1,4 +1,4 @@
-import type { HttpMethod, HttpHeader, ConvertedFile, ImportResult } from './types';
+import type { HttpMethod, HttpHeader, HttpRequest, ConvertedFile, ImportResult } from './types';
 import { serializeHttpFile, extractVariableRefs } from './parser';
 
 // ─── Postman Collection v2.1 Types ─────────────────────────────────────────
@@ -177,7 +177,7 @@ function convertItemsToHttp(
 function convertRequest(
   item: PostmanItem,
   collectionAuth?: PostmanAuth,
-): { id: string; name: string; varName: null; method: HttpMethod; url: string; headers: HttpHeader[]; body: string } {
+): HttpRequest {
   const req = item.request!;
   const method = normalizeMethod(req.method);
   const url = buildUrl(req.url);
@@ -192,6 +192,7 @@ function convertRequest(
     url,
     headers,
     body,
+    directives: [],
   };
 }
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,7 +1,7 @@
 import { writable, derived, get } from 'svelte/store';
 import type {
   HttpFile, HttpRequest, HttpResponse, Variable,
-  EnvironmentFile, NamedRequestResult,
+  EnvironmentFile, NamedRequestResult, PbTestResult,
   Workspace, TreeNode, FileNode, FolderNode, RequestLocation,
 } from './types';
 import { createEmptyRequest, resolveEnvironmentVariables, getEnvironmentNames, serializeHttpFile } from './parser';
@@ -300,6 +300,14 @@ export const resolvedEnvVars = derived(
 
 export const namedResults = writable<Record<string, NamedRequestResult>>({});
 export const dotenvVariables = writable<Record<string, string>>({});
+
+// ─── Pb Script State ─────────────────────────────────────────────────────────
+
+/** Test results from the most recent request's pb directives. */
+export const pbTestResults = writable<PbTestResult[]>([]);
+
+/** Workspace-global variables set via `# @pb.global(...)`. Persist across requests and files. */
+export const pbGlobals = writable<Record<string, string>>({});
 
 // ─── Error / Toast Notifications ────────────────────────────────────────────
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,8 @@ export interface HttpRequest {
   url: string;
   headers: HttpHeader[];
   body: string;
+  /** Pb script directives (`# @pb.set(...)`, `# @pb.test(...)`, etc.) */
+  directives: PbDirective[];
 }
 
 export interface HttpResponse {
@@ -136,6 +138,20 @@ export interface ImportResult {
    * Includes both collection-defined variables (with values) and undefined ones (empty value).
    */
   discoveredVariables: Variable[];
+}
+
+// ─── Pb Script Directives ───────────────────────────────────────────────────
+
+/** A parsed `# @pb.*` directive attached to a request. */
+export type PbDirective =
+  | { type: 'set'; key: string; expr: string }
+  | { type: 'global'; key: string; expr: string }
+  | { type: 'test'; expr: string; label: string };
+
+/** Result of a single pb.test() assertion. */
+export interface PbTestResult {
+  label: string;
+  passed: boolean;
 }
 
 // ─── Request Variable References ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR adds support for pb script directives—a lightweight scripting system for HTTP requests that enables test assertions and dynamic variable extraction from responses. Users can now attach `# @pb.set()`, `# @pb.global()`, and `# @pb.test()` directives to requests to validate responses and capture values for use in subsequent requests.

## Key Changes

- **Pb Directive Parsing**: Added regex-based parsing for three directive types:
  - `# @pb.set("key", expr)` — Extract a value into a request-scoped variable
  - `# @pb.global("key", expr)` — Extract a value into a workspace-global variable
  - `# @pb.test(expr, "label")` — Assert a condition and record the result

- **Expression Evaluator**: Implemented `evaluatePbExpression()` to support:
  - Response access: `pb.response.status`, `pb.response.body.$.path`, `pb.response.headers.X-Header`
  - Request access: `pb.request.url`, `pb.request.method`, `pb.request.body`, `pb.request.headers.*`
  - Comparison operators: `==`, `!=`, `>`, `<`, `>=`, `<=`
  - String operations: `contains`, `startsWith`, `endsWith`
  - Logical operators: `&&`, `||`, `!`
  - Literals: strings, numbers, booleans, null
  - Variable references: `{{varName}}`

- **Directive Execution**: Added `executePbDirectives()` to run directives after a response is received, returning test results and extracted variables

- **UI Integration**: 
  - Extended `ResponseViewer` with a "Tests" tab showing pass/fail results with visual indicators
  - Test count badge displays passed/failed ratio with color coding
  - Integrated pb directive execution into the request flow in `App.svelte`

- **State Management**: Added two new stores:
  - `pbTestResults` — Tracks test results from the most recent request
  - `pbGlobals` — Persists workspace-global variables across requests

- **Type Definitions**: Added `PbDirective` and `PbTestResult` types to support the new functionality

- **Serialization**: Updated `serializeHttpFile()` to preserve directives when saving HTTP files

- **Import Compatibility**: Updated Postman and Insomnia importers to initialize the `directives` array on converted requests

## Implementation Details

- Directives are parsed during HTTP file parsing and stored on each `HttpRequest`
- Expression evaluation uses a recursive descent approach with operator precedence handling
- JSON path resolution for response body uses the existing `getByPath()` utility
- Set variables are immediately available to subsequent directives in the same request
- Global variables persist in the workspace store and are merged into the environment for variable substitution

https://claude.ai/code/session_01JMD8gnSqGhELYWu9178Rzu