### PR TITLE
feat(tabs): persist active sub-tabs per pinned request

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,7 +17,7 @@
     updateRequestInTree, addRequestToFile, deleteRequestFromFile,
     toggleFolder, markFileSaved, addToast,
     tabs, isPreview, pinTab, activateTab, closeTab, previewRequest,
-    cacheCurrentTabResponse,
+    cacheCurrentTabResponse, currentSentRequest, setTabBottomTab, setTabResponseTab,
   } from './lib/stores';
   import {
     serializeHttpFile, substituteAll, parseEnvironmentFile,
@@ -28,6 +28,7 @@
   import { importPostmanCollection } from './lib/postman';
   import { importInsomniaExport } from './lib/insomnia';
   import type { HttpRequest, HttpResponse, RequestLocation, EnvironmentFile, TreeNode, ImportResult, PbAssertionResult } from './lib/types';
+  import type { BottomTab, ResponseTab } from './lib/stores';
   import type { DiscoveredFile } from './lib/parser';
 
   import { open } from '@tauri-apps/plugin-dialog';
@@ -38,8 +39,6 @@
 
   let showEnvEditor = false;
 
-  /** The raw request that was actually sent (resolved URLs, headers, body). */
-  let sentRequest: { method: string; url: string; headers: Record<string, string>; body: string } | null = null;
   let showHelp = false;
 
   // ─── Import Environment Modal ───
@@ -168,9 +167,41 @@
     if (lastEnv !== null) {
       namedResults.set({});
       currentResponse.set(null);
-      sentRequest = null;
+      currentSentRequest.set(null);
     }
     lastEnv = $activeEnvironment;
+  }
+
+  // Active tab's section tab (Body/Assertions) for pinned tabs
+  $: activeBottomTab = (() => {
+    const key = $tabs.length > 0 && $selectedLocation
+      ? `${$selectedLocation.filePath}::${$selectedLocation.requestIndex}`
+      : null;
+    if (!key) return 'body' as BottomTab;
+    const tab = $tabs.find(t => `${t.location.filePath}::${t.location.requestIndex}` === key);
+    return tab?.bottomTab ?? 'body' as BottomTab;
+  })();
+
+  function handleBottomTabChange(e: CustomEvent<BottomTab>) {
+    if ($selectedLocation) {
+      setTabBottomTab($selectedLocation, e.detail);
+    }
+  }
+
+  // Active response tab (Body/Headers/Request/Assertions) for pinned tabs
+  $: activeResponseTab = (() => {
+    const key = $tabs.length > 0 && $selectedLocation
+      ? `${$selectedLocation.filePath}::${$selectedLocation.requestIndex}`
+      : null;
+    if (!key) return 'body' as ResponseTab;
+    const tab = $tabs.find(t => `${t.location.filePath}::${t.location.requestIndex}` === key);
+    return tab?.responseTab ?? 'body' as ResponseTab;
+  })();
+
+  function handleResponseTabChange(e: CustomEvent<ResponseTab>) {
+    if ($selectedLocation) {
+      setTabResponseTab($selectedLocation, e.detail);
+    }
   }
 
   // Reactive resolved URL - all store dependencies are explicit so Svelte tracks them
@@ -202,7 +233,7 @@
       currentResponse.set(null);
       namedResults.set({});
       tabs.set([]);
-      sentRequest = null;
+      currentSentRequest.set(null);
 
       // Reset environment state before loading new env files
       envFile.set(null);
@@ -385,7 +416,7 @@
     isLoading.set(true);
     currentResponse.set(null);
     pbAssertionResults.set([]);
-    sentRequest = null;
+    currentSentRequest.set(null);
 
     const ctx = getSubstitutionContext();
     const startTime = performance.now();
@@ -400,7 +431,7 @@
         }
       }
 
-      sentRequest = { method: request.method, url, headers, body };
+      currentSentRequest.set({ method: request.method, url, headers, body });
 
       const res: { status: number; status_text: string; headers: Record<string, string>; body: string } =
         await invoke('http_request', {
@@ -479,7 +510,7 @@
       });
     } finally {
       isLoading.set(false);
-      cacheCurrentTabResponse(sentRequest);
+      cacheCurrentTabResponse($currentSentRequest);
     }
   }
 
@@ -678,16 +709,18 @@
               fileVariables={$activeFileVariables}
               envVariables={$resolvedEnvVars}
               namedResults={$namedResults}
+              bottomTab={activeBottomTab}
               on:update={handleUpdateRequest}
               on:send={(e) => sendRequest(e.detail)}
               on:save={saveActiveFile}
               on:runAll={handleRunAll}
+              on:bottomTabChange={handleBottomTabChange}
             />
           </div>
           <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
           <div class="divider" on:mousedown={onDividerDown} role="separator"></div>
           <div class="response-pane">
-            <ResponseViewer response={$currentResponse} loading={$isLoading} {sentRequest} assertionResults={$pbAssertionResults} />
+            <ResponseViewer response={$currentResponse} loading={$isLoading} sentRequest={$currentSentRequest} assertionResults={$pbAssertionResults} activeTab={activeResponseTab} on:tabChange={handleResponseTabChange} />
           </div>
         {:else}
           <div class="no-selection">

--- a/src/components/RequestEditor.svelte
+++ b/src/components/RequestEditor.svelte
@@ -27,9 +27,10 @@
     CONNECT: '#CC4455',
   };
 
+  export let bottomTab: 'body' | 'assertions' = 'body';
+
   let headersOpen = true;
   let assertionsOpen = true;
-  let bottomTab: 'body' | 'assertions' = 'body';
   let showPicker = false;
   let pickerTarget: 'url' | 'headerKey' | 'headerValue' | 'body' | 'assertions' | null = null;
   let pickerHeaderIndex: number = -1;
@@ -352,10 +353,10 @@
   <!-- Bottom tabbed panel -->
   <div class="bottom-panel">
     <div class="bottom-tabs">
-      <button class="bottom-tab" class:active={bottomTab === 'body'} on:click={() => bottomTab = 'body'}>
+      <button class="bottom-tab" class:active={bottomTab === 'body'} on:click={() => { bottomTab = 'body'; dispatch('bottomTabChange', bottomTab); }}>
         Body
       </button>
-      <button class="bottom-tab" class:active={bottomTab === 'assertions'} on:click={() => bottomTab = 'assertions'}>
+      <button class="bottom-tab" class:active={bottomTab === 'assertions'} on:click={() => { bottomTab = 'assertions'; dispatch('bottomTabChange', bottomTab); }}>
         Assertions
         {#if assertionDirectives.length > 0}
           <span class="section-count">{assertionDirectives.length}</span>

--- a/src/components/ResponseViewer.svelte
+++ b/src/components/ResponseViewer.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import type { HttpResponse, PbAssertionResult } from '../lib/types';
+  import type { ResponseTab } from '../lib/stores';
 
   export let response: HttpResponse | null = null;
   export let loading: boolean = false;
   export let sentRequest: { method: string; url: string; headers: Record<string, string>; body: string } | null = null;
   export let assertionResults: PbAssertionResult[] = [];
+  export let activeTab: ResponseTab = 'body';
 
-  let activeTab: 'body' | 'headers' | 'request' | 'assertions' = 'body';
+  const dispatch = createEventDispatcher<{ tabChange: ResponseTab }>();
+
+  function setTab(tab: ResponseTab) {
+    activeTab = tab;
+    dispatch('tabChange', tab);
+  }
 
   $: passedCount = assertionResults.filter(t => t.passed).length;
   $: failedCount = assertionResults.filter(t => !t.passed).length;
@@ -106,7 +114,7 @@
       <button
         class="tab"
         class:active={activeTab === 'body'}
-        on:click={() => activeTab = 'body'}
+        on:click={() => setTab('body')}
       >
         Body
         {#if isJson(response.body)}
@@ -116,7 +124,7 @@
       <button
         class="tab"
         class:active={activeTab === 'headers'}
-        on:click={() => activeTab = 'headers'}
+        on:click={() => setTab('headers')}
       >
         Headers
         <span class="tab-count">{Object.keys(response.headers).length}</span>
@@ -125,7 +133,7 @@
         <button
           class="tab"
           class:active={activeTab === 'request'}
-          on:click={() => activeTab = 'request'}
+          on:click={() => setTab('request')}
         >
           Request
         </button>
@@ -134,7 +142,7 @@
         <button
           class="tab"
           class:active={activeTab === 'assertions'}
-          on:click={() => activeTab = 'assertions'}
+          on:click={() => setTab('assertions')}
         >
           Assertions
           <span class="tab-count assertion-count" class:all-pass={failedCount === 0} class:has-fail={failedCount > 0}>

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -21,10 +21,16 @@ export const selectedLocation = writable<RequestLocation | null>(null);
 /** The active response (from the last executed request). */
 export const currentResponse = writable<HttpResponse | null>(null);
 
+/** The resolved request that produced the current response. */
+export const currentSentRequest = writable<{ method: string; url: string; headers: Record<string, string>; body: string } | null>(null);
+
 /** Loading state. */
 export const isLoading = writable<boolean>(false);
 
 // ─── Tabs ────────────────────────────────────────────────────────────────────
+
+export type BottomTab = 'body' | 'assertions';
+export type ResponseTab = 'body' | 'headers' | 'request' | 'assertions';
 
 export interface Tab {
   location: RequestLocation;
@@ -34,6 +40,10 @@ export interface Tab {
   response: HttpResponse | null;
   /** The raw sent request for the Request tab in ResponseViewer */
   sentRequest: { method: string; url: string; headers: Record<string, string>; body: string } | null;
+  /** Last active section tab (Body/Assertions) */
+  bottomTab: BottomTab;
+  /** Last active response tab (Body/Headers/Request/Assertions) */
+  responseTab: ResponseTab;
 }
 
 function tabKey(loc: RequestLocation): string {
@@ -60,13 +70,14 @@ export function pinTab(loc: RequestLocation, label: string) {
   const key = tabKey(loc);
   tabs.update(ts => {
     if (ts.some(t => tabKey(t.location) === key)) return ts;
-    return [...ts, { location: loc, label, response: null, sentRequest: null }];
+    return [...ts, { location: loc, label, response: null, sentRequest: null, bottomTab: 'body', responseTab: 'body' }];
   });
   selectedLocation.set(loc);
   activeTabKey.set(key);
   // Restore cached response for this tab
   const tab = get(tabs).find(t => tabKey(t.location) === key);
   currentResponse.set(tab?.response ?? null);
+  currentSentRequest.set(tab?.sentRequest ?? null);
 }
 
 /** Activate an existing tab. */
@@ -79,6 +90,7 @@ export function activateTab(loc: RequestLocation) {
   selectedLocation.set(loc);
   activeTabKey.set(key);
   currentResponse.set(tab.response);
+  currentSentRequest.set(tab.sentRequest);
 }
 
 /** Close a tab. If it was active, activate an adjacent tab or clear selection. */
@@ -100,6 +112,7 @@ export function closeTab(loc: RequestLocation) {
       selectedLocation.set(null);
       activeTabKey.set(null);
       currentResponse.set(null);
+      currentSentRequest.set(null);
     }
   }
 }
@@ -125,6 +138,7 @@ export function previewRequest(loc: RequestLocation) {
   selectedLocation.set(loc);
   activeTabKey.set(null);
   currentResponse.set(null);
+  currentSentRequest.set(null);
 }
 
 /** Update tab label when a request is renamed. */
@@ -132,6 +146,22 @@ export function updateTabLabel(loc: RequestLocation, label: string) {
   const key = tabKey(loc);
   tabs.update(ts => ts.map(t =>
     tabKey(t.location) === key ? { ...t, label } : t
+  ));
+}
+
+/** Update the active section tab (Body/Assertions) for a pinned tab. */
+export function setTabBottomTab(loc: RequestLocation, bottomTab: BottomTab) {
+  const key = tabKey(loc);
+  tabs.update(ts => ts.map(t =>
+    tabKey(t.location) === key ? { ...t, bottomTab } : t
+  ));
+}
+
+/** Update the active response tab (Body/Headers/Request/Assertions) for a pinned tab. */
+export function setTabResponseTab(loc: RequestLocation, responseTab: ResponseTab) {
+  const key = tabKey(loc);
+  tabs.update(ts => ts.map(t =>
+    tabKey(t.location) === key ? { ...t, responseTab } : t
   ));
 }
 


### PR DESCRIPTION
## Description

Remember which editor section tab (Body/Assertions) and response tab (Body/Headers/Request/Assertions) was last active for each pinned request. Switching between pinned tabs now restores the previously selected sub-tabs.

Also moves sentRequest from local variable to a shared store (currentSentRequest) so it can be cached per tab.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] I have tested this change locally
- [x] I have run `pnpm check` with no errors
- [x] This PR targets the `develop` branch
- [x] I have updated documentation if needed

## Related issue

