### PR TITLE
feat(tree): add toggle to display request URLs instead of names

### DIFF
--- a/src/components/TreeNode.svelte
+++ b/src/components/TreeNode.svelte
@@ -5,6 +5,7 @@
   export let node: TNode;
   export let selected: RequestLocation | null = null;
   export let depth: number = 0;
+  export let displayMode: 'name' | 'url' = 'name';
 
   const dispatch = createEventDispatcher();
 
@@ -16,6 +17,26 @@
 
   let fileExpanded = false;
   let namingIndex: number = -1;
+
+  /** Compute unique URL suffixes for requests in a file node */
+  function computeUrlSuffixes(requests: { url: string }[]): string[] {
+    if (requests.length === 0) return [];
+    if (requests.length === 1) return [requests[0].url];
+    const split = requests.map(r => r.url.split('/'));
+    const minLen = Math.min(...split.map(s => s.length));
+    let common = 0;
+    for (let i = 0; i < minLen; i++) {
+      if (split.every(s => s[i] === split[0][i])) common = i + 1;
+      else break;
+    }
+    if (common === 0) return requests.map(r => r.url);
+    return split.map(s => {
+      const unique = s.slice(common);
+      return '/' + unique.join('/');
+    });
+  }
+
+  $: urlSuffixes = node.type === 'file' ? computeUrlSuffixes(node.requests) : [];
   let namingValue: string = '';
   let confirmDeleteIndex: number = -1;
 
@@ -76,6 +97,7 @@
           node={child}
           {selected}
           depth={depth + 1}
+          {displayMode}
           on:toggleFolder
           on:select
           on:pinRequest
@@ -151,7 +173,7 @@
             <span class="method-badge" style="color: {MC[req.method] || '#888'}">
               {req.method.slice(0, 3)}
             </span>
-            <span class="req-name">{req.name}</span>
+            <span class="req-name" title={displayMode === 'url' ? req.name : req.url}>{displayMode === 'url' ? urlSuffixes[i] : req.name}</span>
             {#if req.varName}
               <span class="varname-tag">{req.varName}</span>
             {/if}

--- a/src/components/TreeSidebar.svelte
+++ b/src/components/TreeSidebar.svelte
@@ -13,6 +13,7 @@
 
   const dispatch = createEventDispatcher();
 
+  let displayMode: 'name' | 'url' = 'name';
   let showAddEnv = false;
   let showImportMenu = false;
   let newEnvName = '';
@@ -129,6 +130,24 @@
   </div>
 
   <!-- Tree -->
+  <div class="tree-toolbar">
+    <button
+      class="btn-display-mode"
+      on:click={() => displayMode = displayMode === 'name' ? 'url' : 'name'}
+      title={displayMode === 'name' ? 'Show URL paths' : 'Show request names'}
+    >
+      {#if displayMode === 'name'}
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+          <path d="M2 4h12M2 8h8M2 12h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      {:else}
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+          <path d="M5 3l6 0M3 7h10M7 11h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          <path d="M1.5 3h1M1.5 7h1M1.5 11h1" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+      {/if}
+    </button>
+  </div>
   <div class="tree-scroll">
     {#if tree.length === 0}
       <div class="empty-tree">
@@ -142,6 +161,7 @@
           {node}
           {selected}
           depth={0}
+          {displayMode}
           on:toggleFolder
           on:select
           on:pinRequest
@@ -348,6 +368,30 @@
   }
 
   /* Tree */
+  .tree-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 4px 12px 0;
+    flex-shrink: 0;
+  }
+  .btn-display-mode {
+    width: 24px; height: 24px;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    background: transparent;
+    color: #999;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: all 0.15s;
+  }
+  .btn-display-mode:hover {
+    border-color: #D4D4D8;
+    color: #666;
+    background: #F0F0F4;
+  }
   .tree-scroll { flex: 1; overflow-y: auto; padding: 4px 0; }
 
   .empty-tree {


### PR DESCRIPTION
## Description

Add toggle feature for request names

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] I have tested this change locally
- [x] I have run `pnpm check` with no errors
- [x] This PR targets the `develop` branch
- [x] I have updated documentation if needed

