### PR TITLE
fix(tree): enforce unique responseAlias names

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -623,6 +623,18 @@
     if (!file) return;
     const req = file.requests[requestIndex];
     if (!req) return;
+    // Block duplicate names
+    if (varName) {
+      const duplicate = getAllFileNodes($workspace.tree).some(f =>
+        f.requests.some((r, ri) =>
+          r.varName === varName && !(f.path === filePath && ri === requestIndex)
+        )
+      );
+      if (duplicate) {
+        addToast(`Name "${varName}" is already in use`);
+        return;
+      }
+    }
     // Remove old name from namedResults if it changed or was cleared
     if (req.varName && req.varName !== varName) {
       namedResults.update(nr => {

--- a/src/components/TreeNode.svelte
+++ b/src/components/TreeNode.svelte
@@ -7,6 +7,7 @@
   export let depth: number = 0;
   export let displayMode: 'name' | 'url' = 'name';
   export let sortByUrl: boolean = false;
+  export let usedNames: string[] = [];
 
   const dispatch = createEventDispatcher();
 
@@ -47,6 +48,14 @@
   let namingValue: string = '';
   let confirmDeleteIndex: number = -1;
 
+  $: isDuplicate = (() => {
+    const v = namingValue.trim();
+    if (!v || namingIndex < 0) return false;
+    const currentVarName = node.type === 'file' ? node.requests[namingIndex]?.varName : null;
+    if (v === currentVarName) return false;
+    return usedNames.includes(v);
+  })();
+
   function isSel(fp: string, ri: number): boolean {
     return selected?.filePath === fp && selected?.requestIndex === ri;
   }
@@ -57,6 +66,7 @@
   }
 
   function confirmNaming(filePath: string) {
+    if (isDuplicate) return;
     dispatch('nameRequest', { filePath, requestIndex: namingIndex, varName: namingValue.trim() });
     namingIndex = -1;
     namingValue = '';
@@ -106,6 +116,7 @@
           depth={depth + 1}
           {displayMode}
           {sortByUrl}
+          {usedNames}
           on:toggleFolder
           on:select
           on:pinRequest
@@ -159,6 +170,7 @@
             <!-- svelte-ignore a11y_autofocus -->
             <input
               class="naming-input"
+              class:naming-error={isDuplicate}
               bind:value={namingValue}
               on:keydown={(e) => { if (e.key === 'Enter') confirmNaming(node.path); if (e.key === 'Escape') { namingIndex = -1; } }}
               on:blur={() => confirmNaming(node.path)}
@@ -166,6 +178,9 @@
               spellcheck="false"
               autofocus
             />
+            {#if isDuplicate}
+              <span class="naming-duplicate-hint">Name in use</span>
+            {/if}
           </div>
         {:else}
           <div
@@ -453,7 +468,18 @@
     outline: none;
     min-width: 0;
   }
+  .naming-input.naming-error {
+    border-color: #CC4455;
+    color: #CC4455;
+  }
   .naming-input::placeholder {
     color: #BBB;
+  }
+  .naming-duplicate-hint {
+    font-size: 9px;
+    color: #CC4455;
+    font-weight: 500;
+    flex-shrink: 0;
+    white-space: nowrap;
   }
 </style>

--- a/src/components/TreeSidebar.svelte
+++ b/src/components/TreeSidebar.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher } from 'svelte';
   import TreeNode from './TreeNode.svelte';
   import type { TreeNode as TNode, RequestLocation } from '../lib/types';
+  import { getAllFileNodes } from '../lib/parser';
 
   export let tree: TNode[] = [];
   export let selected: RequestLocation | null = null;
@@ -44,6 +45,11 @@
     if (e.key === 'Enter') addEnvironment();
     if (e.key === 'Escape') showAddEnv = false;
   }
+
+  $: usedNames = getAllFileNodes(tree)
+    .flatMap(f => f.requests)
+    .map(r => r.varName)
+    .filter((n): n is string => !!n);
 
   $: if (showAddEnv && inputEl) inputEl.focus();
 </script>
@@ -176,6 +182,7 @@
           depth={0}
           {displayMode}
           {sortByUrl}
+          {usedNames}
           on:toggleFolder
           on:select
           on:pinRequest


### PR DESCRIPTION
## Summary

- Add duplicate detection for `# @name` values across all workspace requests
- Show live visual feedback (red border + "Name in use" hint) in the naming input when a duplicate is entered
- Block saving duplicate names with a toast notification as a backend guard

## Test plan

- [x] Right-click a request, set `@name` to "test"
- [x] Right-click another request, type "test" - verify red border and "Name in use" hint appear
- [x] Verify pressing Enter does not save the duplicate name
- [x] Verify renaming to a unique name works normally
- [x] Verify clearing a name (empty input) works normally

Fixes #23