### PR TITLE
fix(tabs): activate existing tab instead of replacing preview

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -523,7 +523,13 @@
       saveEnvFile($envFile);
       showEnvEditor = false;
     }
-    previewRequest(e.detail);
+    const loc = e.detail;
+    const hasTab = $tabs.some(t => t.location.filePath === loc.filePath && t.location.requestIndex === loc.requestIndex);
+    if (hasTab) {
+      activateTab(loc);
+    } else {
+      previewRequest(loc);
+    }
   }
 
   function handlePinRequest(e: CustomEvent<{ filePath: string; requestIndex: number; label: string }>) {


### PR DESCRIPTION
## Summary
- When selecting a request that already has a pinned tab, activate that tab instead of opening a new preview
- Prevents response data from appearing lost when re-selecting a pinned request

## Test plan
- [ ] Pin a request tab and send a request
- [ ] Click a different request in the sidebar, then click back on the pinned request
- [ ] Verify the response data is still visible
- [ ] Verify unpinned/new requests still open as previews normally

Fixes #29