### PR TITLE
fix(flows): clear button now removes last run record and result files

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -37,7 +37,7 @@
   import type { HttpRequest, HttpResponse, RequestLocation, EnvironmentFile, TreeNode, ImportResult, PbAssertionResult } from './lib/types';
   import type { BottomTab, ResponseTab } from './lib/stores';
   import type { DiscoveredFile } from './lib/parser';
-  import { scanForFlowFiles, loadFlowHistory, saveFlowRunRecord, FLOWS_DIR } from './lib/flowIO';
+  import { scanForFlowFiles, loadFlowHistory, saveFlowRunRecord, clearFlowRunHistory, FLOWS_DIR } from './lib/flowIO';
   import { runFlow } from './lib/flowRunner';
   import type { FlowStepResult, FlowRunRecord } from './lib/types';
 
@@ -1016,7 +1016,14 @@
             on:save={handleSaveFlow}
             on:run={handleRunFlow}
             on:abort={handleAbortFlow}
-            on:clearHistory={() => flowRunHistory.set($flowRunHistory.filter(r => r.flowFilePath !== $activeFlowTabPath))}
+            on:clearHistory={() => {
+              flowRunHistory.set($flowRunHistory.filter(r => r.flowFilePath !== $activeFlowTabPath));
+              delete lastFlowRunRecords[$activeFlowTabPath];
+              lastFlowRunRecords = lastFlowRunRecords;
+              if ($workspace.rootPath && $activeFlow) {
+                clearFlowRunHistory($workspace.rootPath, $activeFlow.name);
+              }
+            }}
           />
         {:else if $activeRequest && $selectedLocation}
           <div class="editor-pane" style="flex: 0 0 {editorWidthPercent}%">

--- a/src/lib/flowIO.ts
+++ b/src/lib/flowIO.ts
@@ -7,7 +7,7 @@ import type { FlowDefinition, FlowRunRecord, FlowStep, FlowStepOverrides } from 
 const FLOW_EXTENSION = '.pb-flow.json';
 export const FLOWS_DIR = 'flows';
 const RESULTS_DIR = `${FLOWS_DIR}/.results`;
-const MAX_HISTORY_PER_FLOW = 50;
+const MAX_HISTORY_PER_FLOW = 20;
 
 // ─── Flow File Parsing / Serialization ───────────────────────────────────────
 
@@ -150,6 +150,15 @@ async function pruneFlowHistory(resultsDir: string): Promise<void> {
       } catch { /* best effort */ }
     }
   } catch { /* best effort */ }
+}
+
+/** Delete all persisted run records for a given flow name. */
+export async function clearFlowRunHistory(rootDir: string, flowName: string): Promise<void> {
+  const dirName = sanitizeFlowName(flowName);
+  const resultsDir = await join(rootDir, RESULTS_DIR, dirName);
+  try {
+    await remove(resultsDir, { recursive: true });
+  } catch { /* directory may not exist */ }
 }
 
 /** Load all flow run history from .pb-flow-results/. Returns records sorted newest first. */


### PR DESCRIPTION
## Summary

- The Clear button in FlowResults only removed records from the `flowRunHistory` store, leaving the in-memory `lastFlowRunRecords` entry and persisted `.results/` JSON files on disk. This caused one stale run to remain visible after clearing.
- The handler now also deletes the cached last-run record (fixing the ghost entry) and removes the results directory from disk via a new `clearFlowRunHistory()` function in `flowIO.ts`.
- Lowers `MAX_HISTORY_PER_FLOW` from 50 to 20.

## Test plan

- [ ] Run a flow, verify results appear
- [ ] Click Clear - all results should disappear and no ghost entry remains
- [ ] Confirm the `flows/.results/<flow-name>/` directory is deleted from disk
- [ ] Run the flow again - results should appear normally
- [ ] Click Clear again - everything clears correctly