### PR TITLE
chore(deps-dev): bump typescript from 5.6.x to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/js-yaml": "^4.0.9",
     "svelte": "^5.55.0",
     "svelte-check": "^4.0.0",
-    "typescript": "~5.6.2",
+    "typescript": "~6.0.2",
     "vite": "^6.0.3",
     "vitest": "^4.1.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.55.0)(vite@6.4.1)
+        version: 5.1.1(svelte@5.55.1)(vite@6.4.1)
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.1
@@ -38,13 +38,13 @@ importers:
         version: 4.0.9
       svelte:
         specifier: ^5.55.0
-        version: 5.55.0
+        version: 5.55.1
       svelte-check:
         specifier: ^4.0.0
-        version: 4.4.5(picomatch@4.0.3)(svelte@5.55.0)(typescript@5.6.3)
+        version: 4.4.5(picomatch@4.0.3)(svelte@5.55.1)(typescript@6.0.2)
       typescript:
-        specifier: ~5.6.2
-        version: 5.6.3
+        specifier: ~6.0.2
+        version: 6.0.2
       vite:
         specifier: ^6.0.3
         version: 6.4.1
@@ -493,8 +493,8 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  '@typescript-eslint/types@8.57.2':
-    resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
+  '@typescript-eslint/types@8.57.0':
+    resolution: {integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/expect@4.1.2':
@@ -692,8 +692,8 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
-  svelte@5.55.0:
-    resolution: {integrity: sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw==}
+  svelte@5.55.1:
+    resolution: {integrity: sha512-QjvU7EFemf6mRzdMGlAFttMWtAAVXrax61SZYHdkD6yoVGQ89VeyKfZD4H1JrV1WLmJBxWhFch9H6ig/87VGjw==}
     engines: {node: '>=18'}
 
   tinybench@2.9.0:
@@ -711,8 +711,8 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -987,23 +987,23 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.0)(vite@6.4.1))(svelte@5.55.0)(vite@6.4.1)':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(vite@6.4.1)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.0)(vite@6.4.1)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.1)(vite@6.4.1)
       debug: 4.4.3
-      svelte: 5.55.0
+      svelte: 5.55.1
       vite: 6.4.1
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.0)(vite@6.4.1)':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.0)(vite@6.4.1))(svelte@5.55.0)(vite@6.4.1)
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(vite@6.4.1)
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
-      svelte: 5.55.0
+      svelte: 5.55.1
       vite: 6.4.1
       vitefu: 1.1.2(vite@6.4.1)
     transitivePeerDependencies:
@@ -1087,7 +1087,7 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@typescript-eslint/types@8.57.2': {}
+  '@typescript-eslint/types@8.57.0': {}
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -1194,7 +1194,7 @@ snapshots:
   esrap@2.2.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/types': 8.57.0
 
   estree-walker@3.0.3:
     dependencies:
@@ -1290,19 +1290,19 @@ snapshots:
 
   std-env@4.0.0: {}
 
-  svelte-check@4.4.5(picomatch@4.0.3)(svelte@5.55.0)(typescript@5.6.3):
+  svelte-check@4.4.5(picomatch@4.0.3)(svelte@5.55.1)(typescript@6.0.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.55.0
-      typescript: 5.6.3
+      svelte: 5.55.1
+      typescript: 6.0.2
     transitivePeerDependencies:
       - picomatch
 
-  svelte@5.55.0:
+  svelte@5.55.1:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1332,7 +1332,7 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  typescript@5.6.3: {}
+  typescript@6.0.2: {}
 
   vite@6.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Upgrades `typescript` from `~5.6.2` to `~6.0.2` (major version bump from Dependabot)
- Resolves merge conflicts with develop (retains `vitest` and `svelte ^5.55.0` additions)
- `pnpm check` passes cleanly with 0 errors

## Test plan

- [x] `pnpm check` - TypeScript/Svelte type checking passes
- [ ] CI passes (`pnpm check` + `cargo check`)