### PR TITLE
feat: security hardening - SSRF protection, pinned actions, tightened permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -29,7 +29,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri -> target
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
     outputs:
       release_id: ${{ steps.create.outputs.result }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Create draft release
         id: create
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const { data } = await github.rest.repos.createRelease({
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Extract version from tag
         shell: bash
@@ -88,12 +88,12 @@ jobs:
           echo "$VERSION" > getting-started/.version
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -104,7 +104,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri -> target
 
@@ -118,7 +118,7 @@ jobs:
         run: pnpm install
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0.5
+        uses: tauri-apps/tauri-action@51a9f1156b33df106d827c3a78f8f894946c5faa # v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "license": "MIT",
   "dependencies": {
     "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-fs": "~2.5.0",
     "@tauri-apps/plugin-dialog": "~2.7.0",
+    "@tauri-apps/plugin-fs": "~2.5.0",
     "@tauri-apps/plugin-http": "~2.5.8",
     "@tauri-apps/plugin-opener": "^2",
     "js-yaml": "^4.1.1"
@@ -28,7 +28,7 @@
     "svelte": "^5.55.1",
     "svelte-check": "^4.4.6",
     "typescript": "~6.0.2",
-    "vite": "^6.0.3",
+    "vite": "^6.4.2",
     "vitest": "^4.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.55.1)(vite@6.4.1)
+        version: 5.1.1(svelte@5.55.1)(vite@6.4.2)
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.1
@@ -41,16 +41,16 @@ importers:
         version: 5.55.1
       svelte-check:
         specifier: ^4.4.6
-        version: 4.4.6(picomatch@4.0.3)(svelte@5.55.1)(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.1)(typescript@6.0.2)
       typescript:
         specifier: ~6.0.2
         version: 6.0.2
       vite:
-        specifier: ^6.0.3
-        version: 6.4.1
+        specifier: ^6.4.2
+        version: 6.4.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(vite@6.4.1)
+        version: 4.1.2(vite@6.4.2)
 
 packages:
 
@@ -650,8 +650,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   postcss@8.5.8:
@@ -716,8 +716,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -987,25 +987,25 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(vite@6.4.1)':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.2))(svelte@5.55.1)(vite@6.4.2)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.1)(vite@6.4.1)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.1)(vite@6.4.2)
       debug: 4.4.3
       svelte: 5.55.1
-      vite: 6.4.1
+      vite: 6.4.2
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1)':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.2)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(vite@6.4.1)
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.2))(svelte@5.55.1)(vite@6.4.2)
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.55.1
-      vite: 6.4.1
-      vitefu: 1.1.2(vite@6.4.1)
+      vite: 6.4.2
+      vitefu: 1.1.2(vite@6.4.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -1098,13 +1098,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@6.4.1)':
+  '@vitest/mocker@4.1.2(vite@6.4.2)':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1
+      vite: 6.4.2
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -1202,9 +1202,9 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fsevents@2.3.3:
     optional: true
@@ -1237,7 +1237,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   postcss@8.5.8:
     dependencies:
@@ -1290,11 +1290,11 @@ snapshots:
 
   std-env@4.0.0: {}
 
-  svelte-check@4.4.6(picomatch@4.0.3)(svelte@5.55.1)(typescript@6.0.2):
+  svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.55.1)(typescript@6.0.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.55.1
@@ -1327,32 +1327,32 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
 
   typescript@6.0.2: {}
 
-  vite@6.4.1:
+  vite@6.4.2:
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitefu@1.1.2(vite@6.4.1):
+  vitefu@1.1.2(vite@6.4.2):
     optionalDependencies:
-      vite: 6.4.1
+      vite: 6.4.2
 
-  vitest@4.1.2(vite@6.4.1):
+  vitest@4.1.2(vite@6.4.2):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@6.4.1)
+      '@vitest/mocker': 4.1.2(vite@6.4.2)
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -1363,13 +1363,13 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 6.4.1
+      vite: 6.4.2
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,11 +28,11 @@ tauri-plugin-http = "2"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
-url = { version = "2", optional = true }
+url = "2"
 azure_identity = { version = "0.33", optional = true }
 azure_security_keyvault_secrets = { version = "0.12", optional = true }
 
 [features]
 default = ["keyvault"]
-keyvault = ["dep:azure_identity", "dep:azure_security_keyvault_secrets", "dep:url"]
+keyvault = ["dep:azure_identity", "dep:azure_security_keyvault_secrets"]
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,49 +1,102 @@
 {
+  "identifier": "default",
+  "description": "Capability for the main window",
+  "windows": ["main"],
   "permissions": [
     "core:default",
+
     "dialog:default",
     "dialog:allow-open",
     "dialog:allow-save",
+
     "fs:default",
     {
       "identifier": "fs:allow-read-text-file",
-      "allow": [{ "path": "**" }]
+      "allow": [
+        { "path": "$HOME/**" },
+        { "path": "$RESOURCE/**" }
+      ],
+      "deny": [
+        { "path": "$HOME/.ssh/**" },
+        { "path": "$HOME/.gnupg/**" },
+        { "path": "$HOME/.aws/**" },
+        { "path": "$HOME/.kube/**" },
+        { "path": "$HOME/.docker/**" },
+        { "path": "$HOME/.azure/**" }
+      ]
     },
     {
       "identifier": "fs:allow-write-text-file",
-      "allow": [{ "path": "**" }]
+      "allow": [
+        { "path": "$HOME/**" }
+      ],
+      "deny": [
+        { "path": "$HOME/.ssh/**" },
+        { "path": "$HOME/.gnupg/**" },
+        { "path": "$HOME/.aws/**" },
+        { "path": "$HOME/.kube/**" },
+        { "path": "$HOME/.docker/**" },
+        { "path": "$HOME/.azure/**" }
+      ]
     },
     {
       "identifier": "fs:allow-read-dir",
-      "allow": [{ "path": "**" }]
+      "allow": [
+        { "path": "$HOME/**" },
+        { "path": "$RESOURCE/**" }
+      ],
+      "deny": [
+        { "path": "$HOME/.ssh/**" },
+        { "path": "$HOME/.gnupg/**" },
+        { "path": "$HOME/.aws/**" },
+        { "path": "$HOME/.kube/**" },
+        { "path": "$HOME/.docker/**" },
+        { "path": "$HOME/.azure/**" }
+      ]
     },
     {
       "identifier": "fs:allow-mkdir",
-      "allow": [{ "path": "**" }]
+      "allow": [
+        { "path": "$HOME/**" }
+      ],
+      "deny": [
+        { "path": "$HOME/.ssh/**" },
+        { "path": "$HOME/.gnupg/**" },
+        { "path": "$HOME/.aws/**" },
+        { "path": "$HOME/.kube/**" },
+        { "path": "$HOME/.docker/**" },
+        { "path": "$HOME/.azure/**" }
+      ]
     },
     {
       "identifier": "fs:allow-remove",
-      "allow": [{ "path": "**" }]
+      "allow": [
+        { "path": "$HOME/**" }
+      ],
+      "deny": [
+        { "path": "$HOME/.ssh/**" },
+        { "path": "$HOME/.gnupg/**" },
+        { "path": "$HOME/.aws/**" },
+        { "path": "$HOME/.kube/**" },
+        { "path": "$HOME/.docker/**" },
+        { "path": "$HOME/.azure/**" }
+      ]
     },
     {
       "identifier": "fs:allow-rename",
-      "allow": [{ "path": "**" }]
-    },
-    "http:default",
-    {
-      "identifier": "http:allow-fetch",
       "allow": [
-        { "url": "https://**" },
-        { "url": "http://**" }
+        { "path": "$HOME/**" }
+      ],
+      "deny": [
+        { "path": "$HOME/.ssh/**" },
+        { "path": "$HOME/.gnupg/**" },
+        { "path": "$HOME/.aws/**" },
+        { "path": "$HOME/.kube/**" },
+        { "path": "$HOME/.docker/**" },
+        { "path": "$HOME/.azure/**" }
       ]
     },
-    "http:allow-fetch-send",
-    "http:allow-fetch-read-body",
-    "http:allow-fetch-cancel"
-  ],
-  "identifier": "default",
-  "description": "Capability for the main window",
-  "windows": [
-    "main"
+
+    "http:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
 use std::time::Duration;
 use serde::{Deserialize, Serialize};
@@ -7,6 +8,7 @@ use futures_util::StreamExt;
 
 const REQUEST_TIMEOUT_SECS: u64 = 30;
 const MAX_RESPONSE_BYTES: usize = 50 * 1024 * 1024; // 50 MB
+const MAX_REDIRECTS: usize = 5;
 
 #[derive(Deserialize)]
 struct HttpRequestPayload {
@@ -24,24 +26,114 @@ struct HttpResponsePayload {
     body: String,
 }
 
-fn validate_url(url: &str) -> Result<(), String> {
-    let lower = url.to_lowercase();
-    if lower.starts_with("http://") || lower.starts_with("https://") {
-        Ok(())
-    } else {
-        Err(format!("Only http:// and https:// URLs are allowed, got: {}", url))
+/// Check whether an IP address belongs to a private, loopback, link-local,
+/// or otherwise reserved range that should not be reachable from the HTTP proxy.
+fn is_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()            // 127.0.0.0/8
+            || v4.is_private()          // 10/8, 172.16/12, 192.168/16
+            || v4.is_link_local()       // 169.254.0.0/16 (incl. cloud metadata)
+            || v4.is_broadcast()        // 255.255.255.255
+            || v4.is_unspecified()      // 0.0.0.0
+            || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64) // 100.64.0.0/10 (CGNAT)
+        }
+        IpAddr::V6(v6) => {
+            // Check IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_private_ip(&IpAddr::V4(v4));
+            }
+            v6.is_loopback()            // ::1
+            || v6.is_unspecified()      // ::
+            || (v6.segments()[0] & 0xfe00) == 0xfc00  // fc00::/7 unique local
+            || (v6.segments()[0] == 0xfe80)           // fe80::/10 link-local
+        }
     }
+}
+
+/// Validate that a URL is safe to request: correct scheme and non-private host.
+/// Returns the validated (host, resolved IPs) pair so the caller can pin the
+/// DNS resolution and prevent TOCTOU attacks.
+async fn validate_url(url_str: &str) -> Result<(String, Vec<SocketAddr>), String> {
+    let parsed = url::Url::parse(url_str)
+        .map_err(|_| "Invalid URL format".to_string())?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        _ => return Err("Only http:// and https:// URLs are allowed".to_string()),
+    }
+
+    let host = parsed.host_str()
+        .ok_or_else(|| "URL must contain a host".to_string())?
+        .to_string();
+    let port = parsed.port_or_known_default().unwrap_or(80);
+
+    // Block direct IP addresses in private ranges
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if is_private_ip(&ip) {
+            return Err("Requests to private/internal network addresses are not allowed".to_string());
+        }
+        return Ok((host, vec![SocketAddr::new(ip, port)]));
+    }
+
+    // Resolve hostname and check all resulting IPs
+    let addr = format!("{}:{}", host, port);
+    let resolved: Vec<SocketAddr> = tokio::net::lookup_host(&addr).await
+        .map_err(|_| "Failed to resolve host".to_string())?
+        .collect();
+
+    if resolved.is_empty() {
+        return Err("Host resolved to no addresses".to_string());
+    }
+
+    for sa in &resolved {
+        if is_private_ip(&sa.ip()) {
+            return Err("Requests to private/internal network addresses are not allowed".to_string());
+        }
+    }
+
+    Ok((host, resolved))
+}
+
+/// Custom redirect policy that re-validates each redirect target URL to
+/// prevent SSRF via open redirect chains.
+fn ssrf_safe_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() >= MAX_REDIRECTS {
+            return attempt.error("Too many redirects");
+        }
+        let url = attempt.url();
+        match url.scheme() {
+            "http" | "https" => {}
+            _ => return attempt.error("Redirect to non-HTTP scheme blocked"),
+        }
+        if let Some(host) = url.host_str() {
+            if let Ok(ip) = host.parse::<IpAddr>() {
+                if is_private_ip(&ip) {
+                    return attempt.error("Redirect to private IP blocked");
+                }
+            }
+        }
+        attempt.follow()
+    })
 }
 
 #[tauri::command]
 async fn http_request(payload: HttpRequestPayload) -> Result<HttpResponsePayload, String> {
-    validate_url(&payload.url)?;
+    let (host, resolved_addrs) = validate_url(&payload.url).await?;
 
-    let client = reqwest::Client::builder()
+    // Pin the DNS resolution we already validated to prevent TOCTOU attacks
+    // where a second lookup could return a different (private) IP.
+    let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
-        .redirect(reqwest::redirect::Policy::limited(10))
-        .build()
-        .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
+        .redirect(ssrf_safe_redirect_policy());
+
+    for sa in &resolved_addrs {
+        builder = builder.resolve(&host, *sa);
+    }
+
+    let client = builder.build()
+        .map_err(|_| "Failed to initialize HTTP client".to_string())?;
 
     let method = payload.method.parse::<reqwest::Method>()
         .map_err(|e| format!("Invalid method: {}", e))?;
@@ -59,8 +151,12 @@ async fn http_request(payload: HttpRequestPayload) -> Result<HttpResponsePayload
     let res = req.send().await.map_err(|e| {
         if e.is_timeout() {
             format!("Request timed out after {} seconds", REQUEST_TIMEOUT_SECS)
+        } else if e.is_connect() {
+            "Connection failed - check that the server is reachable".to_string()
+        } else if e.is_redirect() {
+            "Too many redirects or unsafe redirect target".to_string()
         } else {
-            e.to_string()
+            "Request failed - check the URL and try again".to_string()
         }
     })?;
 
@@ -82,7 +178,7 @@ async fn http_request(payload: HttpRequestPayload) -> Result<HttpResponsePayload
     let mut body_bytes = Vec::with_capacity(capacity);
     let mut stream = res.bytes_stream();
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| e.to_string())?;
+        let chunk = chunk.map_err(|_| "Error reading response body".to_string())?;
         body_bytes.extend_from_slice(&chunk);
         if body_bytes.len() > MAX_RESPONSE_BYTES {
             return Err(format!(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost https://* http://*; img-src 'self' data:; font-src 'self' data:"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost; img-src 'self' data:; font-src 'self' data:"
     }
   },
   "bundle": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1106,8 +1106,8 @@
       const { remove } = await import('@tauri-apps/plugin-fs');
       const absolutePath = await safeJoinPath(rootPath, path);
       await remove(absolutePath);
-    } catch (err) {
-      console.warn('Could not delete flow file:', path, err);
+    } catch {
+      // Silently ignore - flow file may not exist on disk
     }
 
     flows.update(f => {


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to commit SHAs to prevent supply chain attacks
- Add SSRF protection to the HTTP proxy backend: validate resolved IPs against private ranges, pin DNS resolution to prevent TOCTOU attacks, and re-validate redirect targets
- Tighten Tauri filesystem permissions to `$HOME` with deny lists for sensitive directories (`.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `.azure`)
- Restrict CSP `connect-src` to IPC only since HTTP is proxied through the Rust backend
- Bump vite to 6.4.2

## Test plan

- [ ] Verify `pnpm tauri dev` launches without permission errors
- [ ] Send HTTP requests to external URLs and confirm they succeed
- [ ] Confirm requests to private IPs (e.g. `http://127.0.0.1`, `http://169.254.169.254`) are blocked
- [ ] Open and read `.http` files from a workspace directory
- [ ] Verify CI workflow runs successfully on this branch