### PR TITLE
fix(parser): let empty file variables fall through to environment values

### DIFF
--- a/src/lib/parser-extended.test.ts
+++ b/src/lib/parser-extended.test.ts
@@ -288,6 +288,24 @@ describe('substituteAll - environment variables', () => {
     expect(substituteAll('{{$dotenv SECRET_KEY}}', ctx)).toBe('[dotenv:SECRET_KEY]');
   });
 
+  it('empty file variable falls through to env variable', () => {
+    const ctx: SubstitutionContext = {
+      fileVariables: [{ key: 'id', value: '' }],
+      environmentVariables: { id: '260e6af6-df59-44bd-a553-06b8be721da9' },
+      namedResults: {},
+    };
+    expect(substituteAll('{{id}}', ctx)).toBe('260e6af6-df59-44bd-a553-06b8be721da9');
+  });
+
+  it('empty file variable stays empty when no env variable exists', () => {
+    const ctx: SubstitutionContext = {
+      fileVariables: [{ key: 'id', value: '' }],
+      environmentVariables: {},
+      namedResults: {},
+    };
+    expect(substituteAll('{{id}}', ctx)).toBe('');
+  });
+
   it('returns placeholder for $processEnv', () => {
     const ctx: SubstitutionContext = {
       fileVariables: [],

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -408,8 +408,16 @@ export function substituteAll(input: string, ctx: SubstitutionContext): string {
 
       const fileVar = ctx.fileVariables.find(v => v.key === name);
       // Skip self-referencing file vars (e.g. @baseUrl = {{baseUrl}}) so
-      // the lookup falls through to environment variables
-      if (fileVar && fileVar.value !== `{{${name}}}`) return fileVar.value;
+      // the lookup falls through to environment variables.
+      // Also skip empty file vars when an env variable exists, so that
+      // placeholder declarations like @id = don't shadow environment values.
+      if (fileVar && fileVar.value !== `{{${name}}}`) {
+        if (fileVar.value === '' && name in ctx.environmentVariables) {
+          // Fall through to environment variable
+        } else {
+          return fileVar.value;
+        }
+      }
 
       if (name in ctx.environmentVariables) {
         return ctx.environmentVariables[name];


### PR DESCRIPTION
## Summary

- Empty file-level variable declarations (e.g. `@id =`) no longer shadow environment variables
- If a file variable has an empty value and a matching environment variable exists, the environment value is used
- If no environment variable exists, the empty value is preserved as before

## Test plan

- [x] Added test: empty file variable falls through to env variable
- [x] Added test: empty file variable stays empty when no env variable exists
- [ ] Run `pnpm test` to verify all parser tests pass
- [ ] Verify in-app that `@var =` declarations pick up environment values correctly