### PR TITLE
feat(env): allow opening environment editor when no env file exists

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -678,8 +678,8 @@
   // ─── Event Handlers ───
 
   function handleSelect(e: CustomEvent<RequestLocation>) {
-    if (showEnvEditor && $envFile) {
-      saveEnvFile($envFile);
+    if (showEnvEditor) {
+      if ($envFile) saveEnvFile($envFile);
       showEnvEditor = false;
     }
     // Deactivate any flow tab when selecting a request
@@ -695,8 +695,8 @@
   }
 
   function handlePinRequest(e: CustomEvent<{ filePath: string; requestIndex: number; label: string }>) {
-    if (showEnvEditor && $envFile) {
-      saveEnvFile($envFile);
+    if (showEnvEditor) {
+      if ($envFile) saveEnvFile($envFile);
       showEnvEditor = false;
     }
     pinTab(
@@ -706,8 +706,8 @@
   }
 
   function handleTabActivate(e: CustomEvent<RequestLocation>) {
-    if (showEnvEditor && $envFile) {
-      saveEnvFile($envFile);
+    if (showEnvEditor) {
+      if ($envFile) saveEnvFile($envFile);
       showEnvEditor = false;
     }
     // Deactivate any flow tab when switching to a request tab
@@ -1224,12 +1224,12 @@
         on:closeFlowTab={(e) => { delete flowUIState[e.detail]; closeFlowTab(e.detail); }}
       />
       <div class="main-panels" bind:this={mainPanelsEl} class:dragging>
-        {#if showEnvEditor && $envFile && $activeEnvironment}
+        {#if showEnvEditor}
           <div class="env-editor-pane">
             <EnvironmentEditor
-              envFile={$envFile}
+              envFile={$envFile ?? { $shared: {} }}
               userEnvFile={$userEnvFile}
-              activeEnv={$activeEnvironment}
+              activeEnv={$activeEnvironment ?? '$shared'}
               kvState={$keyVaultState}
               on:update={(e) => {
                 envFile.set(e.detail);


### PR DESCRIPTION
## Summary
- Clicking the gear icon in the sidebar now opens the environment editor even when the workspace has no `http-client.env.json`.
- The editor renders with a synthetic `$shared` tab so users can use the existing `+ Add environment` button to create the first environment, which is then saved to disk via the normal update/save pipeline.
- No disk writes happen unless the user actually adds an environment; opening and closing the editor on an empty workspace is a no-op.

## Test plan
- [x] `pnpm check` passes (0 errors)
- [x] `pnpm test` passes (182/182)
- [ ] Manual: open a folder with no `http-client.env.json`, click the gear, add an environment, confirm file is created on disk
- [ ] Manual: open a folder with an existing env file, confirm no regression
- [ ] Manual: open editor on empty workspace, close without changes, confirm no file is written