### PR TITLE
fix(variables): make filter input actually filter variable lists

### DIFF
--- a/src/components/VariableInspector.svelte
+++ b/src/components/VariableInspector.svelte
@@ -84,21 +84,39 @@
   $: runtimeCount = overrideEntries.length + globalEntries.length + namedEntries.length;
   $: hasRuntime = runtimeCount > 0;
 
-  function matchesSearch(key: string, value: string): boolean {
-    if (!searchQuery) return true;
-    const q = searchQuery.toLowerCase();
-    return key.toLowerCase().includes(q) || value.toLowerCase().includes(q);
-  }
+  $: searchQueryLower = searchQuery.trim().toLowerCase();
 
-  $: filteredFileVars = fileVariables.filter(v => matchesSearch(v.key, v.value));
-  $: filteredEnvEntries = envEntries
-    .filter(([k, v]) => matchesSearch(k, v))
-    .sort((a, b) => sourcePriority(a[0]) - sourcePriority(b[0]));
-  $: filteredOverrides = overrideEntries.filter(([k, v]) => matchesSearch(k, v));
-  $: filteredGlobals = globalEntries.filter(([k, v]) => matchesSearch(k, v));
-  $: filteredNamed = namedEntries.filter(([name, result]) =>
-    matchesSearch(name, `${result.request.method} ${result.response.status}`)
-  );
+  $: filteredFileVars = searchQueryLower
+    ? fileVariables.filter(v =>
+        v.key.toLowerCase().includes(searchQueryLower) ||
+        v.value.toLowerCase().includes(searchQueryLower)
+      )
+    : fileVariables;
+  $: filteredEnvEntries = (searchQueryLower
+    ? envEntries.filter(([k, v]) =>
+        k.toLowerCase().includes(searchQueryLower) ||
+        v.toLowerCase().includes(searchQueryLower)
+      )
+    : envEntries
+  ).slice().sort((a, b) => sourcePriority(a[0]) - sourcePriority(b[0]));
+  $: filteredOverrides = searchQueryLower
+    ? overrideEntries.filter(([k, v]) =>
+        k.toLowerCase().includes(searchQueryLower) ||
+        v.toLowerCase().includes(searchQueryLower)
+      )
+    : overrideEntries;
+  $: filteredGlobals = searchQueryLower
+    ? globalEntries.filter(([k, v]) =>
+        k.toLowerCase().includes(searchQueryLower) ||
+        v.toLowerCase().includes(searchQueryLower)
+      )
+    : globalEntries;
+  $: filteredNamed = searchQueryLower
+    ? namedEntries.filter(([name, result]) => {
+        const summary = `${result.request.method} ${result.response.status}`.toLowerCase();
+        return name.toLowerCase().includes(searchQueryLower) || summary.includes(searchQueryLower);
+      })
+    : namedEntries;
   $: filteredRuntimeCount = filteredOverrides.length + filteredGlobals.length + filteredNamed.length;
 
   $: totalCount = fileVariables.length + envEntries.length + runtimeCount;

--- a/src/components/VariablePicker.svelte
+++ b/src/components/VariablePicker.svelte
@@ -15,11 +15,7 @@
 
   $: if (visible) { searchQuery = ''; insertedKey = null; }
 
-  function matchesSearch(key: string, value: string): boolean {
-    if (!searchQuery) return true;
-    const q = searchQuery.toLowerCase();
-    return key.toLowerCase().includes(q) || value.toLowerCase().includes(q);
-  }
+  $: searchQueryLower = searchQuery.trim().toLowerCase();
 
   function truncate(str: string, max: number): string {
     return str.length > max ? str.slice(0, max) + '...' : str;
@@ -61,13 +57,29 @@
   $: fileOnly = fileVariables.filter(v => !(v.key in envVariables));
 
   // Filtered lists
-  $: filteredEnv = envEntries.filter(([k, v]) => matchesSearch(k, v));
-  $: filteredFile = fileOnly.filter(v => matchesSearch(v.key, v.value));
-  $: filteredDynamic = [
+  $: filteredEnv = searchQueryLower
+    ? envEntries.filter(([k, v]) =>
+        k.toLowerCase().includes(searchQueryLower) ||
+        v.toLowerCase().includes(searchQueryLower)
+      )
+    : envEntries;
+  $: filteredFile = searchQueryLower
+    ? fileOnly.filter(v =>
+        v.key.toLowerCase().includes(searchQueryLower) ||
+        v.value.toLowerCase().includes(searchQueryLower)
+      )
+    : fileOnly;
+  const dynamicVars = [
     { key: '$randomInt', value: 'random number', insert: '{{$randomInt 1 100}}' },
     { key: '$timestamp', value: 'unix epoch', insert: '{{$timestamp}}' },
     { key: '$datetime', value: 'ISO 8601 date', insert: '{{$datetime iso8601}}' },
-  ].filter(d => matchesSearch(d.key, d.value));
+  ];
+  $: filteredDynamic = searchQueryLower
+    ? dynamicVars.filter(d =>
+        d.key.toLowerCase().includes(searchQueryLower) ||
+        d.value.toLowerCase().includes(searchQueryLower)
+      )
+    : dynamicVars;
 
   // Build response field options for each named result
   $: responseGroups = Object.entries(namedResults).map(([name, result]) => {
@@ -89,8 +101,18 @@
 
   $: filteredResponseGroups = responseGroups.map(group => ({
     ...group,
-    bodyFields: group.bodyFields.filter(f => matchesSearch(f.path, f.value)),
-    headerFields: group.headerFields.filter(f => matchesSearch(f.path, f.value)),
+    bodyFields: searchQueryLower
+      ? group.bodyFields.filter(f =>
+          f.path.toLowerCase().includes(searchQueryLower) ||
+          f.value.toLowerCase().includes(searchQueryLower)
+        )
+      : group.bodyFields,
+    headerFields: searchQueryLower
+      ? group.headerFields.filter(f =>
+          f.path.toLowerCase().includes(searchQueryLower) ||
+          f.value.toLowerCase().includes(searchQueryLower)
+        )
+      : group.headerFields,
   })).filter(g => g.bodyFields.length > 0 || g.headerFields.length > 0);
 
   $: hasEnvOrFile = envEntries.length > 0 || fileOnly.length > 0;


### PR DESCRIPTION
## Summary

- Fixes rektifier/psychic-broccoli#82 - typing in the "Filter variables..." input in the Variables inspector now actually filters the File, Environment, and Runtime lists, and the section badges switch to `filtered/total` as expected.
- Also fixes the same bug in `VariablePicker.svelte` (the inline `{{var}}` autocomplete popup from the request editor), which was silently broken for the same reason.

## Root cause

Both components are in Svelte legacy mode and computed their filtered arrays via a helper:

\`\`\`ts
function matchesSearch(key: string, value: string): boolean {
  if (!searchQuery) return true;
  const q = searchQuery.toLowerCase();
  return key.toLowerCase().includes(q) || value.toLowerCase().includes(q);
}

\$: filteredFileVars = fileVariables.filter(v => matchesSearch(v.key, v.value));
\`\`\`

Svelte's legacy \`\$:\` dependency tracker uses static analysis of variables read directly in the statement body. \`searchQuery\` is only read inside \`matchesSearch\`, so it was never registered as a dependency of any \`filteredXxx\`. The arrays only recomputed when the source data changed, never when the user typed.

## Fix

Add a shared \`\$: searchQueryLower = searchQuery.trim().toLowerCase();\` reactive and inline the membership checks in each filter so the compiler sees the dependency. Applied consistently to both components. No public API, prop, or event changes.

`VariableInspector.filteredEnvEntries` also gains a `.slice()` before `.sort()` so the priority sort never mutates `envEntries` when the search is empty.

## Test plan

- [x] \`pnpm check\` - 0 errors, 0 warnings
- [x] \`pnpm vitest run\` - 182/182 passing
- [ ] Manual: open a workspace with an \`http-client.env.json\` and a \`.http\` file with file-level \`@variables\`. Open the Variables inspector, type into "Filter variables...", confirm rows shrink live and badges flip to \`filtered/total\`. Try a query with no matches and confirm the "No matching variables" empty state renders. Clear the input and confirm all rows return.
- [ ] Manual: in the request editor, open the inline variable picker (\`{{\`), type a substring, confirm Env / File / Dynamic / Response-body sections filter in real time.