### PR TITLE
feat(insomnia): import v5 sub-environments

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -445,11 +445,45 @@
     return written;
   }
 
-  /** After writing files, show the env modal if there are discovered variables. */
-  function showEnvModalIfNeeded(result: ImportResult) {
+  /** After writing files, write the env file directly if multi-env, or show the modal. */
+  async function showEnvModalIfNeeded(result: ImportResult) {
+    if (result.environmentFile && Object.keys(result.environmentFile).length > 0) {
+      await writeImportedEnvironmentFile(result.environmentFile);
+      return;
+    }
     if (result.discoveredVariables.length > 0) {
       pendingImportVars = result.discoveredVariables;
       showImportEnvModal = true;
+    }
+  }
+
+  async function writeImportedEnvironmentFile(imported: EnvironmentFile) {
+    const rootPath = $workspace.rootPath;
+    if (!rootPath) return;
+    try {
+      let current: EnvironmentFile = $envFile ? structuredClone($envFile) : {};
+
+      for (const [envName, vars] of Object.entries(imported)) {
+        if (!current[envName]) current[envName] = {};
+        for (const [key, value] of Object.entries(vars)) {
+          if (typeof value === 'string' && !(key in current[envName])) {
+            current[envName][key] = value;
+          }
+        }
+      }
+
+      const envPath = await join(rootPath, 'http-client.env.json');
+      await writeTextFile(envPath, JSON.stringify(current, null, 2));
+      envFile.set(current);
+
+      const envNames = Object.keys(imported).filter(n => n !== '$shared');
+      if (!$activeEnvironment && envNames.length > 0) {
+        activeEnvironment.set(envNames[0]);
+      }
+
+      addToast(`Imported ${envNames.length} environment${envNames.length !== 1 ? 's' : ''}: ${envNames.join(', ')}`, 'info');
+    } catch (e: any) {
+      addToast(`Failed to write environment file: ${e.message || e}`, 'error');
     }
   }
 
@@ -471,7 +505,7 @@
       }
       const written = await writeImportedFiles(result);
       addToast(`Imported ${written} file${written !== 1 ? 's' : ''} from "${result.collectionName}".`, 'info');
-      showEnvModalIfNeeded(result);
+      await showEnvModalIfNeeded(result);
     } catch (e: any) {
       addToast(`Import failed: ${e.message || e}`, 'error');
     }
@@ -489,7 +523,7 @@
       const result = importOpenApiSpec(e.detail.content);
       const written = await writeImportedFiles(result);
       addToast(`Imported ${written} file${written !== 1 ? 's' : ''} from "${result.collectionName}".`, 'info');
-      showEnvModalIfNeeded(result);
+      await showEnvModalIfNeeded(result);
     } catch (e: any) {
       addToast(`Import failed: ${e.message || e}`, 'error');
     }

--- a/src/lib/detect.test.ts
+++ b/src/lib/detect.test.ts
@@ -35,6 +35,31 @@ describe('detectImportFormat', () => {
     expect(detectImportFormat(content)).toBe('insomnia');
   });
 
+  it('detects Insomnia v5 YAML collection export', () => {
+    const content = 'type: collection.insomnia.rest/5.0\nname: My API\ncollection: []';
+    expect(detectImportFormat(content)).toBe('insomnia');
+  });
+
+  it('detects Insomnia v5 YAML spec export', () => {
+    const content = 'type: spec.insomnia.rest/5.0\nname: My API\ncollection: []';
+    expect(detectImportFormat(content)).toBe('insomnia');
+  });
+
+  it('detects Insomnia v5 YAML environment export', () => {
+    const content = 'type: environment.insomnia.rest/5.0\nname: Env';
+    expect(detectImportFormat(content)).toBe('insomnia');
+  });
+
+  it('detects Insomnia v5 YAML mock export', () => {
+    const content = 'type: mock.insomnia.rest/5.0\nname: Mock';
+    expect(detectImportFormat(content)).toBe('insomnia');
+  });
+
+  it('detects Insomnia v5 YAML mcpClient export', () => {
+    const content = 'type: mcpClient.insomnia/5.0\nname: MCP';
+    expect(detectImportFormat(content)).toBe('insomnia');
+  });
+
   // ── OpenAPI ──
   it('detects OpenAPI 3.x JSON by openapi field', () => {
     const content = JSON.stringify({ openapi: '3.0.0', paths: {} });

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -41,8 +41,9 @@ export function detectImportFormat(content: string): ImportFormat | null {
 
   // YAML content - check for line-level markers
 
-  // Insomnia v5 YAML: starts with "type:" or contains export marker
-  if (/^_type:\s/m.test(trimmed) || trimmed.includes('__insomnia_export')) {
+  // Insomnia v5 YAML: type field referencing insomnia (covers collection, spec, mock, environment, mcpClient)
+  // Insomnia v4 YAML: _type or __export_format markers
+  if (/^type:\s+\S*insomnia/m.test(trimmed) || /^_type:\s/m.test(trimmed) || /^__export_format:\s/m.test(trimmed)) {
     return 'insomnia';
   }
 

--- a/src/lib/insomnia.test.ts
+++ b/src/lib/insomnia.test.ts
@@ -153,4 +153,135 @@ name: Bad
 `;
     expect(() => importInsomniaExport(yaml)).toThrow();
   });
+
+  it('extracts sub-environments into environmentFile', () => {
+    const yaml = `
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: My API
+collection:
+  - url: "{{ _.baseUrl }}/test"
+    name: Test
+    method: GET
+environments:
+  name: Base Environment
+  data:
+    baseUrl: https://api.example.com
+    apiKey: shared-key
+  subEnvironments:
+    - name: dev
+      data:
+        baseUrl: http://localhost:3000
+        debug: "true"
+    - name: prod
+      data:
+        baseUrl: https://prod.example.com
+        apiKey: prod-secret
+`;
+    const result = importInsomniaExport(yaml);
+    expect(result.environmentFile).toBeDefined();
+    expect(result.environmentFile!['$shared']).toEqual({ baseUrl: 'https://api.example.com', apiKey: 'shared-key' });
+    expect(result.environmentFile!['dev']).toEqual({ baseUrl: 'http://localhost:3000', debug: 'true' });
+    expect(result.environmentFile!['prod']).toEqual({ baseUrl: 'https://prod.example.com', apiKey: 'prod-secret' });
+  });
+
+  it('returns no environmentFile when no sub-environments exist', () => {
+    const yaml = `
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Simple
+collection:
+  - url: https://example.com/test
+    name: Test
+    method: GET
+environments:
+  name: Base Environment
+  data:
+    baseUrl: https://api.example.com
+`;
+    const result = importInsomniaExport(yaml);
+    expect(result.environmentFile).toBeUndefined();
+  });
+
+  it('converts non-string primitive env values to strings', () => {
+    const yaml = `
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Primitives
+collection:
+  - url: https://example.com
+    name: Test
+    method: GET
+environments:
+  name: Base
+  data:
+    port: 8080
+    enabled: true
+    name: my-api
+  subEnvironments:
+    - name: dev
+      data:
+        port: 3000
+        debug: false
+`;
+    const result = importInsomniaExport(yaml);
+    expect(result.environmentFile!['$shared']).toEqual({ port: '8080', enabled: 'true', name: 'my-api' });
+    expect(result.environmentFile!['dev']).toEqual({ port: '3000', debug: 'false' });
+  });
+
+  it('skips sub-environments with empty name or no data', () => {
+    const yaml = `
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Gaps
+collection:
+  - url: https://example.com
+    name: Test
+    method: GET
+environments:
+  name: Base
+  data:
+    key: value
+  subEnvironments:
+    - name: ""
+      data:
+        a: b
+    - name: valid
+      data:
+        x: "y"
+`;
+    const result = importInsomniaExport(yaml);
+    expect(result.environmentFile!['valid']).toEqual({ x: 'y' });
+    expect(result.environmentFile!['']).toBeUndefined();
+  });
+
+  it('handles spec.insomnia.rest type with sub-environments', () => {
+    const yaml = `
+type: spec.insomnia.rest/5.0
+schema_version: "5.1"
+name: Spec Export
+collection:
+  - url: "{{ _.base_url }}/api/test"
+    name: Test endpoint
+    method: GET
+environments:
+  name: Base Environment
+  data:
+    base_url: https://api.default.com
+    countryId: se
+  subEnvironments:
+    - name: localhost
+      data:
+        base_url: http://localhost:8080
+    - name: staging
+      data:
+        base_url: https://staging.example.com
+`;
+    const result = importInsomniaExport(yaml);
+    expect(result.files).toHaveLength(1);
+    expect(result.environmentFile).toBeDefined();
+    expect(result.environmentFile!['$shared']).toEqual({ base_url: 'https://api.default.com', countryId: 'se' });
+    expect(result.environmentFile!['localhost']).toEqual({ base_url: 'http://localhost:8080' });
+    expect(result.environmentFile!['staging']).toEqual({ base_url: 'https://staging.example.com' });
+  });
 });

--- a/src/lib/insomnia.ts
+++ b/src/lib/insomnia.ts
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import type { HttpMethod, HttpHeader, HttpRequest, Variable, ConvertedFile, ImportResult } from './types';
+import type { HttpMethod, HttpHeader, HttpRequest, Variable, ConvertedFile, ImportResult, EnvironmentFile } from './types';
 import { serializeHttpFile, extractVariableRefs } from './parser';
 
 // ─── Shared Types ──────────────────────────────────────────────────────────
@@ -62,7 +62,14 @@ interface V5Item {
 interface V5Environment {
   name?: string;
   data?: Record<string, unknown>;
+  subEnvironments?: V5SubEnvironment[];
   meta?: { id?: string };
+}
+
+interface V5SubEnvironment {
+  name: string;
+  data?: Record<string, unknown>;
+  meta?: { id?: string; sortKey?: number };
 }
 
 // ─── v4 JSON Types ─────────────────────────────────────────────────────────
@@ -154,9 +161,44 @@ function importV5Yaml(content: string): ImportResult {
     });
   }
 
+  // Build multi-environment file from sub-environments
+  const environmentFile = buildV5EnvironmentFile(data.environments);
+
   const discoveredVariables = extractVariableRefs(files, envVars);
 
-  return { files, collectionName, variables: envVars, discoveredVariables };
+  return { files, collectionName, variables: envVars, discoveredVariables, environmentFile };
+}
+
+function buildV5EnvironmentFile(env?: V5Environment): EnvironmentFile | undefined {
+  if (!env?.subEnvironments || env.subEnvironments.length === 0) return undefined;
+
+  const result: EnvironmentFile = {};
+
+  // Base environment data becomes $shared
+  if (env.data) {
+    const shared: Record<string, string> = {};
+    for (const [key, value] of Object.entries(env.data)) {
+      if (value != null && typeof value !== 'object') shared[key] = String(value);
+    }
+    if (Object.keys(shared).length > 0) result['$shared'] = shared;
+  }
+
+  // Each sub-environment becomes a named environment, sorted by sortKey
+  const sorted = [...env.subEnvironments].sort(
+    (a, b) => (a.meta?.sortKey ?? 0) - (b.meta?.sortKey ?? 0),
+  );
+  for (const sub of sorted) {
+    if (!sub.name || !sub.data) continue;
+    const vars: Record<string, string> = {};
+    for (const [key, value] of Object.entries(sub.data)) {
+      if (value != null && typeof value !== 'object') vars[key] = String(value);
+    }
+    if (Object.keys(vars).length > 0) {
+      result[sub.name] = vars;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function collectV5Names(items: V5Item[], nameById: Map<string, string>): void {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -181,6 +181,8 @@ export interface ImportResult {
    * Includes both collection-defined variables (with values) and undefined ones (empty value).
    */
   discoveredVariables: Variable[];
+  /** Pre-built environment file from importers that support multi-env (e.g. Insomnia v5 sub-environments) */
+  environmentFile?: EnvironmentFile;
 }
 
 // ─── Pb Script Directives ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Parse Insomnia v5 sub-environments into a multi-environment file (`$shared` defaults + named environments) and write it directly on import
- Improve v5 YAML format detection to cover all export types (collection, spec, mock, environment, mcpClient)
- Add `environmentFile` field to `ImportResult` for importers that support multi-env output

## Test plan

- [ ] Import an Insomnia v5 collection export with sub-environments and verify `http-client.env.json` is created with `$shared` and named environments
- [ ] Import an Insomnia v5 spec export with sub-environments and verify the same behavior
- [ ] Import an Insomnia collection without sub-environments and verify the env modal still appears for discovered variables
- [ ] Run `pnpm test` - all new and existing tests pass