### PR TITLE
feat: ensure $shared environment exists when importing collections

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -31,7 +31,7 @@
   } from './lib/stores';
   import { extractKeyVaultConfig, fetchKeyVaultSecrets, kvCacheKey } from './lib/keyvault';
   import {
-    serializeHttpFile, substituteAll, parseEnvironmentFile,
+    serializeHttpFile, substituteAll, parseEnvironmentFile, ensureSharedEnvironment,
     buildWorkspaceTree, createFileNode, createEmptyFileNode, getAllFileNodes,
     executePbDirectives, parseScriptText, applyRequestMutations,
   } from './lib/parser';
@@ -77,7 +77,7 @@
 
     try {
       // Load or create the env file
-      let currentEnv: EnvironmentFile = $envFile ?? {};
+      let currentEnv: EnvironmentFile = ensureSharedEnvironment($envFile ?? {});
 
       // Ensure the target environment exists
       if (!currentEnv[envName]) {
@@ -461,7 +461,7 @@
     const rootPath = $workspace.rootPath;
     if (!rootPath) return;
     try {
-      let current: EnvironmentFile = $envFile ? structuredClone($envFile) : {};
+      let current: EnvironmentFile = ensureSharedEnvironment($envFile ? structuredClone($envFile) : {});
 
       for (const [envName, vars] of Object.entries(imported)) {
         if (!current[envName]) current[envName] = {};

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1074,6 +1074,17 @@ export function parseEnvironmentFile(jsonString: string): EnvironmentFile | null
 }
 
 /**
+ * Ensure `$shared` exists on an env file as a baseline for the variable resolution cascade.
+ * Mutates and returns the passed object. No-op when `$shared` already exists.
+ */
+export function ensureSharedEnvironment(envFile: EnvironmentFile): EnvironmentFile {
+  if (!envFile['$shared']) {
+    envFile['$shared'] = {};
+  }
+  return envFile;
+}
+
+/**
  * Get the list of selectable environment names from an env file.
  * Excludes the special "$shared" environment.
  */


### PR DESCRIPTION
## Summary
- Guarantees a `$shared` block is present in `http-client.env.json` after any collection import, so the 5-level variable resolution cascade has a baseline.
- New helper `ensureSharedEnvironment` in `src/lib/parser.ts`; called from both import paths in `src/App.svelte`:
  - `handleImportEnvConfirm` (modal path - Postman, OpenAPI, single-env Insomnia)
  - `writeImportedEnvironmentFile` (direct path - Insomnia exports with named sub-environments)

Closes #77

## Test plan
- [x] `pnpm check` - 0 errors
- [x] `pnpm test` - 192/192 pass
- [ ] Import Postman/OpenAPI into a fresh workspace via modal; confirm `$shared: {}` appears alongside the chosen env
- [ ] Import an Insomnia YAML with named sub-environments (e.g. Prod/UAT/Localhost); confirm `$shared` is present
- [ ] Re-import into a workspace with an existing populated `$shared`; confirm no overwrite