### PR TITLE
feat(flow): auto-managed step aliases with cascading renames

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1068,18 +1068,9 @@
     flowRunState.set({ status: record.status, stepResults: record.stepResults });
     runningFlowPath = null;
 
-    // Propagate flow variables back to app stores
-    // Note: flow set vars are not propagated - they are file-scoped and only
-    // meaningful within the flow's isolated execution context. Only globals
-    // and named results cross the boundary back to the workspace.
-    if (record.variables) {
-      if (Object.keys(record.variables.globalVars).length > 0) {
-        pbGlobals.update(g => ({ ...g, ...record.variables!.globalVars }));
-      }
-      if (Object.keys(record.variables.namedResults).length > 0) {
-        namedResults.update(nr => ({ ...nr, ...record.variables!.namedResults }));
-      }
-    }
+    // Flow runs are fully isolated: their named results, set vars, and pb
+    // globals stay inside the FlowRunRecord and do not cross back into the
+    // workspace stores the regular request editor / inspector reads from.
 
     // Persist and update history
     try {

--- a/src/components/FlowEditor.svelte
+++ b/src/components/FlowEditor.svelte
@@ -3,9 +3,10 @@
   import FlowStepPicker from './FlowStepPicker.svelte';
   import FlowResults from './FlowResults.svelte';
   import VariablePicker from './VariablePicker.svelte';
-  import type { FlowDefinition, FlowStep, FlowStepResult, FlowRunRecord, FlowRunStatus, FileNode, TreeNode as TNode, HttpHeader, FlowStepOverrides, PbDirective, Variable } from '../lib/types';
+  import type { FlowDefinition, FlowStep, FlowStepResult, FlowRunRecord, FlowRunStatus, FileNode, TreeNode as TNode, HttpHeader, FlowStepOverrides, PbDirective, Variable, NamedRequestResult } from '../lib/types';
   import { getAllFileNodes, substituteAll, parseScriptText } from '../lib/parser';
-  import { baseEnvVars, namedResults, dotenvVariables } from '../lib/stores';
+  import { applyAliasSync, autoAliasFor } from '../lib/flowAlias';
+  import { baseEnvVars, dotenvVariables } from '../lib/stores';
   import { METHOD_COLORS } from '../lib/theme';
 
   export let flow: FlowDefinition;
@@ -48,6 +49,22 @@
 
   $: brokenCount = flow.steps.filter(isStepBroken).length;
   $: hasAnyBroken = brokenCount > 0;
+
+  /** Captured responses from the most recent flow run, keyed by step alias.
+   *  Flow-run results never reach the global `$namedResults` store, so the
+   *  VariablePicker needs this flow-scoped map to preview body/header values. */
+  $: flowLocalNamedResults = (() => {
+    const source = runState?.stepResults ?? lastRunRecord?.stepResults ?? [];
+    const map: Record<string, NamedRequestResult> = {};
+    for (const result of source) {
+      if (!result.response || !result.sentRequest) continue;
+      const step = flow.steps.find(s => s.id === result.stepId);
+      const alias = step?.varName;
+      if (!alias) continue;
+      map[alias] = { request: result.sentRequest, response: result.response };
+    }
+    return map;
+  })();
 
   $: resolvedStepUrls = (() => {
     const env = $baseEnvVars;
@@ -157,7 +174,7 @@
     // Adjust target index after removal
     const target = insertSlot > draggingIndex ? insertSlot - 1 : insertSlot;
     steps.splice(target, 0, moved);
-    flow = { ...flow, steps };
+    flow = { ...flow, steps: applyAliasSync(steps) };
     save();
     draggingIndex = -1;
     insertSlot = -1;
@@ -181,7 +198,7 @@
     const steps = [...flow.steps];
     const [moved] = steps.splice(from, 1);
     steps.splice(to, 0, moved);
-    flow = { ...flow, steps };
+    flow = { ...flow, steps: applyAliasSync(steps) };
     save();
   }
 
@@ -228,12 +245,13 @@
   }
 
   function addStep(e: CustomEvent<FlowStep>) {
-    flow = { ...flow, steps: [...flow.steps, e.detail] };
+    flow = { ...flow, steps: applyAliasSync([...flow.steps, e.detail]) };
     save();
   }
 
   function removeStep(index: number) {
-    flow = { ...flow, steps: flow.steps.filter((_, i) => i !== index) };
+    const next = flow.steps.filter((_, i) => i !== index);
+    flow = { ...flow, steps: applyAliasSync(next) };
     save();
   }
 
@@ -241,6 +259,30 @@
     const steps = [...flow.steps];
     steps[index] = { ...steps[index], continueOnFailure: !steps[index].continueOnFailure };
     flow = { ...flow, steps };
+    save();
+  }
+
+  /** Set the step's response alias. Any non-empty value that differs from the current
+   *  auto name locks the alias (user-customized). Empty input, or a value matching the
+   *  position's auto name, unlocks and triggers regeneration. */
+  function setStepAlias(index: number, raw: string) {
+    const trimmed = raw.trim();
+    const steps = [...flow.steps];
+    const auto = autoAliasFor(index);
+    if (trimmed === '' || trimmed === auto) {
+      steps[index] = { ...steps[index], varName: null, aliasLocked: false };
+    } else {
+      steps[index] = { ...steps[index], varName: trimmed, aliasLocked: true };
+    }
+    flow = { ...flow, steps: applyAliasSync(steps) };
+    save();
+  }
+
+  /** "Reset to auto" affordance: unlocks the step so it takes the auto Step{N} name. */
+  function resetStepAlias(index: number) {
+    const steps = [...flow.steps];
+    steps[index] = { ...steps[index], varName: null, aliasLocked: false };
+    flow = { ...flow, steps: applyAliasSync(steps) };
     save();
   }
 
@@ -415,6 +457,19 @@
   let pickerTarget: PickerTarget | null = null;
   let pickerCursor: number = -1;
   let pickerFileVars: Variable[] = [];
+  let pickerNamedResults: Record<string, NamedRequestResult> = {};
+  let pickerFlowAliases: { name: string; stepNumber: number }[] = [];
+
+  /** Collect aliases from every step before `stepIndex`. `applyAliasSync` guarantees
+   *  every step has a unique non-null `varName`, so this is a straight map. */
+  function collectPrecedingFlowAliases(stepIndex: number): { name: string; stepNumber: number }[] {
+    const out: { name: string; stepNumber: number }[] = [];
+    for (let i = 0; i < stepIndex && i < flow.steps.length; i++) {
+      const name = flow.steps[i].varName;
+      if (name) out.push({ name, stepNumber: i + 1 });
+    }
+    return out;
+  }
 
   function insertAtCursor(text: string, value: string): string {
     if (pickerCursor >= 0 && pickerCursor <= text.length) {
@@ -428,6 +483,13 @@
     pickerCursor = active?.selectionStart ?? -1;
     pickerTarget = target;
     pickerFileVars = file?.variables ?? [];
+    const aliases = collectPrecedingFlowAliases(target.stepIndex);
+    pickerFlowAliases = aliases;
+    const scoped: Record<string, NamedRequestResult> = {};
+    for (const { name } of aliases) {
+      if (flowLocalNamedResults[name]) scoped[name] = flowLocalNamedResults[name];
+    }
+    pickerNamedResults = scoped;
     showVarPicker = true;
   }
 
@@ -671,6 +733,29 @@
               <div class="override-panel" on:mousedown|stopPropagation on:dragstart|preventDefault|stopPropagation>
                 <div class="override-section">
                   <div class="override-row">
+                    <span class="override-label" title="Flow-local alias for this step's response. Referenced as {'{'}{'{'}alias.response.body.$....{'}'}{'}'} in later steps. Auto-named Step{i + 1} unless you customize it.">Alias{#if step.aliasLocked}<span class="modified-dot" title="Custom"></span>{/if}</span>
+                    <input
+                      class="override-input"
+                      class:showing-base={!step.aliasLocked}
+                      type="text"
+                      value={step.varName ?? ''}
+                      placeholder={autoAliasFor(i)}
+                      on:input={(e) => setStepAlias(i, e.currentTarget.value)}
+                      spellcheck="false"
+                    />
+                    {#if step.aliasLocked}
+                      <button
+                        type="button"
+                        class="btn-alias-reset"
+                        on:click={() => resetStepAlias(i)}
+                        title="Reset to auto alias (Step{i + 1}) and cascade the rename into later steps"
+                      >Reset</button>
+                    {/if}
+                  </div>
+                </div>
+
+                <div class="override-section">
+                  <div class="override-row">
                     <span class="override-label">URL{#if step.overrides?.url !== undefined}<span class="modified-dot" title="Modified"></span>{/if}</span>
                     <input
                       class="override-input"
@@ -870,7 +955,8 @@
   visible={showVarPicker}
   fileVariables={pickerFileVars}
   envVariables={$baseEnvVars}
-  namedResults={$namedResults}
+  namedResults={pickerNamedResults}
+  flowAliases={pickerFlowAliases}
   on:insert={handleVarPickerInsert}
   on:close={() => { showVarPicker = false; pickerTarget = null; }}
 />
@@ -1576,6 +1662,21 @@
     border-color: var(--color-warning);
     color: var(--color-warning);
     background: color-mix(in srgb, var(--color-warning) 6%, transparent);
+  }
+  .btn-alias-reset {
+    font-size: var(--text-xs);
+    padding: 2px var(--space-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .btn-alias-reset:hover {
+    border-color: var(--color-accent-flow);
+    color: var(--color-accent-flow);
+    background: color-mix(in srgb, var(--color-accent-flow) 6%, transparent);
   }
   .override-tab-spacer { flex: 1; }
   .override-body {

--- a/src/components/FlowEditor.svelte
+++ b/src/components/FlowEditor.svelte
@@ -66,18 +66,33 @@
     return map;
   })();
 
+  /** Variables set by `pb.set` / `pb.global` during the flow's most recent run.
+   *  Available only after a completed run (flowRunner attaches them to the record).
+   *  Both kinds are merged: from the user's perspective inside the flow they are
+   *  just "variables this flow defines." */
+  $: flowScopeVars = (() => {
+    const v = lastRunRecord?.variables;
+    if (!v) return {};
+    return { ...v.setVars, ...v.globalVars };
+  })();
+
   $: resolvedStepUrls = (() => {
     const env = $baseEnvVars;
     const dotenv = $dotenvVariables;
+    const scope = flowScopeVars;
     return flow.steps.map((step) => {
       const file = findFileForStep(step);
       const req = file && step.requestIndex >= 0 && step.requestIndex < (file.requests?.length ?? 0)
         ? file.requests[step.requestIndex]
         : null;
-      const rawUrl = req ? req.url : getUrl(step.label);
+      // Prefer the step's override URL (what the user is actively editing) over the base.
+      const rawUrl = step.overrides?.url ?? (req ? req.url : getUrl(step.label));
       if (!rawUrl || !rawUrl.includes('{{')) return '';
+      // Merge env with flow-scope vars (pb.set / pb.global captured on last run) so
+      // URLs that reference them (e.g. {{sessionId}}) resolve in the preview.
       const nonEmptyEnv: Record<string, string> = {};
       for (const [k, v] of Object.entries(env)) if (v) nonEmptyEnv[k] = v;
+      for (const [k, v] of Object.entries(scope)) if (v != null && v !== '') nonEmptyEnv[k] = String(v);
       const resolved = substituteAll(rawUrl, {
         fileVariables: [],
         environmentVariables: nonEmptyEnv,
@@ -957,6 +972,8 @@
   envVariables={$baseEnvVars}
   namedResults={pickerNamedResults}
   flowAliases={pickerFlowAliases}
+  flowName={flow.name}
+  flowSetVars={flowScopeVars}
   on:insert={handleVarPickerInsert}
   on:close={() => { showVarPicker = false; pickerTarget = null; }}
 />

--- a/src/components/FlowEditor.svelte
+++ b/src/components/FlowEditor.svelte
@@ -277,20 +277,42 @@
     save();
   }
 
-  /** Set the step's response alias. Any non-empty value that differs from the current
-   *  auto name locks the alias (user-customized). Empty input, or a value matching the
-   *  position's auto name, unlocks and triggers regeneration. */
+  /** Draft alias values keyed by step id. Keeps the input responsive on every
+   *  keystroke without running `applyAliasSync` / `save()` until the user commits
+   *  (blur, Enter, or native `change`). */
+  let aliasDraft: Record<string, string> = {};
+
+  const AUTO_ALIAS_SHAPE = /^Step\d+$/;
+
+  /** Commit the alias draft for step `index`. Empty input, a value matching the
+   *  position's auto name, or any `Step{N}`-shaped value unlocks the alias -
+   *  auto-shaped names are system-managed and cannot be user-locked.
+   *  Other non-empty values lock the alias as user-customized. */
   function setStepAlias(index: number, raw: string) {
     const trimmed = raw.trim();
     const steps = [...flow.steps];
     const auto = autoAliasFor(index);
-    if (trimmed === '' || trimmed === auto) {
+    if (trimmed === '' || trimmed === auto || AUTO_ALIAS_SHAPE.test(trimmed)) {
       steps[index] = { ...steps[index], varName: null, aliasLocked: false };
     } else {
       steps[index] = { ...steps[index], varName: trimmed, aliasLocked: true };
     }
     flow = { ...flow, steps: applyAliasSync(steps) };
+    delete aliasDraft[steps[index].id];
+    aliasDraft = aliasDraft;
     save();
+  }
+
+  function onAliasInput(stepId: string, value: string) {
+    aliasDraft = { ...aliasDraft, [stepId]: value };
+  }
+
+  function commitAliasDraft(index: number) {
+    const stepId = flow.steps[index]?.id;
+    if (stepId == null) return;
+    const draft = aliasDraft[stepId];
+    if (draft === undefined) return;
+    setStepAlias(index, draft);
   }
 
   /** "Reset to auto" affordance: unlocks the step so it takes the auto Step{N} name. */
@@ -753,9 +775,12 @@
                       class="override-input"
                       class:showing-base={!step.aliasLocked}
                       type="text"
-                      value={step.varName ?? ''}
+                      value={aliasDraft[step.id] ?? (step.varName ?? '')}
                       placeholder={autoAliasFor(i)}
-                      on:input={(e) => setStepAlias(i, e.currentTarget.value)}
+                      on:input={(e) => onAliasInput(step.id, e.currentTarget.value)}
+                      on:change={() => commitAliasDraft(i)}
+                      on:blur={() => commitAliasDraft(i)}
+                      on:keydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commitAliasDraft(i); } }}
                       spellcheck="false"
                     />
                     {#if step.aliasLocked}
@@ -763,7 +788,7 @@
                         type="button"
                         class="btn-alias-reset"
                         on:click={() => resetStepAlias(i)}
-                        title="Reset to auto alias (Step{i + 1}) and cascade the rename into later steps"
+                        title="Reset to auto alias (Step{i + 1}) and rewrite references across all steps"
                       >Reset</button>
                     {/if}
                   </div>

--- a/src/components/FlowStepPicker.svelte
+++ b/src/components/FlowStepPicker.svelte
@@ -38,7 +38,8 @@
       id: crypto.randomUUID(),
       filePath: relativePath,
       requestIndex,
-      varName: req.varName,
+      varName: null,
+      aliasLocked: false,
       label: `${req.method} ${req.url}`,
       continueOnFailure: false,
     };

--- a/src/components/PickerRow.svelte
+++ b/src/components/PickerRow.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  export let label: string;
+  export let value: string;
+  export let inserted: boolean = false;
+  export let nested: boolean = false;
+  export let maxValueLength: number = 30;
+
+  $: truncated = value.length > maxValueLength ? value.slice(0, maxValueLength) + '...' : value;
+</script>
+
+<button class="picker-row" class:row-nested={nested} class:inserted on:click>
+  <span class="row-key">{label}</span>
+  <span class="row-value">{truncated}</span>
+  <span class="row-action">{inserted ? 'Inserted' : 'Insert'}</span>
+</button>
+
+<style>
+  .picker-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: 100%;
+    padding: 7px var(--space-4);
+    border: none;
+    background: transparent;
+    color: var(--color-text);
+    font-family: inherit;
+    font-size: var(--text-base);
+    cursor: pointer;
+    text-align: left;
+    transition: background var(--duration-fast);
+  }
+  .picker-row:hover { background: var(--color-bg-subtle); }
+  .picker-row.inserted { background: #E8F5E9; }
+  .picker-row.row-nested { padding-left: var(--space-6); }
+
+  .row-key {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-warning);
+    font-weight: var(--weight-semibold);
+    flex-shrink: 0;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .row-value {
+    color: var(--color-text-faint);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: right;
+  }
+  .row-action {
+    font-size: var(--text-2xs);
+    font-weight: var(--weight-semibold);
+    color: var(--color-text-placeholder);
+    flex-shrink: 0;
+    white-space: nowrap;
+    opacity: 0;
+    transition: opacity var(--duration-fast);
+  }
+  .picker-row:hover .row-action { opacity: 1; }
+  .picker-row.inserted .row-action {
+    opacity: 1;
+    color: var(--color-success);
+  }
+</style>

--- a/src/components/PickerRow.svelte
+++ b/src/components/PickerRow.svelte
@@ -31,7 +31,7 @@
     transition: background var(--duration-fast);
   }
   .picker-row:hover { background: var(--color-bg-subtle); }
-  .picker-row.inserted { background: #E8F5E9; }
+  .picker-row.inserted { background: color-mix(in srgb, var(--color-success) 12%, transparent); }
   .picker-row.row-nested { padding-left: var(--space-6); }
 
   .row-key {

--- a/src/components/VariablePicker.svelte
+++ b/src/components/VariablePicker.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import type { Variable, NamedRequestResult } from '../lib/types';
+  import PickerRow from './PickerRow.svelte';
 
   export let fileVariables: Variable[] = [];
   export let envVariables: Record<string, string> = {};
   export let namedResults: Record<string, NamedRequestResult> = {};
   export let visible: boolean = false;
+  /** When non-null, scopes the response section to these aliases (from the active test flow).
+   *  Aliases without a captured result still appear with placeholder body/header rows. */
+  export let flowAliases: { name: string; stepNumber: number }[] | null = null;
+
+  let expandedAliases: Record<string, boolean> = {};
+  $: if (visible) { expandedAliases = {}; }
+  function toggleAlias(name: string) {
+    expandedAliases = { ...expandedAliases, [name]: !expandedAliases[name] };
+  }
 
   const dispatch = createEventDispatcher();
 
@@ -16,10 +26,6 @@
   $: if (visible) { searchQuery = ''; insertedKey = null; }
 
   $: searchQueryLower = searchQuery.trim().toLowerCase();
-
-  function truncate(str: string, max: number): string {
-    return str.length > max ? str.slice(0, max) + '...' : str;
-  }
 
   // Flatten JSON object into dot-path entries
   function flattenJson(obj: any, prefix: string = '$', maxDepth: number = 4): { path: string; value: string }[] {
@@ -115,9 +121,21 @@
       : group.headerFields,
   })).filter(g => g.bodyFields.length > 0 || g.headerFields.length > 0);
 
+  $: responseGroupMap = Object.fromEntries(responseGroups.map(g => [g.name, g]));
+
   $: hasEnvOrFile = envEntries.length > 0 || fileOnly.length > 0;
+
+  // Flow-scoped aliases filtered by search query (match on name).
+  $: filteredFlowAliases = flowAliases
+    ? (searchQueryLower
+        ? flowAliases.filter(a => a.name.toLowerCase().includes(searchQueryLower))
+        : flowAliases)
+    : [];
+
   $: totalVisible = filteredEnv.length + filteredFile.length + filteredDynamic.length
-    + filteredResponseGroups.reduce((s, g) => s + g.bodyFields.length + g.headerFields.length, 0);
+    + (flowAliases
+        ? filteredFlowAliases.length
+        : filteredResponseGroups.reduce((s, g) => s + g.bodyFields.length + g.headerFields.length, 0));
 
   function doInsert(key: string, value: string) {
     insertedKey = key;
@@ -176,6 +194,69 @@
               <p class="empty-hint">Try a different search term.</p>
             </div>
           {:else}
+            <!-- Flow-scoped: one collapsible group per preceding-step alias (rendered first in flow picker) -->
+            {#if flowAliases !== null}
+              {#each filteredFlowAliases as alias}
+                {@const group = responseGroupMap[alias.name]}
+                {@const isOpen = expandedAliases[alias.name] === true}
+                {@const bodyFields = group ? (searchQueryLower
+                  ? group.bodyFields.filter(f => f.path.toLowerCase().includes(searchQueryLower) || f.value.toLowerCase().includes(searchQueryLower))
+                  : group.bodyFields) : []}
+                {@const headerFields = group ? (searchQueryLower
+                  ? group.headerFields.filter(f => f.path.toLowerCase().includes(searchQueryLower) || f.value.toLowerCase().includes(searchQueryLower))
+                  : group.headerFields) : []}
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <button
+                  class="group-header group-header-button"
+                  class:open={isOpen}
+                  on:click={() => toggleAlias(alias.name)}
+                  aria-expanded={isOpen}
+                >
+                  <span class="chevron" aria-hidden="true">{isOpen ? '▾' : '▸'}</span>
+                  <span class="step-pill">{alias.stepNumber}</span>
+                  <span class="group-label">{alias.name} - Response</span>
+                  {#if group}
+                    <span class="status-badge" class:success={group.status < 400} class:error={group.status >= 400}>{group.status}</span>
+                  {:else}
+                    <span class="status-badge pending">not run</span>
+                  {/if}
+                </button>
+                {#if isOpen}
+                  <div class="sub-header">Body</div>
+                  {#if group && bodyFields.length > 0}
+                    {#each bodyFields.slice(0, 12) as field}
+                      {@const rowKey = `${alias.name}.body.${field.path}`}
+                      <PickerRow nested label={field.path} value={field.value} inserted={insertedKey === rowKey} on:click={() => insertResponseBody(alias.name, field.path)} />
+                    {/each}
+                    {#if bodyFields.length > 12}
+                      <div class="empty-hint">{bodyFields.length - 12} more fields...</div>
+                    {/if}
+                  {:else}
+                    {@const bodyKey = `${alias.name}.body.pending`}
+                    <PickerRow nested label="$" value={group ? 'no matches' : 'fill in JSONPath after $'} inserted={insertedKey === bodyKey} on:click={() => doInsert(bodyKey, `{{${alias.name}.response.body.$.}}`)} />
+                  {/if}
+
+                  <div class="sub-header">Headers</div>
+                  {#if group && headerFields.length > 0}
+                    {#each headerFields as field}
+                      {@const rowKey = `${alias.name}.hdr.${field.path}`}
+                      <PickerRow nested label={field.path} value={field.value} inserted={insertedKey === rowKey} on:click={() => insertResponseHeader(alias.name, field.path)} />
+                    {/each}
+                  {:else}
+                    {@const hdrKey = `${alias.name}.hdr.pending`}
+                    <PickerRow nested label="headers" value={group ? 'no matches' : 'fill in header name'} inserted={insertedKey === hdrKey} on:click={() => doInsert(hdrKey, `{{${alias.name}.response.headers.}}`)} />
+                  {/if}
+                {/if}
+              {/each}
+
+              {#if filteredFlowAliases.length === 0 && !searchQuery}
+                <div class="group-header">
+                  <span class="group-label">From earlier steps in this flow</span>
+                </div>
+                <div class="empty-hint">No preceding steps have a response alias. Add <code>{'#'} @name alias</code> to a request above this step.</div>
+              {/if}
+            {/if}
+
             <!-- Environment variables -->
             {#if filteredEnv.length > 0}
               <div class="group-header">
@@ -183,11 +264,7 @@
                 <span class="group-count">{filteredEnv.length}</span>
               </div>
               {#each filteredEnv as [key, value]}
-                <button class="picker-row" class:inserted={insertedKey === key} on:click={() => insertEnvVar(key)}>
-                  <span class="row-key">{key}</span>
-                  <span class="row-value">{truncate(value, 30)}</span>
-                  <span class="row-action">{insertedKey === key ? 'Inserted' : 'Insert'}</span>
-                </button>
+                <PickerRow label={key} {value} inserted={insertedKey === key} on:click={() => insertEnvVar(key)} />
               {/each}
             {/if}
 
@@ -198,11 +275,7 @@
                 <span class="group-count">{filteredFile.length}</span>
               </div>
               {#each filteredFile as v}
-                <button class="picker-row" class:inserted={insertedKey === v.key} on:click={() => insertEnvVar(v.key)}>
-                  <span class="row-key">{v.key}</span>
-                  <span class="row-value">{truncate(v.value, 30)}</span>
-                  <span class="row-action">{insertedKey === v.key ? 'Inserted' : 'Insert'}</span>
-                </button>
+                <PickerRow label={v.key} value={v.value} inserted={insertedKey === v.key} on:click={() => insertEnvVar(v.key)} />
               {/each}
             {/if}
 
@@ -220,59 +293,50 @@
                 <span class="group-count">{filteredDynamic.length}</span>
               </div>
               {#each filteredDynamic as d}
-                <button class="picker-row" class:inserted={insertedKey === d.key} on:click={() => doInsert(d.key, d.insert)}>
-                  <span class="row-key">{d.key}</span>
-                  <span class="row-value">{d.value}</span>
-                  <span class="row-action">{insertedKey === d.key ? 'Inserted' : 'Insert'}</span>
-                </button>
+                <PickerRow label={d.key} value={d.value} inserted={insertedKey === d.key} on:click={() => doInsert(d.key, d.insert)} />
               {/each}
             {/if}
 
-            <!-- Response groups -->
-            {#each filteredResponseGroups as group}
-              {#if group.bodyFields.length > 0}
-                <div class="group-header">
-                  <span class="group-label">Response body - {group.name}</span>
-                  <span class="status-badge" class:success={group.status < 400} class:error={group.status >= 400}>
-                    {group.status}
-                  </span>
-                  <span class="group-count">{group.bodyFields.length}</span>
-                </div>
-                {#each group.bodyFields.slice(0, 12) as field}
-                  {@const rowKey = `${group.name}.body.${field.path}`}
-                  <button class="picker-row" class:inserted={insertedKey === rowKey} on:click={() => insertResponseBody(group.name, field.path)}>
-                    <span class="row-key">{field.path}</span>
-                    <span class="row-value">{truncate(field.value, 30)}</span>
-                    <span class="row-action">{insertedKey === rowKey ? 'Inserted' : 'Insert'}</span>
-                  </button>
-                {/each}
-                {#if group.bodyFields.length > 12}
-                  <div class="empty-hint">{group.bodyFields.length - 12} more fields...</div>
+            <!-- Response groups - non-flow picker (unchanged) -->
+            {#if flowAliases === null}
+              {#each filteredResponseGroups as group}
+                {#if group.bodyFields.length > 0}
+                  <div class="group-header">
+                    <span class="group-label">Response body - {group.name}</span>
+                    <span class="status-badge" class:success={group.status < 400} class:error={group.status >= 400}>
+                      {group.status}
+                    </span>
+                    <span class="group-count">{group.bodyFields.length}</span>
+                  </div>
+                  {#each group.bodyFields.slice(0, 12) as field}
+                    {@const rowKey = `${group.name}.body.${field.path}`}
+                    <PickerRow label={field.path} value={field.value} inserted={insertedKey === rowKey} on:click={() => insertResponseBody(group.name, field.path)} />
+                  {/each}
+                  {#if group.bodyFields.length > 12}
+                    <div class="empty-hint">{group.bodyFields.length - 12} more fields...</div>
+                  {/if}
                 {/if}
-              {/if}
 
-              {#if group.headerFields.length > 0}
+                {#if group.headerFields.length > 0}
+                  <div class="group-header">
+                    <span class="group-label">Response headers - {group.name}</span>
+                    <span class="group-count">{group.headerFields.length}</span>
+                  </div>
+                  {#each group.headerFields as field}
+                    {@const rowKey = `${group.name}.hdr.${field.path}`}
+                    <PickerRow label={field.path} value={field.value} inserted={insertedKey === rowKey} on:click={() => insertResponseHeader(group.name, field.path)} />
+                  {/each}
+                {/if}
+              {/each}
+
+              {#if responseGroups.length === 0 && !searchQuery}
                 <div class="group-header">
-                  <span class="group-label">Response headers - {group.name}</span>
-                  <span class="group-count">{group.headerFields.length}</span>
+                  <span class="group-label">Response references</span>
                 </div>
-                {#each group.headerFields as field}
-                  {@const rowKey = `${group.name}.hdr.${field.path}`}
-                  <button class="picker-row" class:inserted={insertedKey === rowKey} on:click={() => insertResponseHeader(group.name, field.path)}>
-                    <span class="row-key">{field.path}</span>
-                    <span class="row-value">{truncate(field.value, 30)}</span>
-                    <span class="row-action">{insertedKey === rowKey ? 'Inserted' : 'Insert'}</span>
-                  </button>
-                {/each}
+                <div class="empty-hint">Send a request with a response alias first (right-click a request to set one).</div>
               {/if}
-            {/each}
-
-            {#if responseGroups.length === 0 && !searchQuery}
-              <div class="group-header">
-                <span class="group-label">Response references</span>
-              </div>
-              <div class="empty-hint">Send a request with a response alias first (right-click a request to set one).</div>
             {/if}
+
           {/if}
         </div>
       </div>
@@ -363,63 +427,54 @@
   }
   .status-badge.success { background: color-mix(in srgb, var(--color-success) 9%, transparent); color: var(--color-success); }
   .status-badge.error { background: color-mix(in srgb, var(--color-error) 9%, transparent); color: var(--color-error); }
+  .status-badge.pending { background: color-mix(in srgb, var(--color-text-muted) 12%, transparent); color: var(--color-text-muted); }
 
-  .picker-row {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    width: 100%;
-    padding: 7px var(--space-4);
+  .group-header-button {
     border: none;
-    background: transparent;
-    color: var(--color-text);
-    font-family: inherit;
-    font-size: var(--text-base);
+    border-top: 1px solid var(--color-divider);
+    background: var(--color-bg-sidebar);
+    font: inherit;
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--color-text-faint);
     cursor: pointer;
     text-align: left;
-    transition: background var(--duration-fast);
+    width: 100%;
+    box-sizing: border-box;
+    margin: 0;
   }
-  .picker-row:hover { background: var(--color-bg-subtle); }
-  .picker-row.inserted { background: #E8F5E9; }
-
-  .row-key {
-    font-family: var(--font-mono);
-    font-size: var(--text-sm);
-    color: var(--color-warning);
-    font-weight: var(--weight-semibold);
+  .chevron {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    width: 12px;
+    display: inline-flex;
+    justify-content: center;
+  }
+  .step-pill {
+    font-size: var(--text-xs);
+    font-weight: var(--weight-bold);
+    color: var(--color-accent-flow);
+    background: color-mix(in srgb, var(--color-accent-flow) 10%, transparent);
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
     flex-shrink: 0;
-    max-width: 160px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
-  .row-value {
-    color: var(--color-text-faint);
-    font-family: var(--font-mono);
-    font-size: var(--text-sm);
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    text-align: right;
-  }
-
-  .row-action {
-    font-size: var(--text-2xs);
+  .sub-header {
+    font-size: var(--text-xs);
     font-weight: var(--weight-semibold);
-    color: var(--color-text-placeholder);
-    flex-shrink: 0;
-    white-space: nowrap;
-    opacity: 0;
-    transition: opacity var(--duration-fast);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: var(--space-1\.5) var(--space-2) var(--space-1\.5) var(--space-6);
+    background: color-mix(in srgb, var(--color-text-muted) 6%, transparent);
+    border-top: 1px solid var(--color-divider);
+    border-bottom: 1px solid var(--color-divider);
   }
-  .picker-row:hover .row-action { opacity: 1; }
-  .picker-row.inserted .row-action {
-    opacity: 1;
-    color: var(--color-success);
-  }
-
   .empty-hint {
     padding: var(--space-2) var(--space-4);
     font-size: var(--text-sm);

--- a/src/components/VariablePicker.svelte
+++ b/src/components/VariablePicker.svelte
@@ -10,9 +10,15 @@
   /** When non-null, scopes the response section to these aliases (from the active test flow).
    *  Aliases without a captured result still appear with placeholder body/header rows. */
   export let flowAliases: { name: string; stepNumber: number }[] | null = null;
+  /** Flow display name; used as the header of the flow-scope variables section. */
+  export let flowName: string = '';
+  /** Variables set via `pb.set` / `pb.global` during the flow's most recent run.
+   *  Rendered as a collapsible section at the top of the flow-scoped picker. */
+  export let flowSetVars: Record<string, string> = {};
 
   let expandedAliases: Record<string, boolean> = {};
-  $: if (visible) { expandedAliases = {}; }
+  let flowVarsExpanded = false;
+  $: if (visible) { expandedAliases = {}; flowVarsExpanded = false; }
   function toggleAlias(name: string) {
     expandedAliases = { ...expandedAliases, [name]: !expandedAliases[name] };
   }
@@ -132,9 +138,17 @@
         : flowAliases)
     : [];
 
+  // Flow-scope variables (pb.set / pb.global captured last run), filtered by search.
+  $: flowSetEntries = Object.entries(flowSetVars);
+  $: filteredFlowSet = searchQueryLower
+    ? flowSetEntries.filter(([k, v]) =>
+        k.toLowerCase().includes(searchQueryLower) ||
+        v.toLowerCase().includes(searchQueryLower))
+    : flowSetEntries;
+
   $: totalVisible = filteredEnv.length + filteredFile.length + filteredDynamic.length
     + (flowAliases
-        ? filteredFlowAliases.length
+        ? filteredFlowAliases.length + filteredFlowSet.length
         : filteredResponseGroups.reduce((s, g) => s + g.bodyFields.length + g.headerFields.length, 0));
 
   function doInsert(key: string, value: string) {
@@ -194,8 +208,29 @@
               <p class="empty-hint">Try a different search term.</p>
             </div>
           {:else}
-            <!-- Flow-scoped: one collapsible group per preceding-step alias (rendered first in flow picker) -->
+            <!-- Flow-scoped sections (rendered first in flow picker) -->
             {#if flowAliases !== null}
+              <!-- Flow-scope variables: pb.set / pb.global captured on the most recent run. -->
+              {#if filteredFlowSet.length > 0}
+                <button
+                  class="group-header group-header-button"
+                  class:open={flowVarsExpanded}
+                  on:click={() => (flowVarsExpanded = !flowVarsExpanded)}
+                  aria-expanded={flowVarsExpanded}
+                  title="Variables set by this flow via pb.set or pb.global on its last run"
+                >
+                  <span class="chevron" aria-hidden="true">{flowVarsExpanded ? '▾' : '▸'}</span>
+                  <span class="group-label">{flowName || 'Flow variables'}</span>
+                  <span class="group-count">{filteredFlowSet.length}</span>
+                </button>
+                {#if flowVarsExpanded}
+                  {#each filteredFlowSet as [key, value]}
+                    {@const rowKey = `flowvar.${key}`}
+                    <PickerRow nested label={key} {value} inserted={insertedKey === rowKey} on:click={() => doInsert(rowKey, `{{${key}}}`)} />
+                  {/each}
+                {/if}
+              {/if}
+
               {#each filteredFlowAliases as alias}
                 {@const group = responseGroupMap[alias.name]}
                 {@const isOpen = expandedAliases[alias.name] === true}

--- a/src/lib/flowAlias.test.ts
+++ b/src/lib/flowAlias.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import type { FlowStep } from './types';
+import { applyAliasSync, applyRenamesToString, normalizeFlowAliases } from './flowAlias';
+
+function step(partial: Partial<FlowStep>): FlowStep {
+  return {
+    id: partial.id ?? crypto.randomUUID(),
+    filePath: 'x.http',
+    requestIndex: 0,
+    varName: partial.varName ?? null,
+    aliasLocked: partial.aliasLocked ?? false,
+    label: partial.label ?? 'GET /',
+    continueOnFailure: false,
+    overrides: partial.overrides,
+  };
+}
+
+describe('normalizeFlowAliases', () => {
+  it('assigns Step1, Step2, ... to unlocked steps', () => {
+    const { steps } = normalizeFlowAliases([step({}), step({}), step({})]);
+    expect(steps.map(s => s.varName)).toEqual(['Step1', 'Step2', 'Step3']);
+  });
+
+  it('preserves locked aliases', () => {
+    const { steps } = normalizeFlowAliases([
+      step({ varName: 'login', aliasLocked: true }),
+      step({}),
+      step({}),
+    ]);
+    expect(steps.map(s => s.varName)).toEqual(['login', 'Step2', 'Step3']);
+  });
+
+  it('skips numbers reserved by locked aliases', () => {
+    // A locked step named "Step2" forces the unlocked step at index 1 to skip to Step3.
+    const { steps } = normalizeFlowAliases([
+      step({}),
+      step({}),
+      step({ varName: 'Step2', aliasLocked: true }),
+    ]);
+    expect(steps.map(s => s.varName)).toEqual(['Step1', 'Step3', 'Step2']);
+  });
+
+  it('reports renames for auto aliases that shifted', () => {
+    const before = [
+      step({ id: 'a', varName: 'Step1' }),
+      step({ id: 'b', varName: 'Step2' }),
+    ];
+    // Move 'b' to position 0.
+    const { renames } = normalizeFlowAliases([before[1], before[0]]);
+    expect(renames).toEqual({ Step2: 'Step1', Step1: 'Step2' });
+  });
+});
+
+describe('applyRenamesToString', () => {
+  it('rewrites {{old.xxx}} to {{new.xxx}}', () => {
+    const out = applyRenamesToString('token={{Step1.response.body.$.id}}', { Step1: 'Step2' });
+    expect(out).toBe('token={{Step2.response.body.$.id}}');
+  });
+
+  it('handles simultaneous swaps without collision', () => {
+    const out = applyRenamesToString('{{Step1.x}}|{{Step2.y}}', { Step1: 'Step2', Step2: 'Step1' });
+    expect(out).toBe('{{Step2.x}}|{{Step1.y}}');
+  });
+
+  it('does not rewrite prefix-matching names (Step10 when renaming Step1)', () => {
+    const out = applyRenamesToString('{{Step10.x}} and {{Step1.y}}', { Step1: 'Step2' });
+    expect(out).toBe('{{Step10.x}} and {{Step2.y}}');
+  });
+
+  it('leaves unrelated text alone', () => {
+    expect(applyRenamesToString('', { a: 'b' })).toBe('');
+    expect(applyRenamesToString('plain text', { a: 'b' })).toBe('plain text');
+  });
+});
+
+describe('applyAliasSync integration', () => {
+  it('renames locked references after reorder', () => {
+    const s1 = step({ id: 'a', varName: 'Step1' });
+    const s2 = step({
+      id: 'b',
+      varName: 'Step2',
+      overrides: { url: '/x?tok={{Step1.response.body.$.token}}' },
+    });
+    // Reorder: swap.
+    const result = applyAliasSync([s2, s1]);
+    expect(result.map(s => s.varName)).toEqual(['Step1', 'Step2']);
+    // The step that was b (now at index 0 = Step1) still holds the old URL referring to the former Step1
+    // which is now Step2. Cascade should rewrite it.
+    expect(result[0].overrides?.url).toBe('/x?tok={{Step2.response.body.$.token}}');
+  });
+
+  it('cascades renames into headers, scripts, and directive exprs', () => {
+    const s1 = step({ id: 'a', varName: 'Step1' });
+    const s2 = step({
+      id: 'b',
+      varName: 'Step2',
+      overrides: {
+        headers: [{ key: 'X-Tok-{{Step1.response.body.$.k}}', value: 'Bearer {{Step1.response.body.$.token}}', enabled: true }],
+        beforeSend: 'const x = "{{Step1.response.body.$.id}}";',
+        afterReceive: 'log("{{Step1.response.headers.X-Trace}}");',
+        directives: [
+          { type: 'assert', expr: 'pb.response.body.$.ref == "{{Step1.response.body.$.id}}"', label: 'ref matches' },
+          { type: 'set', key: 'tok', expr: '{{Step1.response.body.$.token}}' },
+        ],
+      },
+    });
+    const result = applyAliasSync([s2, s1]);
+    const moved = result[0].overrides!;
+    expect(moved.headers?.[0].key).toBe('X-Tok-{{Step2.response.body.$.k}}');
+    expect(moved.headers?.[0].value).toBe('Bearer {{Step2.response.body.$.token}}');
+    expect(moved.beforeSend).toBe('const x = "{{Step2.response.body.$.id}}";');
+    expect(moved.afterReceive).toBe('log("{{Step2.response.headers.X-Trace}}");');
+    const assertDir = moved.directives?.[0];
+    if (assertDir?.type === 'assert') {
+      expect(assertDir.expr).toBe('pb.response.body.$.ref == "{{Step2.response.body.$.id}}"');
+      expect(assertDir.label).toBe('ref matches');
+    }
+    const setDir = moved.directives?.[1];
+    if (setDir?.type === 'set') {
+      expect(setDir.expr).toBe('{{Step2.response.body.$.token}}');
+    }
+  });
+
+  it('preserves user-locked aliases through reorder', () => {
+    const s1 = step({ id: 'a', varName: 'login', aliasLocked: true });
+    const s2 = step({ id: 'b', varName: 'Step2', aliasLocked: false });
+    const result = applyAliasSync([s2, s1]);
+    // Locked alias moves with the step and keeps its name; unlocked becomes Step1.
+    expect(result[0].varName).toBe('Step1');
+    expect(result[1].varName).toBe('login');
+    expect(result[1].aliasLocked).toBe(true);
+  });
+});

--- a/src/lib/flowAlias.ts
+++ b/src/lib/flowAlias.ts
@@ -1,0 +1,130 @@
+/**
+ * Auto-alias management for flow steps.
+ *
+ * Every step owns an alias (`step.varName`) under which its response is stored
+ * during flow execution (see flowRunner.ts). Aliases fall into two categories:
+ *
+ * - Auto (`aliasLocked === false`): name follows position - "Step1", "Step2", ...
+ *   Regenerated whenever the steps array mutates (add, remove, reorder).
+ * - Locked (`aliasLocked === true`): user-typed name. Never auto-modified.
+ *
+ * When auto aliases are renamed, any `{{oldName.response...}}` references in
+ * sibling steps' template strings are rewritten so the flow stays consistent.
+ */
+
+import type { FlowStep, FlowStepOverrides, HttpHeader, PbDirective } from './types';
+
+const AUTO_PREFIX = 'Step';
+
+/** Generate the nth auto alias (1-indexed). */
+export function autoAliasFor(index: number): string {
+  return `${AUTO_PREFIX}${index + 1}`;
+}
+
+/** Walk steps and assign auto aliases to every unlocked step.
+ *  Returns the new steps array plus a map of {oldName: newName} for every
+ *  alias that actually changed (used to cascade references). */
+export function normalizeFlowAliases(
+  steps: FlowStep[],
+): { steps: FlowStep[]; renames: Record<string, string> } {
+  // Names claimed by locked steps are reserved and cannot be reused by auto aliases.
+  const reserved = new Set<string>();
+  for (const s of steps) {
+    if (s.aliasLocked && s.varName) reserved.add(s.varName);
+  }
+
+  const renames: Record<string, string> = {};
+  const used = new Set<string>(reserved);
+
+  const next = steps.map((s, i) => {
+    if (s.aliasLocked) return s;
+    // Pick Step{N} by position, or the next free Step{K} if reserved.
+    let candidate = autoAliasFor(i);
+    let bumpIndex = i;
+    while (used.has(candidate)) {
+      bumpIndex++;
+      candidate = autoAliasFor(bumpIndex);
+    }
+    used.add(candidate);
+    if (s.varName !== candidate) {
+      if (s.varName) renames[s.varName] = candidate;
+      return { ...s, varName: candidate };
+    }
+    return s;
+  });
+
+  return { steps: next, renames };
+}
+
+/** Rewrite `{{oldName.xxx}}` occurrences to `{{newName.xxx}}` in a string.
+ *  Uses a sentinel two-pass substitution so simultaneous swaps
+ *  (e.g. Step2 <-> Step3) don't collide. */
+export function applyRenamesToString(
+  text: string,
+  renames: Record<string, string>,
+): string {
+  if (!text) return text;
+  const entries = Object.entries(renames);
+  if (entries.length === 0) return text;
+
+  // Pass 1: replace each old name with a unique sentinel.
+  let out = text;
+  const sentinels: { sentinel: string; newName: string }[] = [];
+  entries.forEach(([oldName, newName], i) => {
+    const sentinel = `__FLOW_ALIAS_RENAME_${i}__`;
+    sentinels.push({ sentinel, newName });
+    // Match `{{  oldName` followed by `.`, `}`, whitespace, or `|` (pipe for future filters).
+    // Escapes `.` and other regex-special chars if any ever leak into names.
+    const escaped = oldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`(\\{\\{\\s*)${escaped}(?=[.}\\s|])`, 'g');
+    out = out.replace(re, `$1${sentinel}`);
+  });
+
+  // Pass 2: sentinel -> final new name.
+  for (const { sentinel, newName } of sentinels) {
+    out = out.split(sentinel).join(newName);
+  }
+  return out;
+}
+
+/** Apply the `renames` map to every template-bearing field in an overrides object. */
+function rewriteOverrides(
+  overrides: FlowStepOverrides | undefined,
+  renames: Record<string, string>,
+): FlowStepOverrides | undefined {
+  if (!overrides) return overrides;
+  const next: FlowStepOverrides = { ...overrides };
+  if (next.url !== undefined) next.url = applyRenamesToString(next.url, renames);
+  if (next.body !== undefined) next.body = applyRenamesToString(next.body, renames);
+  if (next.beforeSend !== undefined) next.beforeSend = applyRenamesToString(next.beforeSend, renames);
+  if (next.afterReceive !== undefined) next.afterReceive = applyRenamesToString(next.afterReceive, renames);
+  if (next.headers) {
+    next.headers = next.headers.map((h: HttpHeader) => ({
+      ...h,
+      key: applyRenamesToString(h.key, renames),
+      value: applyRenamesToString(h.value, renames),
+    }));
+  }
+  if (next.directives) {
+    next.directives = next.directives.map((d: PbDirective) => ({
+      ...d,
+      expr: applyRenamesToString(d.expr, renames),
+    }));
+  }
+  return next;
+}
+
+/** Cascade a rename map through every step's override text fields. */
+export function rewriteAliasReferences(
+  steps: FlowStep[],
+  renames: Record<string, string>,
+): FlowStep[] {
+  if (Object.keys(renames).length === 0) return steps;
+  return steps.map(s => ({ ...s, overrides: rewriteOverrides(s.overrides, renames) }));
+}
+
+/** One-shot: normalize auto aliases and cascade any resulting renames into references. */
+export function applyAliasSync(steps: FlowStep[]): FlowStep[] {
+  const { steps: normalized, renames } = normalizeFlowAliases(steps);
+  return rewriteAliasReferences(normalized, renames);
+}

--- a/src/lib/flowIO.ts
+++ b/src/lib/flowIO.ts
@@ -40,11 +40,12 @@ function parseOverrides(raw: any): FlowStepOverrides | undefined {
 function parseFlowStep(raw: any): FlowStep {
   // Legacy flows don't carry `aliasLocked`. Infer:
   //   - explicit boolean: honor it
-  //   - has a non-null varName: treat as user-customized (preserve the name)
-  //   - null varName: auto (will get Step{N} during normalization)
+  //   - varName matches auto shape `Step{N}`: treat as auto (re-normalized)
+  //   - non-null custom varName: preserve as locked
+  //   - null varName: auto
   const aliasLocked = typeof raw.aliasLocked === 'boolean'
     ? raw.aliasLocked
-    : (raw.varName != null);
+    : (raw.varName != null && !/^Step\d+$/.test(raw.varName));
   return {
     id: raw.id ?? crypto.randomUUID(),
     filePath: raw.filePath ?? '',

--- a/src/lib/flowIO.ts
+++ b/src/lib/flowIO.ts
@@ -1,6 +1,7 @@
 import { readTextFile, writeTextFile, readDir, mkdir, remove } from '@tauri-apps/plugin-fs';
 import { join, basename } from '@tauri-apps/api/path';
 import type { FlowDefinition, FlowRunRecord, FlowStep, FlowStepOverrides } from './types';
+import { applyAliasSync } from './flowAlias';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -14,11 +15,15 @@ const MAX_HISTORY_PER_FLOW = 20;
 /** Parse a .pb-flow.json file's contents into a FlowDefinition. */
 export function parseFlowFile(content: string): FlowDefinition {
   const raw = JSON.parse(content);
+  const steps = Array.isArray(raw.steps) ? raw.steps.map(parseFlowStep) : [];
+  // One-time normalization: ensures every step has an auto alias if unlocked.
+  // Legacy flows without `aliasLocked`: parseFlowStep infers it from varName presence.
+  const normalized = applyAliasSync(steps);
   return {
     version: raw.version ?? 1,
     name: raw.name ?? 'Untitled Flow',
     description: raw.description ?? '',
-    steps: Array.isArray(raw.steps) ? raw.steps.map(parseFlowStep) : [],
+    steps: normalized,
   };
 }
 
@@ -33,11 +38,19 @@ function parseOverrides(raw: any): FlowStepOverrides | undefined {
 }
 
 function parseFlowStep(raw: any): FlowStep {
+  // Legacy flows don't carry `aliasLocked`. Infer:
+  //   - explicit boolean: honor it
+  //   - has a non-null varName: treat as user-customized (preserve the name)
+  //   - null varName: auto (will get Step{N} during normalization)
+  const aliasLocked = typeof raw.aliasLocked === 'boolean'
+    ? raw.aliasLocked
+    : (raw.varName != null);
   return {
     id: raw.id ?? crypto.randomUUID(),
     filePath: raw.filePath ?? '',
     requestIndex: raw.requestIndex ?? 0,
     varName: raw.varName ?? null,
+    aliasLocked,
     label: raw.label ?? '',
     continueOnFailure: raw.continueOnFailure ?? false,
     overrides: parseOverrides(raw.overrides),

--- a/src/lib/flowRunner.ts
+++ b/src/lib/flowRunner.ts
@@ -102,9 +102,9 @@ export async function runFlow(
       dotenvVariables,
     };
 
-    // Flow step's own varName takes precedence over the underlying request's `# @name`.
-    const effectiveAlias = step.varName ?? request.varName ?? null;
-    const stepResult = await executeStep(step.id, request, ctx, localNamedResults, localEnvOverrides, localGlobals, effectiveAlias);
+    // Post-normalization invariant (flowAlias.ts): step.varName is always set
+    // and supersedes the underlying request's `# @name`.
+    const stepResult = await executeStep(step.id, request, ctx, localNamedResults, localEnvOverrides, localGlobals, step.varName);
     stepResults.push(stepResult);
     callbacks.onStepComplete(step.id, stepResult);
 

--- a/src/lib/flowRunner.ts
+++ b/src/lib/flowRunner.ts
@@ -102,7 +102,9 @@ export async function runFlow(
       dotenvVariables,
     };
 
-    const stepResult = await executeStep(step.id, request, ctx, localNamedResults, localEnvOverrides, localGlobals);
+    // Flow step's own varName takes precedence over the underlying request's `# @name`.
+    const effectiveAlias = step.varName ?? request.varName ?? null;
+    const stepResult = await executeStep(step.id, request, ctx, localNamedResults, localEnvOverrides, localGlobals, effectiveAlias);
     stepResults.push(stepResult);
     callbacks.onStepComplete(step.id, stepResult);
 
@@ -145,6 +147,7 @@ async function executeStep(
   localNamedResults: Record<string, NamedRequestResult>,
   localEnvOverrides: Record<string, string>,
   localGlobals: Record<string, string>,
+  effectiveAlias: string | null,
 ): Promise<FlowStepResult> {
   const startTime = performance.now();
 
@@ -211,9 +214,10 @@ async function executeStep(
       size: new TextEncoder().encode(res.body).length,
     };
 
-    // Store named result for chaining
-    if (request.varName) {
-      localNamedResults[request.varName] = { request: sentRequest, response };
+    // Store named result for chaining. The flow step's alias (if any) wins over the
+    // underlying request's `# @name`, so flows can name responses independently of .http files.
+    if (effectiveAlias) {
+      localNamedResults[effectiveAlias] = { request: sentRequest, response };
     }
 
     // Execute pb directives + afterReceive scripts

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -232,8 +232,14 @@ export interface FlowStep {
   filePath: string;
   /** Index of the request within that file */
   requestIndex: number;
-  /** @name alias from the request, used as fallback when indices shift */
+  /** Alias under which this step's response is stored in the flow's named-results map.
+   *  When set, takes precedence over the underlying request's `# @name` - lets a flow
+   *  name a step's response independently of the .http file. Also used as a fallback
+   *  to locate the request when `requestIndex` drifts. */
   varName: string | null;
+  /** Whether `varName` is user-customized (true) or system-managed auto alias (false).
+   *  Auto aliases take the form "Step{N}" and are regenerated on reorder/add/remove. */
+  aliasLocked: boolean;
   /** Cached display label (e.g. "POST /api/login") */
   label: string;
   /** If true, the runner continues to the next step even if this step fails */


### PR DESCRIPTION
## Summary
- Flow steps now carry an auto-managed alias (`Step1`, `Step2`, ...) under which their response is stored in the flow run's named-results map. Reorder / add / remove regenerates names and cascades the rename into every `{{oldName.response...}}` reference across step URLs, bodies, headers, scripts, and pb directives.
- Users can lock a custom alias by typing one in; auto-shaped names (`Step{N}`) are reserved for the system and cannot be locked.
- Flow runs are now fully isolated: named results, set vars, and pb globals stay inside the `FlowRunRecord` and no longer leak back into the workspace stores.
- Variable picker gets a dedicated flow-scope section showing preceding step aliases (with captured body/header previews from the last run) and flow-local `pb.set` / `pb.global` vars.

## Test plan
- [x] `pnpm test` (203 passing, including new `flowAlias.test.ts`)
- [x] `pnpm check` (0 errors)
- [ ] Manual: reorder steps, confirm `{{StepN.response...}}` references rewrite
- [ ] Manual: type a custom alias, confirm lock + cascade; type `Step5`, confirm it unlocks rather than locking
- [ ] Manual: load a legacy flow without `aliasLocked`, confirm custom names stay and `Step{N}` names re-normalize
- [ ] Manual: run a flow that uses `pb.set` / `pb.global`, confirm those values show up in the flow's variable picker but not in regular request editors