### PR TITLE
feat(mcp): embedded MCP server with request/flow tools

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -248,6 +248,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "azure_core"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1824,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2291,6 +2350,12 @@ dependencies = [
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2985,6 +3050,7 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 name = "psychic-broccoli"
 version = "0.4.2"
 dependencies = [
+ "axum",
  "azure_identity",
  "azure_security_keyvault_secrets",
  "futures-util",
@@ -2999,6 +3065,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tokio",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3649,6 +3716,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4685,6 +4763,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4728,6 +4807,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ reqwest = { version = "0.13", features = ["json", "stream"] }
 futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 url = "2"
+axum = "0.8"
+uuid = { version = "1", features = ["v4"] }
 azure_identity = { version = "0.35", optional = true }
 azure_security_keyvault_secrets = { version = "0.14", optional = true }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use tauri::Manager;
 use futures_util::StreamExt;
 
+mod mcp;
+
 const REQUEST_TIMEOUT_SECS: u64 = 30;
 const MAX_RESPONSE_BYTES: usize = 50 * 1024 * 1024; // 50 MB
 const MAX_REDIRECTS: usize = 5;
@@ -351,14 +353,23 @@ pub fn run() {
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .plugin(tauri_plugin_opener::init());
+        .plugin(tauri_plugin_opener::init())
+        .manage(mcp::McpServerState::default())
+        .setup(|app| {
+            mcp::init(app.handle());
+            Ok(())
+        });
 
     #[cfg(feature = "keyvault")]
     {
         builder = builder.invoke_handler(tauri::generate_handler![
             http_request,
             extract_getting_started,
-            keyvault_cmd::fetch_keyvault_secret
+            keyvault_cmd::fetch_keyvault_secret,
+            mcp::mcp_get_settings,
+            mcp::mcp_is_running,
+            mcp::mcp_set_enabled,
+            mcp::mcp_set_port
         ]);
     }
 
@@ -366,7 +377,11 @@ pub fn run() {
     {
         builder = builder.invoke_handler(tauri::generate_handler![
             http_request,
-            extract_getting_started
+            extract_getting_started,
+            mcp::mcp_get_settings,
+            mcp::mcp_is_running,
+            mcp::mcp_set_enabled,
+            mcp::mcp_set_port
         ]);
     }
 

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -59,6 +59,9 @@ const EVENT_BRIDGE_REQUEST: &str = "mcp:request";
 const EVENT_BRIDGE_RESPONSE: &str = "mcp:response";
 /// How long a tool waits for the frontend to answer a bridge request.
 const BRIDGE_TIMEOUT_SECS: u64 = 5;
+/// A flow runs many HTTP requests in sequence, so it needs a far longer budget
+/// than the single-shot bridge default before the bridge gives up waiting.
+const FLOW_BRIDGE_TIMEOUT_SECS: u64 = 300;
 
 /* ---------------------------------------------------------------- settings */
 
@@ -464,12 +467,15 @@ fn handle_rpc_message(
 ///
 /// Returns the `data` payload on success, or an error string (frontend-reported
 /// error, timeout, or transport failure) that the caller surfaces as a tool
-/// error. Subsequent tools should follow this same `kind`-dispatched pattern.
+/// error. `timeout_secs` bounds the wait: single-shot tools pass
+/// [`BRIDGE_TIMEOUT_SECS`]; longer-running ones (e.g. flows) pass a larger value.
+/// Subsequent tools should follow this same `kind`-dispatched pattern.
 async fn bridge_request(
     app: &AppHandle,
     pending: &PendingBridge,
     kind: &str,
     params: serde_json::Value,
+    timeout_secs: u64,
 ) -> Result<serde_json::Value, String> {
     let id = uuid::Uuid::new_v4().simple().to_string();
     let (tx, rx) = oneshot::channel::<BridgeResponse>();
@@ -489,7 +495,7 @@ async fn bridge_request(
         return Err(format!("Failed to emit bridge request: {}", e));
     }
 
-    match tokio::time::timeout(Duration::from_secs(BRIDGE_TIMEOUT_SECS), rx).await {
+    match tokio::time::timeout(Duration::from_secs(timeout_secs), rx).await {
         Ok(Ok(resp)) if resp.ok => Ok(resp.data.unwrap_or(serde_json::Value::Null)),
         Ok(Ok(resp)) => Err(resp
             .error
@@ -500,10 +506,7 @@ async fn bridge_request(
             if let Ok(mut map) = pending.lock() {
                 map.remove(&id);
             }
-            Err(format!(
-                "Frontend did not respond within {}s",
-                BRIDGE_TIMEOUT_SECS
-            ))
+            Err(format!("Frontend did not respond within {}s", timeout_secs))
         }
     }
 }
@@ -545,6 +548,25 @@ fn tool_schemas() -> serde_json::Value {
                 "required": ["filePath", "requestIndex"],
                 "additionalProperties": false
             }
+        },
+        {
+            "name": "execute_flow",
+            "description": "Run an entire .pb-flow.json flow from the open workspace and return its run record: an overall status, a passed/failed/skipped summary, and per-step results including the outcome of any pb assertions. Steps run in order with variable chaining between them, and each step's continueOnFailure flag is respected. Variables are resolved using the given environment, falling back to the active environment when omitted. Runs silently: the app's flow panel and run history are left unchanged.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "flowFilePath": {
+                        "type": "string",
+                        "description": "Workspace-relative path to the .pb-flow.json flow file (e.g. 'flows/login.pb-flow.json')."
+                    },
+                    "environment": {
+                        "type": "string",
+                        "description": "Optional environment name used to resolve variables. Defaults to the active environment."
+                    }
+                },
+                "required": ["flowFilePath"],
+                "additionalProperties": false
+            }
         }
     ])
 }
@@ -566,6 +588,7 @@ async fn handle_tool_call(msg: &serde_json::Value, state: &McpState) -> Option<s
     let outcome = match tool_name {
         Some("list_requests") => tool_list_requests(state, arguments).await,
         Some("execute_request") => tool_execute_request(state, arguments).await,
+        Some("execute_flow") => tool_execute_flow(state, arguments).await,
         Some(other) => Err(format!("Unknown tool: {}", other)),
         None => Err("Missing tool name".to_string()),
     };
@@ -604,7 +627,14 @@ async fn tool_list_requests(
         .app
         .as_ref()
         .ok_or_else(|| "MCP bridge unavailable".to_string())?;
-    bridge_request(app, &state.pending, "list_requests", json!({})).await
+    bridge_request(
+        app,
+        &state.pending,
+        "list_requests",
+        json!({}),
+        BRIDGE_TIMEOUT_SECS,
+    )
+    .await
 }
 
 /// `execute_request`: fire one request silently and return its response.
@@ -643,7 +673,56 @@ async fn tool_execute_request(
         "requestIndex": request_index,
         "environment": environment,
     });
-    bridge_request(app, &state.pending, "execute_request", params).await
+    bridge_request(
+        app,
+        &state.pending,
+        "execute_request",
+        params,
+        BRIDGE_TIMEOUT_SECS,
+    )
+    .await
+}
+
+/// `execute_flow`: run a whole flow silently and return its structured run record.
+///
+/// Argument shape is validated here; loading the flow file, resolving variables,
+/// executing every step in order (with chaining and pb assertions), respecting
+/// each step's `continueOnFailure`, and computing the summary all happen on the
+/// frontend (which owns the live workspace state) and come back through the
+/// bridge. The frontend reports a missing or invalid flow file as a bridge error,
+/// which surfaces here as a tool error. No UI stores or run history are touched.
+async fn tool_execute_flow(
+    state: &McpState,
+    arguments: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let flow_file_path = arguments
+        .get("flowFilePath")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "execute_flow requires a string 'flowFilePath'".to_string())?;
+    // `environment` is optional; reject a non-string if present rather than silently ignoring it.
+    let environment = match arguments.get("environment") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(s)) => Some(s.clone()),
+        Some(_) => return Err("'environment' must be a string when provided".to_string()),
+    };
+
+    let app = state
+        .app
+        .as_ref()
+        .ok_or_else(|| "MCP bridge unavailable".to_string())?;
+
+    let params = json!({
+        "flowFilePath": flow_file_path,
+        "environment": environment,
+    });
+    bridge_request(
+        app,
+        &state.pending,
+        "execute_flow",
+        params,
+        FLOW_BRIDGE_TIMEOUT_SECS,
+    )
+    .await
 }
 
 /* ------------------------------------------------------------- Tauri glue */
@@ -820,6 +899,58 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("filePath"));
+    }
+
+    #[test]
+    fn tools_list_advertises_execute_flow() {
+        let msg = json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" });
+        let resp = handle_rpc_message(&msg, SERVER_NAME, "v").unwrap();
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        let ef = tools
+            .iter()
+            .find(|t| t["name"] == json!("execute_flow"))
+            .expect("execute_flow tool advertised");
+        let schema = &ef["inputSchema"];
+        assert_eq!(schema["type"], json!("object"));
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("flowFilePath")));
+    }
+
+    #[tokio::test]
+    async fn execute_flow_rejects_missing_arguments() {
+        let (state, _tx) = test_state("t");
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": { "name": "execute_flow", "arguments": {} }
+        });
+        let resp = handle_tool_call(&msg, &state).await.unwrap();
+        assert_eq!(resp["result"]["isError"], json!(true));
+        assert!(resp["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("flowFilePath"));
+    }
+
+    #[tokio::test]
+    async fn execute_flow_rejects_non_string_environment() {
+        let (state, _tx) = test_state("t");
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": 13,
+            "method": "tools/call",
+            "params": {
+                "name": "execute_flow",
+                "arguments": { "flowFilePath": "flows/x.pb-flow.json", "environment": 5 }
+            }
+        });
+        let resp = handle_tool_call(&msg, &state).await.unwrap();
+        assert_eq!(resp["result"]["isError"], json!(true));
+        assert!(resp["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("environment"));
     }
 
     #[test]

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -567,6 +567,15 @@ fn tool_schemas() -> serde_json::Value {
                 "required": ["flowFilePath"],
                 "additionalProperties": false
             }
+        },
+        {
+            "name": "get_last_result",
+            "description": "Read the response from the user's most recent manually-triggered request, without executing anything. Returns the same shape as execute_request (status, headers, body, timing, and the outcome of any pb assertions), or null if no request has been run yet in the current session. Reflects the state at call time: a later manual request changes what a subsequent call returns.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
         }
     ])
 }
@@ -589,6 +598,7 @@ async fn handle_tool_call(msg: &serde_json::Value, state: &McpState) -> Option<s
         Some("list_requests") => tool_list_requests(state, arguments).await,
         Some("execute_request") => tool_execute_request(state, arguments).await,
         Some("execute_flow") => tool_execute_flow(state, arguments).await,
+        Some("get_last_result") => tool_get_last_result(state, arguments).await,
         Some(other) => Err(format!("Unknown tool: {}", other)),
         None => Err("Missing tool name".to_string()),
     };
@@ -721,6 +731,31 @@ async fn tool_execute_flow(
         "execute_flow",
         params,
         FLOW_BRIDGE_TIMEOUT_SECS,
+    )
+    .await
+}
+
+/// `get_last_result`: read the user's most recent manual request result.
+///
+/// Takes no arguments and mutates nothing. The frontend snapshots the live
+/// `currentResponse`/`pbAssertionResults` stores and returns them in the
+/// `execute_request` shape, or JSON `null` if no request has run yet this
+/// session. Because it reads at call time, a later manual request changes what
+/// a subsequent call returns.
+async fn tool_get_last_result(
+    state: &McpState,
+    _arguments: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let app = state
+        .app
+        .as_ref()
+        .ok_or_else(|| "MCP bridge unavailable".to_string())?;
+    bridge_request(
+        app,
+        &state.pending,
+        "get_last_result",
+        json!({}),
+        BRIDGE_TIMEOUT_SECS,
     )
     .await
 }
@@ -914,6 +949,39 @@ mod tests {
         assert_eq!(schema["type"], json!("object"));
         let required = schema["required"].as_array().unwrap();
         assert!(required.contains(&json!("flowFilePath")));
+    }
+
+    #[test]
+    fn tools_list_advertises_get_last_result() {
+        let msg = json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" });
+        let resp = handle_rpc_message(&msg, SERVER_NAME, "v").unwrap();
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        let glr = tools
+            .iter()
+            .find(|t| t["name"] == json!("get_last_result"))
+            .expect("get_last_result tool advertised");
+        let schema = &glr["inputSchema"];
+        assert_eq!(schema["type"], json!("object"));
+        assert_eq!(schema["additionalProperties"], json!(false));
+        // Takes no input.
+        assert!(schema.get("required").is_none());
+    }
+
+    #[tokio::test]
+    async fn get_last_result_dispatches_via_bridge() {
+        // No frontend listening and `app` is None, so the bridge cannot run: the
+        // tool is reached (not "Unknown tool") and surfaces a bridge error.
+        let (state, _tx) = test_state("t");
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": 14,
+            "method": "tools/call",
+            "params": { "name": "get_last_result", "arguments": {} }
+        });
+        let resp = handle_tool_call(&msg, &state).await.unwrap();
+        assert_eq!(resp["result"]["isError"], json!(true));
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(!text.contains("Unknown tool"), "got: {}", text);
     }
 
     #[tokio::test]

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1,0 +1,1001 @@
+//! Embedded MCP (Model Context Protocol) server.
+//!
+//! Exposes the running app over a localhost-only HTTP/SSE endpoint so MCP
+//! clients (e.g. Claude Code) can drive it. This module is the infrastructure
+//! slice: server lifecycle, bearer-token auth, settings persistence, and the
+//! legacy MCP HTTP+SSE transport with an empty tool list. Individual tools are
+//! added in later slices.
+//!
+//! ## Transport
+//!
+//! This implements the MCP "HTTP+SSE" transport (protocol 2024-11-05):
+//!
+//! - The client opens `GET /sse`. The server replies with an SSE stream whose
+//!   first event is an `endpoint` event carrying the relative URL the client
+//!   must POST to (`/message?sessionId=<id>`).
+//! - The client POSTs JSON-RPC requests to that endpoint. The server answers
+//!   `202 Accepted` and delivers the JSON-RPC response back over the SSE stream
+//!   as a `message` event.
+//!
+//! ## Security
+//!
+//! - The listener binds `127.0.0.1` only, never `0.0.0.0`.
+//! - Every request must carry `Authorization: Bearer <token>`; the token is
+//!   generated once on first run and persisted.
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::fs;
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::{
+    extract::{Query, Request, State},
+    http::{header, StatusCode},
+    middleware::{self, Next},
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse, Response,
+    },
+    routing::{get, post},
+    Router,
+};
+use futures_util::{stream, Stream};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tauri::{AppHandle, Emitter, Listener, Manager, State as TauriState};
+use tokio::sync::{mpsc, oneshot, watch};
+
+const DEFAULT_PORT: u16 = 3742;
+const SERVER_NAME: &str = "psychic-broccoli";
+const PROTOCOL_VERSION: &str = "2024-11-05";
+const SETTINGS_FILE: &str = "mcp.json";
+
+/// Event the backend emits to ask the frontend for live app state.
+const EVENT_BRIDGE_REQUEST: &str = "mcp:request";
+/// Event the frontend emits back, carrying the result keyed by request id.
+const EVENT_BRIDGE_RESPONSE: &str = "mcp:response";
+/// How long a tool waits for the frontend to answer a bridge request.
+const BRIDGE_TIMEOUT_SECS: u64 = 5;
+
+/* ---------------------------------------------------------------- settings */
+
+/// Persisted MCP server configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct McpSettings {
+    /// Whether the server should run (and auto-start on launch).
+    pub enabled: bool,
+    /// TCP port the server listens on (loopback only).
+    pub port: u16,
+    /// Static bearer token, generated once on first run.
+    pub token: String,
+}
+
+impl Default for McpSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            port: DEFAULT_PORT,
+            token: String::new(),
+        }
+    }
+}
+
+fn generate_token() -> String {
+    uuid::Uuid::new_v4().simple().to_string()
+}
+
+fn settings_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|e| format!("Failed to resolve config dir: {}", e))?;
+    Ok(dir.join(SETTINGS_FILE))
+}
+
+fn read_settings(app: &AppHandle) -> McpSettings {
+    match settings_path(app).and_then(|p| fs::read_to_string(p).map_err(|e| e.to_string())) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => McpSettings::default(),
+    }
+}
+
+fn write_settings(app: &AppHandle, settings: &McpSettings) -> Result<(), String> {
+    let path = settings_path(app)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create config dir: {}", e))?;
+    }
+    let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
+    fs::write(&path, json).map_err(|e| format!("Failed to write MCP settings: {}", e))
+}
+
+/// Load settings, generating and persisting a token on first run.
+fn load_or_init_settings(app: &AppHandle) -> McpSettings {
+    let mut settings = read_settings(app);
+    if settings.token.is_empty() {
+        settings.token = generate_token();
+        let _ = write_settings(app, &settings);
+    }
+    settings
+}
+
+/* --------------------------------------------------------- server lifecycle */
+
+struct RunningServer {
+    shutdown_tx: watch::Sender<bool>,
+}
+
+/// Pending bridge requests, keyed by request id, awaiting a frontend reply.
+type PendingBridge = Arc<Mutex<HashMap<String, oneshot::Sender<BridgeResponse>>>>;
+
+/// Managed Tauri state tracking the running server, if any.
+#[derive(Default)]
+pub struct McpServerState {
+    inner: Mutex<Option<RunningServer>>,
+    /// Shared with the running server and the global `mcp:response` listener so
+    /// tool handlers can await frontend replies. Lives for the whole app run.
+    pending: PendingBridge,
+}
+
+impl McpServerState {
+    pub fn is_running(&self) -> bool {
+        self.inner.lock().map(|g| g.is_some()).unwrap_or(false)
+    }
+
+    fn set(&self, server: RunningServer) {
+        if let Ok(mut guard) = self.inner.lock() {
+            *guard = Some(server);
+        }
+    }
+
+    fn take(&self) -> Option<RunningServer> {
+        self.inner.lock().ok().and_then(|mut g| g.take())
+    }
+}
+
+/* ----------------------------------------------------------- HTTP/SSE state */
+
+struct OutEvent {
+    event: String,
+    data: String,
+}
+
+type SharedSessions = Arc<Mutex<HashMap<String, mpsc::Sender<OutEvent>>>>;
+
+#[derive(Clone)]
+struct McpState {
+    token: Arc<String>,
+    sessions: SharedSessions,
+    shutdown_rx: watch::Receiver<bool>,
+    server_version: Arc<String>,
+    /// Handle used to emit bridge requests to the frontend. `None` only in unit
+    /// tests that exercise transport/auth without driving tools.
+    app: Option<AppHandle>,
+    /// Bridge requests awaiting a frontend reply (shared with `McpServerState`).
+    pending: PendingBridge,
+}
+
+/// A reply from the frontend to a bridge request, routed back to the awaiting
+/// tool handler by `id`.
+#[derive(Debug, Deserialize)]
+struct BridgeResponse {
+    id: String,
+    ok: bool,
+    #[serde(default)]
+    data: Option<serde_json::Value>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// Removes a session from the registry when its SSE stream is dropped (client
+/// disconnect or server shutdown), preventing leaked senders.
+struct SessionGuard {
+    id: String,
+    sessions: SharedSessions,
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        if let Ok(mut map) = self.sessions.lock() {
+            map.remove(&self.id);
+        }
+    }
+}
+
+/* ------------------------------------------------------------------- server */
+
+fn start_server(
+    app: &AppHandle,
+    state: &McpServerState,
+    settings: &McpSettings,
+) -> Result<(), String> {
+    if state.is_running() {
+        return Ok(());
+    }
+
+    // Bind synchronously so a port conflict surfaces as an error the caller can
+    // report. Loopback-only: never exposed on the network.
+    let std_listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, settings.port))
+        .map_err(|e| format!("Failed to bind 127.0.0.1:{} - {}", settings.port, e))?;
+    std_listener
+        .set_nonblocking(true)
+        .map_err(|e| format!("Failed to configure listener: {}", e))?;
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let mcp_state = McpState {
+        token: Arc::new(settings.token.clone()),
+        sessions: Arc::new(Mutex::new(HashMap::new())),
+        shutdown_rx: shutdown_rx.clone(),
+        server_version: Arc::new(app.package_info().version.to_string()),
+        app: Some(app.clone()),
+        pending: state.pending.clone(),
+    };
+    let router = build_router(mcp_state);
+
+    let mut graceful_rx = shutdown_rx;
+    tauri::async_runtime::spawn(async move {
+        let listener = match tokio::net::TcpListener::from_std(std_listener) {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("MCP listener init failed: {}", e);
+                return;
+            }
+        };
+        let shutdown = async move {
+            while !*graceful_rx.borrow() {
+                if graceful_rx.changed().await.is_err() {
+                    break;
+                }
+            }
+        };
+        if let Err(e) = axum::serve(listener, router)
+            .with_graceful_shutdown(shutdown)
+            .await
+        {
+            eprintln!("MCP server error: {}", e);
+        }
+    });
+
+    state.set(RunningServer { shutdown_tx });
+    Ok(())
+}
+
+fn stop_server(state: &McpServerState) {
+    if let Some(running) = state.take() {
+        // Signals both the graceful-shutdown future and every open SSE stream
+        // to end, so connections drain and the port is released.
+        let _ = running.shutdown_tx.send(true);
+    }
+}
+
+fn build_router(state: McpState) -> Router {
+    Router::new()
+        .route("/sse", get(sse_handler))
+        .route("/message", post(message_handler))
+        .layer(middleware::from_fn_with_state(state.clone(), auth_middleware))
+        .with_state(state)
+}
+
+/// Constant-time comparison to avoid leaking the token via response timing.
+fn tokens_match(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+async fn auth_middleware(State(state): State<McpState>, req: Request, next: Next) -> Response {
+    let provided = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "));
+
+    match provided {
+        Some(token) if tokens_match(token, &state.token) => next.run(req).await,
+        _ => (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
+    }
+}
+
+async fn sse_handler(
+    State(state): State<McpState>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let session_id = uuid::Uuid::new_v4().simple().to_string();
+    let (tx, rx) = mpsc::channel::<OutEvent>(64);
+
+    // The first SSE event tells the client where to POST its JSON-RPC messages.
+    let endpoint = format!("/message?sessionId={}", session_id);
+    let _ = tx
+        .send(OutEvent {
+            event: "endpoint".to_string(),
+            data: endpoint,
+        })
+        .await;
+
+    if let Ok(mut map) = state.sessions.lock() {
+        map.insert(session_id.clone(), tx);
+    }
+
+    let guard = SessionGuard {
+        id: session_id,
+        sessions: state.sessions.clone(),
+    };
+    let shutdown_rx = state.shutdown_rx.clone();
+
+    let body = stream::unfold(
+        (rx, guard, shutdown_rx),
+        |(mut rx, guard, mut shutdown_rx)| async move {
+            if *shutdown_rx.borrow() {
+                return None;
+            }
+            tokio::select! {
+                maybe = rx.recv() => match maybe {
+                    Some(ev) => {
+                        let event = Event::default().event(ev.event).data(ev.data);
+                        Some((Ok(event), (rx, guard, shutdown_rx)))
+                    }
+                    None => None,
+                },
+                _ = shutdown_rx.changed() => None,
+            }
+        },
+    );
+
+    Sse::new(body).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
+}
+
+#[derive(Deserialize)]
+struct MessageQuery {
+    #[serde(rename = "sessionId")]
+    session_id: String,
+}
+
+async fn message_handler(
+    State(state): State<McpState>,
+    Query(query): Query<MessageQuery>,
+    body: String,
+) -> Response {
+    let parsed: serde_json::Value = match serde_json::from_str(&body) {
+        Ok(value) => value,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid JSON").into_response(),
+    };
+
+    let sender = match state.sessions.lock() {
+        Ok(map) => map.get(&query.session_id).cloned(),
+        Err(_) => None,
+    };
+    let sender = match sender {
+        Some(s) => s,
+        None => return (StatusCode::NOT_FOUND, "Session not found").into_response(),
+    };
+
+    let messages = match parsed {
+        serde_json::Value::Array(arr) => arr,
+        other => vec![other],
+    };
+
+    for msg in &messages {
+        // Tool calls need live frontend state and run async via the bridge;
+        // every other method is handled synchronously.
+        let response = match msg.get("method").and_then(|m| m.as_str()) {
+            Some("tools/call") => handle_tool_call(msg, &state).await,
+            _ => handle_rpc_message(msg, SERVER_NAME, &state.server_version),
+        };
+        if let Some(response) = response {
+            let data = serde_json::to_string(&response).unwrap_or_default();
+            let _ = sender
+                .send(OutEvent {
+                    event: "message".to_string(),
+                    data,
+                })
+                .await;
+        }
+    }
+
+    StatusCode::ACCEPTED.into_response()
+}
+
+/// Dispatch a single JSON-RPC message. Returns `Some(response)` for requests
+/// and `None` for notifications (which get no reply).
+fn handle_rpc_message(
+    msg: &serde_json::Value,
+    name: &str,
+    version: &str,
+) -> Option<serde_json::Value> {
+    let method = msg.get("method")?.as_str()?;
+    let has_id = msg.get("id").map(|v| !v.is_null()).unwrap_or(false);
+
+    // Notifications carry no id and expect no response.
+    if !has_id {
+        return None;
+    }
+    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+
+    let result: Result<serde_json::Value, (i64, String)> = match method {
+        "initialize" => {
+            let proto = msg
+                .get("params")
+                .and_then(|p| p.get("protocolVersion"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(PROTOCOL_VERSION)
+                .to_string();
+            Ok(json!({
+                "protocolVersion": proto,
+                "capabilities": { "tools": { "listChanged": false } },
+                "serverInfo": { "name": name, "version": version }
+            }))
+        }
+        "ping" => Ok(json!({})),
+        "tools/list" => Ok(json!({ "tools": tool_schemas() })),
+        other => Err((-32601, format!("Method not found: {}", other))),
+    };
+
+    Some(match result {
+        Ok(value) => json!({ "jsonrpc": "2.0", "id": id, "result": value }),
+        Err((code, message)) => {
+            json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+        }
+    })
+}
+
+/* ------------------------------------------------------- frontend bridge */
+
+/// Ask the frontend for live app state and await its reply.
+///
+/// The MCP server runs in the Rust backend, but the app's live state (the open
+/// workspace, responses, etc.) lives in Svelte stores on the frontend. This is
+/// the bridge every tool uses to reach across that boundary:
+///
+/// 1. We mint a request `id`, register a oneshot sender under it, then emit an
+///    `mcp:request` Tauri event carrying `{ id, kind, params }`.
+/// 2. The frontend listens for `mcp:request`, does the work for `kind`, and
+///    emits `mcp:response` carrying `{ id, ok, data?, error? }`.
+/// 3. A single global listener (registered in [`init`]) matches the reply to the
+///    pending `id` and fires the oneshot, which we await here with a timeout.
+///
+/// Returns the `data` payload on success, or an error string (frontend-reported
+/// error, timeout, or transport failure) that the caller surfaces as a tool
+/// error. Subsequent tools should follow this same `kind`-dispatched pattern.
+async fn bridge_request(
+    app: &AppHandle,
+    pending: &PendingBridge,
+    kind: &str,
+    params: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let id = uuid::Uuid::new_v4().simple().to_string();
+    let (tx, rx) = oneshot::channel::<BridgeResponse>();
+
+    match pending.lock() {
+        Ok(mut map) => {
+            map.insert(id.clone(), tx);
+        }
+        Err(_) => return Err("MCP bridge state is poisoned".to_string()),
+    }
+
+    let payload = json!({ "id": id, "kind": kind, "params": params });
+    if let Err(e) = app.emit(EVENT_BRIDGE_REQUEST, payload) {
+        if let Ok(mut map) = pending.lock() {
+            map.remove(&id);
+        }
+        return Err(format!("Failed to emit bridge request: {}", e));
+    }
+
+    match tokio::time::timeout(Duration::from_secs(BRIDGE_TIMEOUT_SECS), rx).await {
+        Ok(Ok(resp)) if resp.ok => Ok(resp.data.unwrap_or(serde_json::Value::Null)),
+        Ok(Ok(resp)) => Err(resp
+            .error
+            .unwrap_or_else(|| "Frontend reported an error".to_string())),
+        Ok(Err(_)) => Err("Bridge response channel closed".to_string()),
+        Err(_) => {
+            // Timed out: drop the pending entry so a late reply is ignored.
+            if let Ok(mut map) = pending.lock() {
+                map.remove(&id);
+            }
+            Err(format!(
+                "Frontend did not respond within {}s",
+                BRIDGE_TIMEOUT_SECS
+            ))
+        }
+    }
+}
+
+/* --------------------------------------------------------------- MCP tools */
+
+/// JSON schemas advertised by `tools/list`.
+fn tool_schemas() -> serde_json::Value {
+    json!([
+        {
+            "name": "list_requests",
+            "description": "List every HTTP request across all .http files in the currently open workspace. Returns an empty array when no workspace folder is open.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "execute_request",
+            "description": "Execute a single HTTP request from the open workspace and return its response, including the outcome of any pb assertions. Variables are resolved using the given environment, falling back to the active environment when omitted. Runs silently: the app's response pane and tabs are left unchanged.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "filePath": {
+                        "type": "string",
+                        "description": "Workspace-relative path to the .http file, as returned by list_requests."
+                    },
+                    "requestIndex": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Zero-based index of the request within the file, as returned by list_requests."
+                    },
+                    "environment": {
+                        "type": "string",
+                        "description": "Optional environment name used to resolve variables. Defaults to the active environment."
+                    }
+                },
+                "required": ["filePath", "requestIndex"],
+                "additionalProperties": false
+            }
+        }
+    ])
+}
+
+/// Dispatch a `tools/call` request to the matching tool handler.
+async fn handle_tool_call(msg: &serde_json::Value, state: &McpState) -> Option<serde_json::Value> {
+    if !msg.get("id").map(|v| !v.is_null()).unwrap_or(false) {
+        return None;
+    }
+    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+
+    let params = msg.get("params");
+    let tool_name = params.and_then(|p| p.get("name")).and_then(|v| v.as_str());
+    let arguments = params
+        .and_then(|p| p.get("arguments"))
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    let outcome = match tool_name {
+        Some("list_requests") => tool_list_requests(state, arguments).await,
+        Some("execute_request") => tool_execute_request(state, arguments).await,
+        Some(other) => Err(format!("Unknown tool: {}", other)),
+        None => Err("Missing tool name".to_string()),
+    };
+
+    Some(match outcome {
+        Ok(value) => tool_result_ok(&id, &value),
+        Err(message) => tool_result_error(&id, &message),
+    })
+}
+
+/// Wrap a successful tool value as an MCP `tools/call` result with JSON text content.
+fn tool_result_ok(id: &serde_json::Value, value: &serde_json::Value) -> serde_json::Value {
+    let text = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": { "content": [{ "type": "text", "text": text }], "isError": false }
+    })
+}
+
+/// Wrap a tool failure as an MCP `tools/call` result with `isError: true`.
+fn tool_result_error(id: &serde_json::Value, message: &str) -> serde_json::Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": { "content": [{ "type": "text", "text": message }], "isError": true }
+    })
+}
+
+/// `list_requests`: returns every request in the open workspace via the bridge.
+async fn tool_list_requests(
+    state: &McpState,
+    _arguments: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let app = state
+        .app
+        .as_ref()
+        .ok_or_else(|| "MCP bridge unavailable".to_string())?;
+    bridge_request(app, &state.pending, "list_requests", json!({})).await
+}
+
+/// `execute_request`: fire one request silently and return its response.
+///
+/// Argument shape is validated here; locating the request, resolving variables,
+/// sending it, and running pb assertions all happen on the frontend (which owns
+/// the live workspace state) and come back through the bridge. The frontend
+/// reports a missing file/index or a network failure as a bridge error, which
+/// surfaces here as a tool error.
+async fn tool_execute_request(
+    state: &McpState,
+    arguments: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let file_path = arguments
+        .get("filePath")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "execute_request requires a string 'filePath'".to_string())?;
+    let request_index = arguments
+        .get("requestIndex")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| "execute_request requires a non-negative integer 'requestIndex'".to_string())?;
+    // `environment` is optional; reject a non-string if present rather than silently ignoring it.
+    let environment = match arguments.get("environment") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(s)) => Some(s.clone()),
+        Some(_) => return Err("'environment' must be a string when provided".to_string()),
+    };
+
+    let app = state
+        .app
+        .as_ref()
+        .ok_or_else(|| "MCP bridge unavailable".to_string())?;
+
+    let params = json!({
+        "filePath": file_path,
+        "requestIndex": request_index,
+        "environment": environment,
+    });
+    bridge_request(app, &state.pending, "execute_request", params).await
+}
+
+/* ------------------------------------------------------------- Tauri glue */
+
+/// Initialise the MCP subsystem on app launch: ensure a token exists and
+/// auto-start the server if it was enabled. Call from the Tauri `setup` hook.
+pub fn init(app: &AppHandle) {
+    let settings = load_or_init_settings(app);
+    let state = app.state::<McpServerState>();
+
+    // One global listener routes every `mcp:response` back to the tool handler
+    // that is awaiting it (matched by request id). Registered once, for the app
+    // lifetime, so it works whether the server is running now or started later.
+    let pending = state.pending.clone();
+    app.listen(EVENT_BRIDGE_RESPONSE, move |event| {
+        if let Ok(resp) = serde_json::from_str::<BridgeResponse>(event.payload()) {
+            if let Ok(mut map) = pending.lock() {
+                if let Some(tx) = map.remove(&resp.id) {
+                    let _ = tx.send(resp);
+                }
+            }
+        }
+    });
+
+    if settings.enabled {
+        if let Err(e) = start_server(app, &state, &settings) {
+            eprintln!("Failed to auto-start MCP server: {}", e);
+        }
+    }
+}
+
+#[tauri::command]
+pub fn mcp_get_settings(app: AppHandle) -> Result<McpSettings, String> {
+    Ok(load_or_init_settings(&app))
+}
+
+#[tauri::command]
+pub fn mcp_is_running(state: TauriState<'_, McpServerState>) -> bool {
+    state.is_running()
+}
+
+#[tauri::command]
+pub fn mcp_set_enabled(
+    app: AppHandle,
+    state: TauriState<'_, McpServerState>,
+    enabled: bool,
+) -> Result<(), String> {
+    let mut settings = load_or_init_settings(&app);
+    if enabled {
+        match start_server(&app, &state, &settings) {
+            Ok(()) => {
+                settings.enabled = true;
+                write_settings(&app, &settings)
+            }
+            Err(e) => {
+                // Persist disabled so a failing config does not auto-start next launch.
+                if settings.enabled {
+                    settings.enabled = false;
+                    let _ = write_settings(&app, &settings);
+                }
+                Err(e)
+            }
+        }
+    } else {
+        stop_server(&state);
+        settings.enabled = false;
+        write_settings(&app, &settings)
+    }
+}
+
+#[tauri::command]
+pub fn mcp_set_port(
+    app: AppHandle,
+    state: TauriState<'_, McpServerState>,
+    port: u16,
+) -> Result<(), String> {
+    if state.is_running() {
+        return Err("Stop the server before changing the port".to_string());
+    }
+    if port == 0 {
+        return Err("Port must be between 1 and 65535".to_string());
+    }
+    let mut settings = load_or_init_settings(&app);
+    settings.port = port;
+    write_settings(&app, &settings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokens_match_compares_correctly() {
+        assert!(tokens_match("abc123", "abc123"));
+        assert!(!tokens_match("abc123", "abc124"));
+        assert!(!tokens_match("abc", "abcd"));
+        assert!(!tokens_match("", "x"));
+    }
+
+    #[test]
+    fn generate_token_is_nonempty_and_unique() {
+        let a = generate_token();
+        let b = generate_token();
+        assert!(!a.is_empty());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn initialize_returns_server_info_and_capabilities() {
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": { "protocolVersion": "2024-11-05" }
+        });
+        let resp = handle_rpc_message(&msg, SERVER_NAME, "0.4.2").unwrap();
+        assert_eq!(resp["id"], json!(1));
+        assert_eq!(resp["result"]["serverInfo"]["name"], json!(SERVER_NAME));
+        assert_eq!(resp["result"]["serverInfo"]["version"], json!("0.4.2"));
+        assert_eq!(resp["result"]["protocolVersion"], json!("2024-11-05"));
+        assert!(resp["result"]["capabilities"]["tools"].is_object());
+    }
+
+    #[test]
+    fn initialize_defaults_protocol_version_when_absent() {
+        let msg = json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize" });
+        let resp = handle_rpc_message(&msg, SERVER_NAME, "0.4.2").unwrap();
+        assert_eq!(resp["result"]["protocolVersion"], json!(PROTOCOL_VERSION));
+    }
+
+    #[test]
+    fn tools_list_advertises_list_requests() {
+        let msg = json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" });
+        let resp = handle_rpc_message(&msg, SERVER_NAME, "v").unwrap();
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        assert!(tools
+            .iter()
+            .any(|t| t["name"] == json!("list_requests")));
+        let lr = tools
+            .iter()
+            .find(|t| t["name"] == json!("list_requests"))
+            .unwrap();
+        assert_eq!(lr["inputSchema"]["type"], json!("object"));
+    }
+
+    #[test]
+    fn tools_list_advertises_execute_request() {
+        let msg = json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" });
+        let resp = handle_rpc_message(&msg, SERVER_NAME, "v").unwrap();
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        let er = tools
+            .iter()
+            .find(|t| t["name"] == json!("execute_request"))
+            .expect("execute_request tool advertised");
+        let schema = &er["inputSchema"];
+        assert_eq!(schema["type"], json!("object"));
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("filePath")));
+        assert!(required.contains(&json!("requestIndex")));
+    }
+
+    #[tokio::test]
+    async fn execute_request_rejects_missing_arguments() {
+        let (state, _tx) = test_state("t");
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "tools/call",
+            "params": { "name": "execute_request", "arguments": { "requestIndex": 0 } }
+        });
+        let resp = handle_tool_call(&msg, &state).await.unwrap();
+        assert_eq!(resp["result"]["isError"], json!(true));
+        assert!(resp["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("filePath"));
+    }
+
+    #[test]
+    fn tool_result_helpers_set_is_error_flag() {
+        let ok = tool_result_ok(&json!(1), &json!([{ "url": "/x" }]));
+        assert_eq!(ok["result"]["isError"], json!(false));
+        assert!(ok["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("/x"));
+
+        let err = tool_result_error(&json!(2), "boom");
+        assert_eq!(err["result"]["isError"], json!(true));
+        assert_eq!(err["result"]["content"][0]["text"], json!("boom"));
+    }
+
+    #[test]
+    fn ping_returns_empty_result() {
+        let msg = json!({ "jsonrpc": "2.0", "id": 3, "method": "ping" });
+        let resp = handle_rpc_message(&msg, SERVER_NAME, "v").unwrap();
+        assert!(resp["result"].is_object());
+        assert!(resp.get("error").is_none());
+    }
+
+    #[test]
+    fn notification_yields_no_response() {
+        let msg = json!({ "jsonrpc": "2.0", "method": "notifications/initialized" });
+        assert!(handle_rpc_message(&msg, SERVER_NAME, "v").is_none());
+    }
+
+    #[test]
+    fn unknown_method_returns_method_not_found() {
+        let msg = json!({ "jsonrpc": "2.0", "id": 9, "method": "resources/list", "params": {} });
+        let resp = handle_rpc_message(&msg, SERVER_NAME, "v").unwrap();
+        assert_eq!(resp["error"]["code"], json!(-32601));
+    }
+
+    #[tokio::test]
+    async fn tool_call_unknown_tool_returns_tool_error() {
+        let (state, _tx) = test_state("t");
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": { "name": "does_not_exist", "arguments": {} }
+        });
+        let resp = handle_tool_call(&msg, &state).await.unwrap();
+        assert_eq!(resp["id"], json!(7));
+        assert_eq!(resp["result"]["isError"], json!(true));
+        assert!(resp["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("does_not_exist"));
+    }
+
+    #[tokio::test]
+    async fn tool_call_times_out_without_frontend() {
+        // No frontend is listening and `app` is None, so the bridge cannot run.
+        let (state, _tx) = test_state("t");
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": { "name": "list_requests", "arguments": {} }
+        });
+        let resp = handle_tool_call(&msg, &state).await.unwrap();
+        assert_eq!(resp["result"]["isError"], json!(true));
+    }
+
+    #[test]
+    fn default_settings_use_default_port_and_disabled() {
+        let settings = McpSettings::default();
+        assert!(!settings.enabled);
+        assert_eq!(settings.port, DEFAULT_PORT);
+        assert!(settings.token.is_empty());
+    }
+
+    fn test_state(token: &str) -> (McpState, watch::Sender<bool>) {
+        let (tx, rx) = watch::channel(false);
+        let state = McpState {
+            token: Arc::new(token.to_string()),
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+            shutdown_rx: rx,
+            server_version: Arc::new("test".to_string()),
+            app: None,
+            pending: Arc::new(Mutex::new(HashMap::new())),
+        };
+        (state, tx)
+    }
+
+    /// Spins up the real axum router on an ephemeral loopback port and drives it
+    /// with an HTTP client to verify auth and the MCP handshake end-to-end.
+    #[tokio::test]
+    async fn server_enforces_auth_and_completes_initialize_handshake() {
+        use futures_util::StreamExt;
+
+        let token = "test-secret-token";
+        let (state, _shutdown_tx) = test_state(token);
+        let router = build_router(state);
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, router).await;
+        });
+
+        let client = reqwest::Client::new();
+        let sse_url = format!("http://{}/sse", addr);
+
+        // No token -> 401.
+        let resp = client.get(&sse_url).send().await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Wrong token -> 401.
+        let resp = client.get(&sse_url).bearer_auth("wrong").send().await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Correct token -> 200 SSE stream, first event names the POST endpoint.
+        let resp = client.get(&sse_url).bearer_auth(token).send().await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let mut body = resp.bytes_stream();
+
+        let mut buf = Vec::new();
+        while let Some(chunk) = body.next().await {
+            buf.extend_from_slice(&chunk.unwrap());
+            let text = String::from_utf8_lossy(&buf);
+            if text.contains("event: endpoint") && text.contains("sessionId=") {
+                break;
+            }
+            assert!(buf.len() < 8192, "endpoint event never arrived");
+        }
+        let text = String::from_utf8_lossy(&buf).to_string();
+        assert!(text.contains("event: endpoint"), "got: {}", text);
+        let session: String = text
+            .split("sessionId=")
+            .nth(1)
+            .unwrap()
+            .chars()
+            .take_while(|c| !c.is_whitespace())
+            .collect();
+        assert!(!session.is_empty());
+
+        // POST initialize to the session endpoint -> 202, response over SSE.
+        let post_url = format!("http://{}/message?sessionId={}", addr, session);
+        let init = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": { "protocolVersion": "2024-11-05" }
+        });
+        let resp = client
+            .post(&post_url)
+            .bearer_auth(token)
+            .json(&init)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+        buf.clear();
+        while let Some(chunk) = body.next().await {
+            buf.extend_from_slice(&chunk.unwrap());
+            let text = String::from_utf8_lossy(&buf);
+            if text.contains("serverInfo") {
+                break;
+            }
+            assert!(buf.len() < 8192, "initialize response never arrived");
+        }
+        let text = String::from_utf8_lossy(&buf);
+        assert!(text.contains("event: message"), "got: {}", text);
+        assert!(text.contains(SERVER_NAME), "got: {}", text);
+        assert!(text.contains("\"protocolVersion\""), "got: {}", text);
+
+        // An unauthenticated POST is also rejected.
+        let resp = client.post(&post_url).json(&init).send().await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -518,7 +518,7 @@ fn tool_schemas() -> serde_json::Value {
     json!([
         {
             "name": "list_requests",
-            "description": "List every HTTP request across all .http files in the currently open workspace. Returns an empty array when no workspace folder is open.",
+            "description": "Lists every HTTP request available in the open workspace by scanning all .http files. Use this tool when the user asks to see available requests, list requests, show what HTTP calls exist, or explore the workspace. Call this first to obtain valid filePath and requestIndex values before calling execute_request. Do not use this to run a request; use execute_request instead. Returns an empty array when no workspace folder is open in the app.",
             "inputSchema": {
                 "type": "object",
                 "properties": {},
@@ -527,22 +527,22 @@ fn tool_schemas() -> serde_json::Value {
         },
         {
             "name": "execute_request",
-            "description": "Execute a single HTTP request from the open workspace and return its response, including the outcome of any pb assertions. Variables are resolved using the given environment, falling back to the active environment when omitted. Runs silently: the app's response pane and tabs are left unchanged.",
+            "description": "Executes a single HTTP request from the open workspace and returns its full response: status code, headers, body, timing, and the outcome of any pb assertions. Use this tool when the user asks to run, execute, send, or test a specific request. Call list_requests first to get a valid filePath and requestIndex if you do not already have them. Do not use this to run a sequence of requests; use execute_flow instead. Variables are resolved using the given environment; if omitted, the active environment is used. Runs silently: the app UI is not updated.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "filePath": {
                         "type": "string",
-                        "description": "Workspace-relative path to the .http file, as returned by list_requests."
+                        "description": "Workspace-relative path to the .http file. Use the filePath value returned by list_requests."
                     },
                     "requestIndex": {
                         "type": "integer",
                         "minimum": 0,
-                        "description": "Zero-based index of the request within the file, as returned by list_requests."
+                        "description": "Zero-based index of the request within the file. Use the requestIndex value returned by list_requests."
                     },
                     "environment": {
                         "type": "string",
-                        "description": "Optional environment name used to resolve variables. Defaults to the active environment."
+                        "description": "Environment name used to resolve variables (e.g. 'Development', 'Production'). Omit to use the active environment."
                     }
                 },
                 "required": ["filePath", "requestIndex"],
@@ -551,7 +551,7 @@ fn tool_schemas() -> serde_json::Value {
         },
         {
             "name": "execute_flow",
-            "description": "Run an entire .pb-flow.json flow from the open workspace and return its run record: an overall status, a passed/failed/skipped summary, and per-step results including the outcome of any pb assertions. Steps run in order with variable chaining between them, and each step's continueOnFailure flag is respected. Variables are resolved using the given environment, falling back to the active environment when omitted. Runs silently: the app's flow panel and run history are left unchanged.",
+            "description": "Runs an entire flow from the open workspace and returns its full run record: overall status, a passed/failed/skipped step summary, and per-step results including pb assertion outcomes. Use this tool when the user asks to run, execute, or trigger a flow or an ordered sequence of requests. Do not use this for a single request; use execute_request instead. Steps run in order with variable chaining and each step's continueOnFailure flag is respected. Variables are resolved using the given environment; if omitted, the active environment is used. Runs silently: the app's flow panel and run history are not updated.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -561,7 +561,7 @@ fn tool_schemas() -> serde_json::Value {
                     },
                     "environment": {
                         "type": "string",
-                        "description": "Optional environment name used to resolve variables. Defaults to the active environment."
+                        "description": "Environment name used to resolve variables (e.g. 'Development', 'Production'). Omit to use the active environment."
                     }
                 },
                 "required": ["flowFilePath"],
@@ -570,7 +570,7 @@ fn tool_schemas() -> serde_json::Value {
         },
         {
             "name": "get_last_result",
-            "description": "Read the response from the user's most recent manually-triggered request, without executing anything. Returns the same shape as execute_request (status, headers, body, timing, and the outcome of any pb assertions), or null if no request has been run yet in the current session. Reflects the state at call time: a later manual request changes what a subsequent call returns.",
+            "description": "Returns the response from the user's most recent manually triggered request, without executing anything. Use this tool when the user asks about the last result, what the previous response was, or wants to inspect the most recent request outcome without re-running it. Do not use this when the user wants to run a request; use execute_request instead. Returns the same shape as execute_request (status, headers, body, timing, and pb assertion outcomes), or null if no request has been run yet in the current session. Reflects the state at call time: a later manual request changes what a subsequent call returns.",
             "inputSchema": {
                 "type": "object",
                 "properties": {},

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -495,6 +495,24 @@
     return { status: overall, summary: record.summary, steps };
   }
 
+  /**
+   * Snapshot the user's most recent manual request result for the MCP
+   * `get_last_result` tool. Reads the live UI stores without mutating them and
+   * returns the `execute_request` shape, or `null` if no request has run yet.
+   */
+  function snapshotLastResult() {
+    const response = get(currentResponse);
+    if (!response) return null;
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+      body: response.body,
+      time: response.time,
+      assertions: get(pbAssertionResults).map((a) => ({ label: a.label, passed: a.passed })),
+    };
+  }
+
   async function handleBridgeRequest(req: BridgeRequest) {
     try {
       switch (req.kind) {
@@ -506,6 +524,9 @@
           break;
         case 'execute_flow':
           respondBridge(req.id, { ok: true, data: await executeFlowSilently(req.params as ExecuteFlowParams) });
+          break;
+        case 'get_last_result':
+          respondBridge(req.id, { ok: true, data: snapshotLastResult() });
           break;
         default:
           respondBridge(req.id, { ok: false, error: `Unknown MCP bridge request: ${req.kind}` });

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -33,7 +33,7 @@
   import {
     serializeHttpFile, substituteAll, parseEnvironmentFile, ensureSharedEnvironment,
     buildWorkspaceTree, createFileNode, createEmptyFileNode, getAllFileNodes,
-    executePbDirectives, parseScriptText, applyRequestMutations,
+    executePbDirectives, parseScriptText, applyRequestMutations, resolveEnvironmentVariables,
   } from './lib/parser';
   import type { SubstitutionContext } from './lib/parser';
   import { importPostmanCollection } from './lib/postman';
@@ -49,8 +49,10 @@
   import { open } from '@tauri-apps/plugin-dialog';
   import { readTextFile, writeTextFile, readDir, rename } from '@tauri-apps/plugin-fs';
   import { invoke } from '@tauri-apps/api/core';
+  import { listen, emit } from '@tauri-apps/api/event';
   import { join, basename, dirname } from '@tauri-apps/api/path';
   import { onDestroy } from 'svelte';
+  import { get } from 'svelte/store';
 
   let showEnvEditor = false;
   let showVarInspector = false;
@@ -229,8 +231,196 @@
     refreshKeyVaultSecrets();
   });
 
+  // ─── MCP Bridge ───
+  // The embedded MCP server (Rust) reaches live app state through Tauri events:
+  // it emits `mcp:request` with { id, kind, params }; we do the work for `kind`
+  // and emit `mcp:response` with { id, ok, data?, error? }, matched by `id`.
+  // New MCP tools that need frontend state add a `kind` branch here.
+
+  interface BridgeRequest {
+    id: string;
+    kind: string;
+    params: unknown;
+  }
+
+  function respondBridge(id: string, payload: { ok: true; data: unknown } | { ok: false; error: string }) {
+    emit('mcp:response', { id, ...payload }).catch(() => {});
+  }
+
+  /** Gather every request across all .http files in the open workspace. */
+  function collectWorkspaceRequests() {
+    const ws = get(workspace);
+    if (!ws.rootPath) return [];
+    return getAllFileNodes(ws.tree).flatMap((file) => {
+      const filePath = file.path.substring(ws.rootPath!.length + 1).replaceAll('\\', '/');
+      return file.requests.map((req, requestIndex) => ({
+        filePath,
+        requestIndex,
+        name: req.name,
+        method: req.method,
+        url: req.url,
+      }));
+    });
+  }
+
+  interface ExecuteRequestParams {
+    filePath: string;
+    requestIndex: number;
+    environment?: string | null;
+  }
+
+  /**
+   * Run a single request for the MCP `execute_request` tool and return the
+   * structured result. This is the silent twin of `sendRequest`: it must never
+   * touch UI stores (`currentResponse`, `currentSentRequest`, `pbAssertionResults`,
+   * tabs, `namedResults`, `pbGlobals`, `pbFileOverrides`). All runtime state from
+   * pb directives is kept in locals and discarded after the call.
+   */
+  async function executeRequestSilently(params: ExecuteRequestParams) {
+    const ws = get(workspace);
+    if (!ws.rootPath) throw new Error('No workspace folder is open');
+
+    const normalized = params.filePath.replaceAll('\\', '/');
+    const file = getAllFileNodes(ws.tree).find(
+      (f) => f.path.substring(ws.rootPath!.length + 1).replaceAll('\\', '/') === normalized,
+    );
+    if (!file) throw new Error(`File not found in workspace: ${params.filePath}`);
+
+    const request = file.requests[params.requestIndex];
+    if (!request) {
+      throw new Error(`No request at index ${params.requestIndex} in ${params.filePath}`);
+    }
+
+    // Resolve environment variables for the requested environment, falling back to
+    // the active one. For the active environment, reuse the fully-resolved store so
+    // Key Vault secrets, globals, and pb.set overrides are included exactly as the
+    // UI sees them; for any other environment, resolve it fresh from the env files.
+    const active = get(activeEnvironment);
+    const effectiveEnv = params.environment ?? active;
+    let environmentVariables: Record<string, string>;
+    if (effectiveEnv && effectiveEnv === active) {
+      environmentVariables = { ...get(resolvedEnvVars) };
+    } else if (effectiveEnv) {
+      environmentVariables = {
+        ...resolveEnvironmentVariables(effectiveEnv, get(envFile), get(userEnvFile)),
+        ...get(pbGlobals),
+        ...(get(pbFileOverrides)[file.path] ?? {}),
+      };
+    } else {
+      environmentVariables = { ...get(pbGlobals) };
+    }
+
+    const ctx: SubstitutionContext = {
+      fileVariables: file.variables,
+      environmentVariables,
+      // Read-only copy: chaining can resolve existing named results, but the
+      // silent run must not mutate the shared store.
+      namedResults: { ...get(namedResults) },
+      dotenvVariables: get(dotenvVariables),
+    };
+
+    const startTime = performance.now();
+    let url = substituteAll(request.url, ctx);
+    let body = substituteAll(request.body, ctx);
+    let headers: Record<string, string> = {};
+    for (const h of request.headers) {
+      if (h.enabled) headers[substituteAll(h.key, ctx)] = substituteAll(h.value, ctx);
+    }
+
+    // beforeSend scripts — runtime vars stay local and never reach the stores.
+    const localEnvOverrides: Record<string, string> = {};
+    const localGlobals: Record<string, string> = {};
+    const beforeSendDirectives = parseScriptText(request.beforeSend ?? '');
+    if (beforeSendDirectives.length > 0) {
+      const mergedVars: Record<string, string> = { ...ctx.environmentVariables };
+      for (const v of ctx.fileVariables) mergedVars[v.key] = v.value;
+      const dummyResponse: HttpResponse = { status: 0, statusText: '', headers: {}, body: '', time: 0, size: 0 };
+      const bsResult = executePbDirectives(
+        beforeSendDirectives, dummyResponse,
+        { url, method: request.method, headers, body },
+        mergedVars, ctx.namedResults,
+      );
+      const mutated = applyRequestMutations(
+        { url, method: request.method, headers, body },
+        bsResult.requestMutations,
+      );
+      url = mutated.url;
+      headers = mutated.headers;
+      body = mutated.body;
+      Object.assign(localEnvOverrides, bsResult.setVars);
+      Object.assign(localGlobals, bsResult.globalVars);
+      Object.assign(localEnvOverrides, bsResult.globalVars);
+    }
+
+    const sentRequest = { method: request.method, url, headers, body };
+    const res: { status: number; status_text: string; headers: Record<string, string>; body: string } =
+      await invoke('http_request', {
+        payload: {
+          method: request.method,
+          url,
+          headers,
+          body: ['GET', 'HEAD', 'OPTIONS'].includes(request.method) ? null : body || null,
+        },
+      });
+
+    const elapsed = performance.now() - startTime;
+    const response: HttpResponse = {
+      status: res.status,
+      statusText: res.status_text,
+      headers: res.headers,
+      body: res.body,
+      time: Math.round(elapsed),
+      size: new TextEncoder().encode(res.body).length,
+    };
+
+    // pb directives + afterReceive scripts — assertion results only; no store writes.
+    const afterReceiveDirectives = parseScriptText(request.afterReceive ?? '');
+    const allDirectives = [
+      ...(request.directives || []).filter((d) => d.enabled !== false),
+      ...afterReceiveDirectives,
+    ];
+    let assertionResults: PbAssertionResult[] = [];
+    if (allDirectives.length > 0) {
+      const mergedVars: Record<string, string> = { ...ctx.environmentVariables, ...localEnvOverrides, ...localGlobals };
+      for (const v of ctx.fileVariables) mergedVars[v.key] = v.value;
+      const pbResult = executePbDirectives(allDirectives, response, sentRequest, mergedVars, ctx.namedResults);
+      assertionResults = pbResult.assertionResults;
+    }
+
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+      body: response.body,
+      time: response.time,
+      assertions: assertionResults.map((a) => ({ label: a.label, passed: a.passed })),
+    };
+  }
+
+  async function handleBridgeRequest(req: BridgeRequest) {
+    try {
+      switch (req.kind) {
+        case 'list_requests':
+          respondBridge(req.id, { ok: true, data: collectWorkspaceRequests() });
+          break;
+        case 'execute_request':
+          respondBridge(req.id, { ok: true, data: await executeRequestSilently(req.params as ExecuteRequestParams) });
+          break;
+        default:
+          respondBridge(req.id, { ok: false, error: `Unknown MCP bridge request: ${req.kind}` });
+      }
+    } catch (e) {
+      respondBridge(req.id, { ok: false, error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  const mcpBridgeUnlisten = listen<BridgeRequest>('mcp:request', (event) => {
+    void handleBridgeRequest(event.payload);
+  });
+
   onDestroy(() => {
     unsubKv();
+    mcpBridgeUnlisten.then((unlisten) => unlisten());
     document.removeEventListener('mousemove', onDividerMove);
     document.removeEventListener('mouseup', onDividerUp);
     document.removeEventListener('mousemove', onSidebarDividerMove);
@@ -1150,8 +1340,8 @@
 <SettingsModal
   visible={showSettings}
   currentTheme={currentTheme}
-  on:changeTheme={(e) => { currentTheme = e.detail; setTheme(e.detail); }}
-  on:close={() => showSettings = false}
+  onchangeTheme={(id) => { currentTheme = id; setTheme(id); }}
+  onclose={() => showSettings = false}
 />
 <VariableInspector
   visible={showVarInspector}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,7 +42,7 @@
   import type { HttpRequest, HttpResponse, RequestLocation, EnvironmentFile, TreeNode, ImportResult, PbAssertionResult, KeyVaultState } from './lib/types';
   import type { BottomTab, ResponseTab } from './lib/stores';
   import type { DiscoveredFile } from './lib/parser';
-  import { scanForFlowFiles, loadFlowHistory, saveFlowRunRecord, clearFlowRunHistory, FLOWS_DIR } from './lib/flowIO';
+  import { scanForFlowFiles, loadFlowHistory, saveFlowRunRecord, clearFlowRunHistory, parseFlowFile, FLOWS_DIR } from './lib/flowIO';
   import { runFlow } from './lib/flowRunner';
   import type { FlowStepResult, FlowRunRecord } from './lib/types';
 
@@ -397,6 +397,104 @@
     };
   }
 
+  interface ExecuteFlowParams {
+    flowFilePath: string;
+    environment?: string | null;
+  }
+
+  /**
+   * Run a whole flow for the MCP `execute_flow` tool and return the structured
+   * run record. This is the silent twin of `handleRunFlow`: it loads and runs the
+   * flow but must never touch UI stores (`flowRunState`, `flowRunHistory`,
+   * `lastFlowRunRecords`, tabs) and must not persist a results file. `runFlow`
+   * keeps all run state in isolated locals, which are discarded after mapping.
+   */
+  async function executeFlowSilently(params: ExecuteFlowParams) {
+    const ws = get(workspace);
+    if (!ws.rootPath) throw new Error('No workspace folder is open');
+
+    const relPath = params.flowFilePath.replaceAll('\\', '/');
+    if (!relPath.endsWith('.pb-flow.json')) {
+      throw new Error(`Not a flow file (expected .pb-flow.json): ${params.flowFilePath}`);
+    }
+    const absolutePath = await join(ws.rootPath, relPath);
+
+    let content: string;
+    try {
+      content = await readTextFile(absolutePath);
+    } catch {
+      throw new Error(`Flow file not found: ${params.flowFilePath}`);
+    }
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(content);
+    } catch {
+      throw new Error(`Flow file is not valid JSON: ${params.flowFilePath}`);
+    }
+    if (typeof raw !== 'object' || raw === null || !Array.isArray((raw as { steps?: unknown }).steps)) {
+      throw new Error(`Not a valid flow file: ${params.flowFilePath}`);
+    }
+    const flow = parseFlowFile(content);
+
+    // Resolve environment variables for the requested environment, falling back to
+    // the active one. Mirror executeRequestSilently: reuse the resolved store for
+    // the active env (so Key Vault secrets, globals, and pb.set overrides are
+    // included as the UI sees them); resolve any other env fresh from the files.
+    const active = get(activeEnvironment);
+    const effectiveEnv = params.environment ?? active;
+    let environmentVariables: Record<string, string>;
+    if (effectiveEnv && effectiveEnv === active) {
+      environmentVariables = { ...get(resolvedEnvVars) };
+    } else if (effectiveEnv) {
+      environmentVariables = {
+        ...resolveEnvironmentVariables(effectiveEnv, get(envFile), get(userEnvFile)),
+        ...get(pbGlobals),
+      };
+    } else {
+      environmentVariables = { ...get(pbGlobals) };
+    }
+
+    // No-op callbacks: a silent run reports nothing to the UI. runFlow returns a
+    // fully isolated record; we never write it to stores or to disk.
+    const record = await runFlow(
+      flow,
+      ws.rootPath,
+      ws.tree,
+      environmentVariables,
+      get(dotenvVariables),
+      effectiveEnv,
+      { onStepStart() {}, onStepComplete() {} },
+    );
+
+    // Map the internal record onto the tool's output shape. The flow runner stores
+    // both network errors and assertion/HTTP failures as `failed`; split them back
+    // out so a network-level failure (non-null `error`) surfaces as `error`.
+    const stepById = new Map(flow.steps.map((s) => [s.id, s]));
+    const steps = record.stepResults.map((r) => {
+      const status: 'passed' | 'failed' | 'skipped' | 'error' =
+        r.status === 'failed' && r.error != null ? 'error'
+        : r.status === 'passed' ? 'passed'
+        : r.status === 'skipped' ? 'skipped'
+        : 'failed';
+      return {
+        id: r.stepId,
+        label: stepById.get(r.stepId)?.label ?? '',
+        status,
+        durationMs: r.durationMs,
+        assertions: r.assertionResults.map((a) => ({ label: a.label, passed: a.passed })),
+        error: r.error,
+      };
+    });
+
+    const overall: 'passed' | 'failed' | 'error' =
+      steps.some((s) => s.status === 'error') ? 'error'
+      : steps.some((s) => s.status === 'failed') ? 'failed'
+      : 'passed';
+
+    return { status: overall, summary: record.summary, steps };
+  }
+
   async function handleBridgeRequest(req: BridgeRequest) {
     try {
       switch (req.kind) {
@@ -405,6 +503,9 @@
           break;
         case 'execute_request':
           respondBridge(req.id, { ok: true, data: await executeRequestSilently(req.params as ExecuteRequestParams) });
+          break;
+        case 'execute_flow':
+          respondBridge(req.id, { ok: true, data: await executeFlowSilently(req.params as ExecuteFlowParams) });
           break;
         default:
           respondBridge(req.id, { ok: false, error: `Unknown MCP bridge request: ${req.kind}` });

--- a/src/components/SettingsModal.svelte
+++ b/src/components/SettingsModal.svelte
@@ -232,7 +232,11 @@
     padding: var(--space-4);
   }
   .section {
-    margin-bottom: var(--space-4);
+    margin-bottom: var(--space-3);
+    padding: var(--space-3);
+    background: var(--color-bg-subtle);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
   }
   .section:last-child {
     margin-bottom: 0;

--- a/src/components/SettingsModal.svelte
+++ b/src/components/SettingsModal.svelte
@@ -1,30 +1,118 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount } from 'svelte';
+  import { onMount } from 'svelte';
   import { getVersion } from '@tauri-apps/api/app';
+  import { invoke } from '@tauri-apps/api/core';
   import { THEMES, type ThemeId } from '../lib/theme';
 
-  export let visible = false;
-  export let currentTheme: ThemeId = 'default';
+  interface Props {
+    visible?: boolean;
+    currentTheme?: ThemeId;
+    onchangeTheme?: (id: ThemeId) => void;
+    onclose?: () => void;
+  }
 
-  const dispatch = createEventDispatcher();
+  let { visible = false, currentTheme = 'default', onchangeTheme, onclose }: Props = $props();
 
-  let appVersion = '';
+  interface McpSettings {
+    enabled: boolean;
+    port: number;
+    token: string;
+  }
+
+  let appVersion = $state('');
+
+  let mcpEnabled = $state(false);
+  let mcpPort = $state(3742);
+  let mcpToken = $state('');
+  let mcpRunning = $state(false);
+  let mcpBusy = $state(false);
+  let mcpError = $state('');
+  let copyLabel = $state('Copy MCP config');
+
   onMount(async () => {
     try { appVersion = await getVersion(); } catch {}
+    await loadMcp();
   });
 
+  async function loadMcp() {
+    try {
+      const settings = await invoke<McpSettings>('mcp_get_settings');
+      mcpEnabled = settings.enabled;
+      mcpPort = settings.port;
+      mcpToken = settings.token;
+      mcpRunning = await invoke<boolean>('mcp_is_running');
+    } catch (e) {
+      mcpError = String(e);
+    }
+  }
+
+  async function toggleMcp() {
+    if (mcpBusy) return;
+    mcpBusy = true;
+    mcpError = '';
+    const next = !mcpEnabled;
+    try {
+      await invoke('mcp_set_enabled', { enabled: next });
+      mcpEnabled = next;
+      mcpRunning = await invoke<boolean>('mcp_is_running');
+    } catch (e) {
+      mcpError = String(e);
+      await loadMcp();
+    } finally {
+      mcpBusy = false;
+    }
+  }
+
+  async function changePort(value: number) {
+    mcpError = '';
+    if (!Number.isInteger(value) || value < 1 || value > 65535) {
+      mcpError = 'Port must be between 1 and 65535';
+      return;
+    }
+    try {
+      await invoke('mcp_set_port', { port: value });
+      mcpPort = value;
+    } catch (e) {
+      mcpError = String(e);
+      await loadMcp();
+    }
+  }
+
+  async function copyConfig() {
+    const config = {
+      mcpServers: {
+        'psychic-broccoli': {
+          type: 'sse',
+          url: `http://localhost:${mcpPort}/sse`,
+          headers: { Authorization: `Bearer ${mcpToken}` },
+        },
+      },
+    };
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(config, null, 2));
+      copyLabel = 'Copied!';
+      setTimeout(() => { copyLabel = 'Copy MCP config'; }, 1500);
+    } catch {
+      mcpError = 'Could not copy to clipboard';
+    }
+  }
+
   function selectTheme(id: ThemeId) {
-    dispatch('changeTheme', id);
+    onchangeTheme?.(id);
   }
 </script>
 
 {#if visible}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="overlay" on:click|self={() => dispatch('close')} on:keydown={() => {}}>
+  <div
+    class="overlay"
+    onclick={(e) => { if (e.target === e.currentTarget) onclose?.(); }}
+    onkeydown={() => {}}
+  >
     <div class="modal">
       <div class="modal-header">
         <span class="modal-title">Settings</span>
-        <button class="btn-close" on:click={() => dispatch('close')}>&times;</button>
+        <button class="btn-close" onclick={() => onclose?.()}>&times;</button>
       </div>
       <div class="modal-body">
         <div class="section">
@@ -32,15 +120,59 @@
           <div class="theme-options">
             {#each THEMES as theme}
               <button
-                class="theme-option"
-                class:active={currentTheme === theme.id}
-                on:click={() => selectTheme(theme.id)}
+                class={{ 'theme-option': true, active: currentTheme === theme.id }}
+                onclick={() => selectTheme(theme.id)}
               >
                 <span class="theme-name">{theme.label}</span>
               </button>
             {/each}
           </div>
         </div>
+
+        <div class="section">
+          <span class="section-label">MCP Server</span>
+          <p class="section-desc">
+            Expose this workspace to MCP clients such as Claude Code over a
+            local-only endpoint (127.0.0.1).
+          </p>
+
+          <label class="mcp-row toggle-row" for="mcp-enabled">
+            <span class="field-label">Enable server</span>
+            <input
+              id="mcp-enabled"
+              type="checkbox"
+              checked={mcpEnabled}
+              disabled={mcpBusy}
+              onchange={toggleMcp}
+            />
+          </label>
+
+          <div class="mcp-row">
+            <label class="field-label" for="mcp-port">Port</label>
+            <input
+              id="mcp-port"
+              class="port-input"
+              type="number"
+              min="1"
+              max="65535"
+              value={mcpPort}
+              disabled={mcpRunning}
+              onchange={(e) => changePort(parseInt(e.currentTarget.value, 10))}
+            />
+            <span class={{ status: true, running: mcpRunning }}>
+              {mcpRunning ? 'Running' : 'Stopped'}
+            </span>
+          </div>
+
+          <button class="copy-btn" onclick={copyConfig} disabled={!mcpToken}>
+            {copyLabel}
+          </button>
+
+          {#if mcpError}
+            <p class="mcp-error">{mcpError}</p>
+          {/if}
+        </div>
+
         {#if appVersion}
           <div class="version-info">v{appVersion}</div>
         {/if}
@@ -99,6 +231,12 @@
   .modal-body {
     padding: var(--space-4);
   }
+  .section {
+    margin-bottom: var(--space-4);
+  }
+  .section:last-child {
+    margin-bottom: 0;
+  }
   .section-label {
     display: block;
     font-size: var(--text-sm);
@@ -107,6 +245,12 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
     margin-bottom: var(--space-2);
+  }
+  .section-desc {
+    margin: 0 0 var(--space-3);
+    font-size: var(--text-sm);
+    color: var(--color-text-faint);
+    line-height: 1.4;
   }
   .theme-options {
     display: flex;
@@ -135,6 +279,69 @@
     background: var(--color-primary-subtle);
     color: var(--color-primary);
     font-weight: var(--weight-semibold);
+  }
+  .mcp-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-2);
+  }
+  .toggle-row {
+    justify-content: space-between;
+    cursor: pointer;
+  }
+  .field-label {
+    font-size: var(--text-base);
+    color: var(--color-text);
+  }
+  .port-input {
+    width: 90px;
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-default);
+    background: var(--color-bg-surface);
+    color: var(--color-text);
+    font-family: inherit;
+    font-size: var(--text-base);
+  }
+  .port-input:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  .status {
+    font-size: var(--text-sm);
+    color: var(--color-text-faint);
+  }
+  .status.running {
+    color: var(--color-primary);
+    font-weight: var(--weight-semibold);
+  }
+  .copy-btn {
+    margin-top: var(--space-2);
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-default);
+    background: var(--color-bg-surface);
+    color: var(--color-text);
+    font-family: inherit;
+    font-size: var(--text-base);
+    font-weight: var(--weight-medium);
+    cursor: pointer;
+    transition: all var(--duration-normal);
+  }
+  .copy-btn:hover:not(:disabled) {
+    background: var(--color-bg-hover);
+    border-color: var(--color-text-faint);
+  }
+  .copy-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .mcp-error {
+    margin: var(--space-2) 0 0;
+    font-size: var(--text-sm);
+    color: var(--color-method-delete);
   }
   .version-info {
     margin-top: var(--space-4);


### PR DESCRIPTION
## Summary

Adds an embedded, localhost-only MCP server to the app so MCP clients (e.g. Claude Code) can drive the running workspace. Built as vertical slices: server/transport infrastructure plus four tools that read live frontend state over a Rust-to-Svelte event bridge.

- **Server + transport** (`src-tauri/src/mcp.rs`): loopback-only HTTP+SSE transport, bearer-token auth (generated once, persisted), settings persistence, auto-start, and the `mcp:request`/`mcp:response` event bridge with per-tool timeouts. Settings UI in `SettingsModal.svelte`.
- **`list_requests`**: every request across all `.http` files in the open workspace (empty array if none open).
- **`execute_request`**: fire one request silently and return its response + pb assertion results, without touching the response pane/tabs.
- **`execute_flow`**: run a whole `.pb-flow.json` silently and return the structured run record (summary + per-step results), without touching the flow panel/history.
- **`get_last_result`**: read the user's most recent manual request result (or `null`), reflecting state at call time, mutating no stores.

All `.http` parsing, variable resolution, and execution stay on the frontend; the bridge keeps the Rust side thin. Silent tools keep all runtime state in locals and never write UI stores.

Closes #125, #126, #127, #128, #129.

## Test plan

- [ ] `pnpm check` passes (frontend type-check, currently green)
- [ ] `cargo check --tests` compiles cleanly
- [ ] Rust unit tests pass in CI (Linux): transport/auth handshake, tool schemas advertised, argument validation, bridge dispatch/timeout
- [ ] Manual: enable the server in Settings, point an MCP client at it, and exercise each tool against an open workspace