### PR TITLE
feat(sidebar): allow creating folders from the tree sidebar

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -22,7 +22,7 @@
     pbAssertionResults, pbGlobals,
     keyVaultState, varSourcePrefs,
     updateRequestInTree, addRequestToFile, deleteRequestFromFile, removeFileFromTree,
-    addFileToTree, renameFileInTree, editingFilePath,
+    addFileToTree, addFolderToTree, renameFolderInTree, renameFileInTree, editingFilePath, editingFolderPath,
     toggleFolder, markFileSaved, addToast,
     tabs, isPreview, pinTab, activateTab, closeTab, previewRequest,
     cacheCurrentTabResponse, currentSentRequest, setTabBottomTab, setTabResponseTab,
@@ -43,6 +43,7 @@
   import type { BottomTab, ResponseTab } from './lib/stores';
   import type { DiscoveredFile } from './lib/parser';
   import { scanForFlowFiles, loadFlowHistory, saveFlowRunRecord, clearFlowRunHistory, parseFlowFile, FLOWS_DIR } from './lib/flowIO';
+  import { generateFolderName } from './lib/folderCreate';
   import { runFlow } from './lib/flowRunner';
   import type { FlowStepResult, FlowRunRecord } from './lib/types';
 
@@ -1137,6 +1138,66 @@
     editingFilePath.set(filePath);
   }
 
+  async function handleCreateFolder(e: CustomEvent<string | null>) {
+    const rootPath = $workspace.rootPath;
+    if (!rootPath) return;
+
+    const parentDir = e.detail || rootPath;
+
+    // Collect sibling names in the target parent
+    const siblings = new Set<string>();
+    function collectSiblings(nodes: TreeNode[], targetPath: string) {
+      for (const n of nodes) {
+        if (n.type === 'folder' && n.path === targetPath) {
+          for (const c of n.children) siblings.add(c.name);
+          return;
+        }
+        if (n.type === 'folder') collectSiblings(n.children, targetPath);
+      }
+    }
+    if (parentDir === rootPath) {
+      for (const n of $workspace.tree) siblings.add(n.name);
+    } else {
+      collectSiblings($workspace.tree, parentDir);
+    }
+
+    const folderName = generateFolderName(siblings);
+    const folderPath = await join(parentDir, folderName);
+
+    try {
+      const { mkdir } = await import('@tauri-apps/plugin-fs');
+      await mkdir(folderPath, { recursive: true });
+    } catch (err) {
+      addToast(`Failed to create folder: ${err instanceof Error ? err.message : err}`, 'error');
+      return;
+    }
+
+    addFolderToTree(parentDir === rootPath ? null : parentDir, {
+      type: 'folder',
+      name: folderName,
+      path: folderPath,
+      children: [],
+      expanded: true,
+    });
+    editingFolderPath.set(folderPath);
+  }
+
+  async function handleRenameFolder(e: CustomEvent<{ oldPath: string; newName: string }>) {
+    const { oldPath, newName } = e.detail;
+    const dir = await dirname(oldPath);
+    const newPath = await join(dir, newName);
+
+    try {
+      await rename(oldPath, newPath);
+    } catch (err) {
+      addToast(`Failed to rename folder: ${err instanceof Error ? err.message : err}`, 'error');
+      return;
+    }
+
+    renameFolderInTree(oldPath, newPath, newName);
+    editingFolderPath.set(null);
+  }
+
   async function handleRenameFile(e: CustomEvent<{ oldPath: string; newName: string }>) {
     const { oldPath, newName } = e.detail;
 
@@ -1220,6 +1281,7 @@
 
   function handleCancelRename() {
     editingFilePath.set(null);
+    editingFolderPath.set(null);
   }
 
   function handleToggleFolder(e: CustomEvent<string>) {
@@ -1515,6 +1577,7 @@
         rootName={$workspace.rootName}
         hasWorkspace={!!$workspace.rootPath}
         editingFilePath={$editingFilePath}
+        editingFolderPath={$editingFolderPath}
         environments={$availableEnvironments}
         activeEnv={$activeEnvironment}
         flows={$flows}
@@ -1529,7 +1592,9 @@
         on:deleteRequest={handleDeleteRequest}
         on:deleteFile={handleDeleteFile}
         on:createFile={handleCreateFile}
+        on:createFolder={handleCreateFolder}
         on:renameFile={handleRenameFile}
+        on:renameFolder={handleRenameFolder}
         on:duplicateFile={handleDuplicateFile}
         on:cancelRename={handleCancelRename}
         on:changeEnv={(e) => activeEnvironment.set(e.detail)}

--- a/src/components/TreeNode.svelte
+++ b/src/components/TreeNode.svelte
@@ -12,8 +12,12 @@
   export let forceExpand: boolean = false;
   /** When set and matches this node's path, auto-enter inline rename mode */
   export let editingFilePath: string | null = null;
+  /** When set and matches this folder's path, auto-enter inline folder rename mode */
+  export let editingFolderPath: string | null = null;
   /** Sibling file names in the same folder (for collision detection) */
   export let siblingNames: string[] = [];
+  /** Sibling folder/file names in the same folder (for folder rename collision detection) */
+  export let siblingFolderNames: string[] = [];
 
   const dispatch = createEventDispatcher();
 
@@ -63,9 +67,20 @@
   let showFolderMenu = false;
   let folderMenuPos = { x: 0, y: 0 };
 
+  // Inline folder rename state
+  let renamingFolder = false;
+  let renamingFolderValue = '';
+  let folderRenameInputEl: HTMLInputElement;
+  let cancelledFolderRename = false;
+
   // Auto-enter rename mode when editingFilePath matches this node
   $: if (node.type === 'file' && editingFilePath === node.path && !renamingFile) {
     enterFileRename();
+  }
+
+  // Auto-enter folder rename mode when editingFolderPath matches this folder
+  $: if (node.type === 'folder' && editingFolderPath === node.path && !renamingFolder) {
+    enterFolderRename();
   }
 
   function enterFileRename() {
@@ -108,6 +123,45 @@
     cancelledRename = true;
     renamingFile = false;
     renamingValue = '';
+    dispatch('cancelRename');
+  }
+
+  function enterFolderRename() {
+    cancelledFolderRename = false;
+    renamingFolder = true;
+    renamingFolderValue = node.type === 'folder' ? node.name : '';
+    tick().then(() => {
+      folderRenameInputEl?.focus();
+      folderRenameInputEl?.select();
+    });
+  }
+
+  $: folderRenameError = (() => {
+    if (!renamingFolder) return '';
+    const v = renamingFolderValue.trim();
+    if (!v) return 'Name required';
+    if (INVALID_FS_CHARS.test(v)) return 'Invalid character';
+    if (node.type === 'folder' && v !== node.name && siblingFolderNames.includes(v)) return 'Name in use';
+    return '';
+  })();
+
+  function confirmFolderRename() {
+    if (!renamingFolder) return;
+    if (cancelledFolderRename) { cancelledFolderRename = false; return; }
+    if (folderRenameError) return;
+    const newName = renamingFolderValue.trim();
+    renamingFolder = false;
+    renamingFolderValue = '';
+    if (node.type === 'folder' && newName !== node.name) {
+      dispatch('renameFolder', { oldPath: node.path, newName });
+    }
+    dispatch('cancelRename');
+  }
+
+  function cancelFolderRename() {
+    cancelledFolderRename = true;
+    renamingFolder = false;
+    renamingFolderValue = '';
     dispatch('cancelRename');
   }
 
@@ -195,28 +249,59 @@
 
 {#if node.type === 'folder'}
   <!-- Folder -->
-  <button
-    class="tree-row folder-row"
-    style="padding-left: {12 + depth * 16}px"
-    on:click={() => dispatch('toggleFolder', node.path)}
-    on:contextmenu={handleFolderContextMenu}
-  >
-    <span class="chevron" class:open={node.expanded}>
-      <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-        <path d="M3 1.5l4 3.5-4 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  {#if renamingFolder}
+    <div class="tree-row folder-row folder-rename-row" style="padding-left: {12 + depth * 16}px">
+      <span class="chevron">
+        <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+          <path d="M3 1.5l4 3.5-4 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </span>
+      <svg class="icon folder-icon" width="15" height="15" viewBox="0 0 16 16" fill="none">
+        <path d="M2 12V4.5a1 1 0 011-1h3.5l1.5 1.5H13a1 1 0 011 1V12a1 1 0 01-1 1H3a1 1 0 01-1-1z"
+          fill="#B0883020" stroke="#B08830" stroke-width="1.2"/>
       </svg>
-    </span>
-    <svg class="icon folder-icon" width="15" height="15" viewBox="0 0 16 16" fill="none">
-      <path d="M2 12V4.5a1 1 0 011-1h3.5l1.5 1.5H13a1 1 0 011 1V12a1 1 0 01-1 1H3a1 1 0 01-1-1z"
-        fill="#B0883020" stroke="#B08830" stroke-width="1.2"/>
-    </svg>
-    <span class="node-name">{node.name}</span>
-  </button>
+      <!-- svelte-ignore a11y_autofocus -->
+      <input
+        bind:this={folderRenameInputEl}
+        class="file-rename-input"
+        class:naming-error={!!folderRenameError}
+        bind:value={renamingFolderValue}
+        on:keydown={(e) => { if (e.key === 'Enter') confirmFolderRename(); if (e.key === 'Escape') cancelFolderRename(); }}
+        on:blur={confirmFolderRename}
+        spellcheck="false"
+        autofocus
+      />
+      {#if folderRenameError}
+        <span class="naming-duplicate-hint">{folderRenameError}</span>
+      {/if}
+    </div>
+  {:else}
+    <button
+      class="tree-row folder-row"
+      style="padding-left: {12 + depth * 16}px"
+      on:click={() => dispatch('toggleFolder', node.path)}
+      on:contextmenu={handleFolderContextMenu}
+    >
+      <span class="chevron" class:open={node.expanded}>
+        <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+          <path d="M3 1.5l4 3.5-4 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </span>
+      <svg class="icon folder-icon" width="15" height="15" viewBox="0 0 16 16" fill="none">
+        <path d="M2 12V4.5a1 1 0 011-1h3.5l1.5 1.5H13a1 1 0 011 1V12a1 1 0 01-1 1H3a1 1 0 01-1-1z"
+          fill="#B0883020" stroke="#B08830" stroke-width="1.2"/>
+      </svg>
+      <span class="node-name">{node.name}</span>
+    </button>
+  {/if}
 
   {#if showFolderMenu}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div class="file-context-menu folder-context-menu" style="left: {folderMenuPos.x}px; top: {folderMenuPos.y}px" on:click|stopPropagation on:keydown|stopPropagation>
       <button class="file-context-item" on:click|stopPropagation={() => { dispatch('createFile', node.path); showFolderMenu = false; }}>New .http file</button>
+      <button class="file-context-item" on:click|stopPropagation={() => { dispatch('createFolder', node.path); showFolderMenu = false; }}>New subfolder</button>
+      <div class="context-menu-divider"></div>
+      <button class="file-context-item" on:click|stopPropagation={() => { showFolderMenu = false; enterFolderRename(); }}>Rename</button>
     </div>
   {/if}
 
@@ -232,7 +317,9 @@
           {usedNames}
           {forceExpand}
           {editingFilePath}
+          {editingFolderPath}
           siblingNames={childSiblingNames(node.children)}
+          siblingFolderNames={node.children.map(c => c.name)}
           on:toggleFolder
           on:select
           on:pinRequest
@@ -241,8 +328,10 @@
           on:deleteFile
           on:nameRequest
           on:renameFile
+          on:renameFolder
           on:duplicateFile
           on:createFile
+          on:createFolder
           on:cancelRename
         />
       {/each}
@@ -691,8 +780,9 @@
     margin: var(--space-0\.5) 0;
   }
 
-  /* File inline rename */
-  .file-rename-row {
+  /* Folder / file inline rename */
+  .file-rename-row,
+  .folder-rename-row {
     cursor: default;
   }
   .file-rename-input {

--- a/src/components/TreeSidebar.svelte
+++ b/src/components/TreeSidebar.svelte
@@ -18,6 +18,7 @@
 
   // File management props
   export let editingFilePath: string | null = null;
+  export let editingFolderPath: string | null = null;
 
   // Flow props
   export let flows: Record<string, FlowDefinition> = {};
@@ -289,6 +290,17 @@
         <path d="M8 3v10M3 8h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
       </svg>
     </button>
+    <button
+      class="btn-display-mode"
+      class:disabled={!hasWorkspace}
+      on:click={() => { if (hasWorkspace) dispatch('createFolder', null); }}
+      title={!hasWorkspace ? 'Open a folder first' : 'New folder'}
+    >
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+        <path d="M2 12V5.5a1 1 0 011-1h3l1.5 1.5H13a1 1 0 011 1V12a1 1 0 01-1 1H3a1 1 0 01-1-1z" fill="#B0883020" stroke="currentColor" stroke-width="1.2"/>
+        <path d="M8 7.5v4M6 9.5h4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+      </svg>
+    </button>
   </div>
   <div class="tree-scroll">
     {#if tree.length === 0}
@@ -313,7 +325,9 @@
           {usedNames}
           forceExpand={!!filterText.trim()}
           {editingFilePath}
+          {editingFolderPath}
           siblingNames={tree.filter(n => n.type === 'file').map(n => n.name)}
+          siblingFolderNames={tree.map(n => n.name)}
           on:toggleFolder
           on:select
           on:pinRequest
@@ -322,8 +336,10 @@
           on:deleteFile
           on:nameRequest
           on:renameFile
+          on:renameFolder
           on:duplicateFile
           on:createFile
+          on:createFolder
           on:cancelRename
         />
       {/each}

--- a/src/lib/folderCreate.test.ts
+++ b/src/lib/folderCreate.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { generateFolderName } from './folderCreate';
+import { addFolderToTree, renameFolderInTree, workspace } from './stores';
+import { get } from 'svelte/store';
+import type { FolderNode } from './types';
+
+// ─── generateFolderName ──────────────────────────────────────────────────────
+
+describe('generateFolderName', () => {
+  it('returns new-folder when no siblings exist', () => {
+    expect(generateFolderName(new Set())).toBe('new-folder');
+  });
+
+  it('returns new-folder-2 when new-folder already exists', () => {
+    expect(generateFolderName(new Set(['new-folder']))).toBe('new-folder-2');
+  });
+
+  it('increments counter past all existing collisions', () => {
+    expect(generateFolderName(new Set(['new-folder', 'new-folder-2', 'new-folder-3']))).toBe('new-folder-4');
+  });
+});
+
+// ─── addFolderToTree ─────────────────────────────────────────────────────────
+
+describe('addFolderToTree', () => {
+  function makeFolder(path: string, name: string): FolderNode {
+    return { type: 'folder', name, path, children: [], expanded: true };
+  }
+
+  beforeEach(() => {
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [] });
+  });
+
+  it('adds a folder to the root when parentPath is null', () => {
+    addFolderToTree(null, makeFolder('/ws/apis', 'apis'));
+    const tree = get(workspace).tree;
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({ type: 'folder', name: 'apis', path: '/ws/apis', expanded: true, children: [] });
+  });
+
+  it('adds a subfolder inside an existing folder', () => {
+    workspace.set({
+      rootPath: '/ws',
+      rootName: 'ws',
+      tree: [makeFolder('/ws/apis', 'apis')],
+    });
+    addFolderToTree('/ws/apis', makeFolder('/ws/apis/v1', 'v1'));
+    const tree = get(workspace).tree;
+    const parent = tree[0] as FolderNode;
+    expect(parent.children).toHaveLength(1);
+    expect(parent.children[0]).toMatchObject({ type: 'folder', name: 'v1', path: '/ws/apis/v1' });
+  });
+
+  it('newly added folder is expanded with empty children', () => {
+    addFolderToTree(null, makeFolder('/ws/empty', 'empty'));
+    const node = get(workspace).tree[0] as FolderNode;
+    expect(node.expanded).toBe(true);
+    expect(node.children).toEqual([]);
+  });
+});
+
+// ─── renameFolderInTree ──────────────────────────────────────────────────────
+
+describe('renameFolderInTree', () => {
+  beforeEach(() => {
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [] });
+  });
+
+  it('updates the folder name and path at root level', () => {
+    workspace.set({
+      rootPath: '/ws',
+      rootName: 'ws',
+      tree: [{ type: 'folder', name: 'old', path: '/ws/old', children: [], expanded: true }],
+    });
+    renameFolderInTree('/ws/old', '/ws/renamed', 'renamed');
+    const tree = get(workspace).tree;
+    expect(tree[0]).toMatchObject({ type: 'folder', name: 'renamed', path: '/ws/renamed' });
+  });
+
+  it('updates paths of children recursively', () => {
+    workspace.set({
+      rootPath: '/ws',
+      rootName: 'ws',
+      tree: [{
+        type: 'folder', name: 'apis', path: '/ws/apis', expanded: true,
+        children: [
+          { type: 'file', name: 'auth.http', path: '/ws/apis/auth.http', requests: [], variables: [], dirty: false, savedContent: '' },
+          { type: 'folder', name: 'v2', path: '/ws/apis/v2', children: [], expanded: false },
+        ],
+      }],
+    });
+    renameFolderInTree('/ws/apis', '/ws/services', 'services');
+    const folder = get(workspace).tree[0] as FolderNode;
+    expect(folder.path).toBe('/ws/services');
+    expect(folder.children[0]).toMatchObject({ path: '/ws/services/auth.http' });
+    expect(folder.children[1]).toMatchObject({ path: '/ws/services/v2' });
+  });
+});

--- a/src/lib/folderCreate.ts
+++ b/src/lib/folderCreate.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns a unique folder name that doesn't collide with any existing sibling
+ * names. Tries 'new-folder', then 'new-folder-2', 'new-folder-3', ...
+ */
+export function generateFolderName(siblingNames: Set<string>): string {
+  const stem = 'new-folder';
+  if (!siblingNames.has(stem)) return stem;
+  let counter = 2;
+  while (siblingNames.has(`${stem}-${counter}`)) counter++;
+  return `${stem}-${counter}`;
+}

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -309,6 +309,9 @@ export function markFileSaved(filePath: string) {
 /** Path of a file currently in inline-rename mode (used to trigger editing from App). */
 export const editingFilePath = writable<string | null>(null);
 
+/** Path of a folder currently in inline-rename mode. */
+export const editingFolderPath = writable<string | null>(null);
+
 /** Add a file node to the tree under the given parent folder path. */
 export function addFileToTree(parentPath: string | null, fileNode: FileNode) {
   workspace.update(ws => {
@@ -319,6 +322,27 @@ export function addFileToTree(parentPath: string | null, fileNode: FileNode) {
       return nodes.map(node => {
         if (node.type === 'folder' && node.path === parentPath) {
           return { ...node, children: [...node.children, fileNode] };
+        }
+        if (node.type === 'folder') {
+          return { ...node, children: insert(node.children) };
+        }
+        return node;
+      });
+    }
+    return { ...ws, tree: insert(ws.tree) };
+  });
+}
+
+/** Add a folder node to the tree under the given parent folder path. */
+export function addFolderToTree(parentPath: string | null, folderNode: FolderNode) {
+  workspace.update(ws => {
+    if (!parentPath || parentPath === ws.rootPath) {
+      return { ...ws, tree: [...ws.tree, folderNode] };
+    }
+    function insert(nodes: TreeNode[]): TreeNode[] {
+      return nodes.map(node => {
+        if (node.type === 'folder' && node.path === parentPath) {
+          return { ...node, children: [...node.children, folderNode] };
         }
         if (node.type === 'folder') {
           return { ...node, children: insert(node.children) };
@@ -362,6 +386,36 @@ export function renameFileInTree(oldPath: string, newPath: string, newName: stri
       name: newName,
     })),
   }));
+}
+
+/** Rename a folder in the tree, updating its name, path, and all descendant paths. */
+export function renameFolderInTree(oldPath: string, newPath: string, newName: string) {
+  function rewriteDescendants(nodes: TreeNode[]): TreeNode[] {
+    return nodes.map(n => {
+      if (n.type === 'file') {
+        if (!n.path.startsWith(oldPath + '/') && !n.path.startsWith(oldPath + '\\')) return n;
+        return { ...n, path: newPath + n.path.slice(oldPath.length) };
+      }
+      const childPath = n.path.startsWith(oldPath + '/') || n.path.startsWith(oldPath + '\\')
+        ? newPath + n.path.slice(oldPath.length)
+        : n.path;
+      return { ...n, path: childPath, children: rewriteDescendants(n.children) };
+    });
+  }
+
+  function update(nodes: TreeNode[]): TreeNode[] {
+    return nodes.map(n => {
+      if (n.type === 'folder' && n.path === oldPath) {
+        return { ...n, name: newName, path: newPath, children: rewriteDescendants(n.children) };
+      }
+      if (n.type === 'folder') {
+        return { ...n, children: update(n.children) };
+      }
+      return n;
+    });
+  }
+
+  workspace.update(ws => ({ ...ws, tree: update(ws.tree) }));
 }
 
 /** Toggle a folder's expanded state. */


### PR DESCRIPTION
## Summary

- Add a **New folder** toolbar button in the tree sidebar (creates at workspace root)
- Add **New subfolder** and **Rename** entries to the folder context menu
- New folders enter inline rename mode immediately, matching the existing new-file flow
- Collision handling: `new-folder`, `new-folder-2`, `new-folder-3`, ... matching `handleCreateFile` logic

## Implementation

- `src/lib/folderCreate.ts` - pure `generateFolderName(siblingNames)` helper
- `src/lib/stores.ts` - `addFolderToTree`, `renameFolderInTree`, `editingFolderPath` store
- `src/components/TreeNode.svelte` - inline folder rename UI + context menu entries + event propagation
- `src/components/TreeSidebar.svelte` - toolbar button + event forwarding
- `src/App.svelte` - `handleCreateFolder` and `handleRenameFolder` handlers

## Test plan

- [ ] 8 unit tests covering `generateFolderName` (no collision, single, multiple) and `addFolderToTree` / `renameFolderInTree` store mutations - all passing (`pnpm test`)
- [ ] `pnpm check` passes with 0 errors
- [ ] Toolbar "New folder" button creates a folder at root and enters rename mode
- [ ] Folder context menu "New subfolder" creates inside the right-clicked folder
- [ ] Folder context menu "Rename" enters rename mode for an existing folder
- [ ] Collision counter increments correctly when `new-folder` already exists
- [ ] Escape cancels rename without creating/renaming anything
- [ ] Invalid characters are rejected with an inline error

closes #76