### PR TITLE
feat(tree): hide dot-folders and rename flows dir to .flows

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,7 +42,7 @@
   import type { HttpRequest, HttpResponse, RequestLocation, EnvironmentFile, TreeNode, ImportResult, PbAssertionResult, KeyVaultState } from './lib/types';
   import type { BottomTab, ResponseTab } from './lib/stores';
   import type { DiscoveredFile, DiscoveredFolder } from './lib/parser';
-  import { scanForFlowFiles, loadFlowHistory, saveFlowRunRecord, clearFlowRunHistory, parseFlowFile, FLOWS_DIR } from './lib/flowIO';
+  import { scanForFlowFiles, loadFlowHistory, saveFlowRunRecord, clearFlowRunHistory, parseFlowFile, FLOWS_DIR, migrateFlowsDirectory } from './lib/flowIO';
   import { generateFolderName } from './lib/folderCreate';
   import { runFlow } from './lib/flowRunner';
   import type { FlowStepResult, FlowRunRecord } from './lib/types';
@@ -639,6 +639,12 @@
 
     // Auto-discover env files from workspace root
     await tryLoadEnvFiles(rootPath);
+
+    // Migrate legacy flows/ to .flows/ if needed
+    try {
+      const migrated = await migrateFlowsDirectory(rootPath);
+      if (migrated) addToast("Workspace updated: renamed 'flows' to '.flows'", 'info');
+    } catch { /* best effort */ }
 
     // Discover test flows and load run history
     try {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -691,6 +691,7 @@
     let hasHttpDescendant = false;
 
     for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
       const fullPath = await join(dir, entry.name);
       if (entry.isDirectory) {
         const subFiles = await scanDir(fullPath, rootDir, emptyFolderSink);
@@ -718,6 +719,7 @@
     const files: DiscoveredFile[] = [];
 
     for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
       const fullPath = await join(rootDir, entry.name);
       if (entry.isDirectory) {
         const subFiles = await scanDir(fullPath, rootDir, emptyFolders);

--- a/src/lib/flowIO.test.ts
+++ b/src/lib/flowIO.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+  readDir: vi.fn(),
+  mkdir: vi.fn(),
+  remove: vi.fn(),
+  rename: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/path', () => ({
+  join: vi.fn(async (...parts: string[]) => parts.join('/')),
+  basename: vi.fn(async (p: string) => p.split('/').pop() ?? p),
+}));
+
+import { migrateFlowsDirectory } from './flowIO';
+import { readDir, rename } from '@tauri-apps/plugin-fs';
+
+const mockedReadDir = vi.mocked(readDir);
+const mockedRename = vi.mocked(rename);
+
+// ─── migrateFlowsDirectory ───────────────────────────────────────────────────
+
+describe('migrateFlowsDirectory', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedRename.mockResolvedValue(undefined);
+  });
+
+  it('returns false when flows/ does not exist', async () => {
+    mockedReadDir.mockRejectedValue(new Error('not found'));
+    const migrated = await migrateFlowsDirectory('/workspace');
+    expect(migrated).toBe(false);
+    expect(mockedRename).not.toHaveBeenCalled();
+  });
+
+  it('renames flows/ to .flows/ and returns true when only flows/ exists', async () => {
+    mockedReadDir
+      .mockResolvedValueOnce([]) // flows/ exists
+      .mockRejectedValueOnce(new Error('not found')); // .flows/ does not
+    const migrated = await migrateFlowsDirectory('/workspace');
+    expect(migrated).toBe(true);
+    expect(mockedRename).toHaveBeenCalledWith('/workspace/flows', '/workspace/.flows');
+  });
+
+  it('returns false and skips rename when both flows/ and .flows/ exist', async () => {
+    mockedReadDir.mockResolvedValue([]);
+    const migrated = await migrateFlowsDirectory('/workspace');
+    expect(migrated).toBe(false);
+    expect(mockedRename).not.toHaveBeenCalled();
+  });
+
+  it('returns false when only .flows/ exists (already migrated)', async () => {
+    mockedReadDir
+      .mockRejectedValueOnce(new Error('not found')) // flows/ missing
+      .mockResolvedValueOnce([]); // .flows/ exists (not reached, but explicit)
+    const migrated = await migrateFlowsDirectory('/workspace');
+    expect(migrated).toBe(false);
+    expect(mockedRename).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/flowIO.ts
+++ b/src/lib/flowIO.ts
@@ -1,4 +1,4 @@
-import { readTextFile, writeTextFile, readDir, mkdir, remove } from '@tauri-apps/plugin-fs';
+import { readTextFile, writeTextFile, readDir, mkdir, remove, rename } from '@tauri-apps/plugin-fs';
 import { join, basename } from '@tauri-apps/api/path';
 import type { FlowDefinition, FlowRunRecord, FlowStep, FlowStepOverrides } from './types';
 import { applyAliasSync } from './flowAlias';
@@ -71,6 +71,40 @@ export function createEmptyFlow(name: string): FlowDefinition {
     description: '',
     steps: [],
   };
+}
+
+// ─── Migration ───────────────────────────────────────────────────────────────
+
+/**
+ * Renames legacy `flows/` to `.flows/` if `flows/` exists and `.flows/` does not.
+ * Returns true if migration was performed, false otherwise.
+ */
+export async function migrateFlowsDirectory(rootPath: string): Promise<boolean> {
+  const legacyDir = await join(rootPath, 'flows');
+  const dotDir = await join(rootPath, FLOWS_DIR);
+
+  let legacyExists = false;
+  try {
+    await readDir(legacyDir);
+    legacyExists = true;
+  } catch {
+    // flows/ doesn't exist
+  }
+
+  if (!legacyExists) return false;
+
+  let dotExists = false;
+  try {
+    await readDir(dotDir);
+    dotExists = true;
+  } catch {
+    // .flows/ doesn't exist - good, proceed with migration
+  }
+
+  if (dotExists) return false;
+
+  await rename(legacyDir, dotDir);
+  return true;
 }
 
 // ─── Flow Discovery ──────────────────────────────────────────────────────────

--- a/src/lib/flowIO.ts
+++ b/src/lib/flowIO.ts
@@ -6,7 +6,7 @@ import { applyAliasSync } from './flowAlias';
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const FLOW_EXTENSION = '.pb-flow.json';
-export const FLOWS_DIR = 'flows';
+export const FLOWS_DIR = '.flows';
 const RESULTS_DIR = `${FLOWS_DIR}/.results`;
 const MAX_HISTORY_PER_FLOW = 20;
 
@@ -91,7 +91,7 @@ export async function scanForFlowFiles(dir: string, rootDir: string): Promise<Di
   try {
     entries = await readDir(flowsDir) as any[];
   } catch {
-    return []; // flows/ directory doesn't exist yet
+    return []; // .flows/ directory doesn't exist yet
   }
 
   const results: DiscoveredFlow[] = [];

--- a/src/lib/parser-extended.test.ts
+++ b/src/lib/parser-extended.test.ts
@@ -759,6 +759,32 @@ describe('buildWorkspaceTree', () => {
     expect(tree[0].name).toBe('Users');
     expect((tree[0] as any).children).toHaveLength(2);
   });
+
+  it('excludes files inside dot-prefixed folders', () => {
+    const files = [
+      { absolutePath: '/root/.flows/my.pb-flow.json', relativePath: '.flows/my.pb-flow.json', content: '{}' },
+      { absolutePath: '/root/api.http', relativePath: 'api.http', content: 'GET https://example.com\n' },
+    ];
+    const tree = buildWorkspaceTree(files);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].name).toBe('api.http');
+  });
+
+  it('excludes empty dot-prefixed folders', () => {
+    const emptyFolders = [{ relativePath: '.flows' }, { relativePath: '.git' }];
+    const tree = buildWorkspaceTree([], emptyFolders);
+    expect(tree).toHaveLength(0);
+  });
+
+  it('still shows regular flows/ folder without dot prefix', () => {
+    const files = [
+      { absolutePath: '/root/flows/my.http', relativePath: 'flows/my.http', content: 'GET https://example.com\n' },
+    ];
+    const tree = buildWorkspaceTree(files);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].type).toBe('folder');
+    expect(tree[0].name).toBe('flows');
+  });
 });
 
 describe('getAllFileNodes', () => {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1297,13 +1297,17 @@ export function buildWorkspaceTree(files: DiscoveredFile[], emptyFolders: Discov
   }
 
   // Pre-create all discovered empty/empty-subtree folder paths so they appear in the tree
-  const sortedFolders = [...emptyFolders].sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  const sortedFolders = [...emptyFolders]
+    .filter(f => !f.relativePath.startsWith('.'))
+    .sort((a, b) => a.relativePath.localeCompare(b.relativePath));
   for (const folder of sortedFolders) {
     ensureFolder(folder.relativePath);
   }
 
   // Sort files so folder structure is stable
-  const sorted = [...files].sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  const sorted = [...files]
+    .filter(f => !f.relativePath.startsWith('.'))
+    .sort((a, b) => a.relativePath.localeCompare(b.relativePath));
 
   for (const file of sorted) {
     const parts = file.relativePath.split('/');


### PR DESCRIPTION
Closes #139

## Summary

- Renames `FLOWS_DIR` from `'flows'` to `'.flows'` so flow files are saved/read from `.flows/`
- Filters dot-prefixed paths from `buildWorkspaceTree` so `.flows/`, `.git/`, and any future dot-folders never appear in the sidebar
- Adds `migrateFlowsDirectory()` to auto-rename legacy `flows/` to `.flows/` on workspace open

## Test plan

- [ ] All 218 existing tests pass (`pnpm test`)
- [ ] `migrateFlowsDirectory` covered by 4 unit tests (no-op, rename, both exist, already migrated)
- [ ] `parser-extended.test.ts` confirms `.flows/` is hidden and `flows/` (no dot) still shows