### PR TITLE
fix(parser): evaluate &&/|| before comparisons in pb.assert expressions (#158)

### DIFF
--- a/src/lib/parser-extended.test.ts
+++ b/src/lib/parser-extended.test.ts
@@ -509,6 +509,35 @@ describe('evaluatePbExpression', () => {
   it('resolves {{variable}} references in expressions', () => {
     expect(evaluatePbExpression('{{myVar}}', ctx)).toBe('hello');
   });
+
+  const ctx404 = { ...ctx, response: { ...mockResponse, status: 404 } };
+
+  it('evaluates comparisons combined with && (range check)', () => {
+    expect(evaluatePbExpression('pb.response.status >= 200 && pb.response.status < 300', ctx)).toBe(true);
+    expect(evaluatePbExpression('pb.response.status >= 200 && pb.response.status < 300', ctx404)).toBe(false);
+  });
+
+  it('evaluates comparisons combined with ||', () => {
+    expect(evaluatePbExpression('pb.response.status == 200 || pb.response.status == 201', ctx)).toBe(true);
+    expect(evaluatePbExpression('pb.response.status == 200 || pb.response.status == 201', ctx404)).toBe(false);
+  });
+
+  it('gives && higher precedence than ||', () => {
+    // (404-check && true) || 200-check → false || true → true
+    expect(
+      evaluatePbExpression('pb.response.status == 404 && true || pb.response.status == 200', ctx)
+    ).toBe(true);
+    expect(
+      evaluatePbExpression('pb.response.status == 404 && true || pb.response.status == 200', ctx404)
+    ).toBe(true);
+  });
+
+  it('ignores operators inside string literals', () => {
+    expect(evaluatePbExpression('pb.response.body.$.token == "a==b"', ctx)).toBe(false);
+    expect(evaluatePbExpression('"a==b" == "a==b"', ctx)).toBe(true);
+    expect(evaluatePbExpression('pb.response.body.$.token contains "&&"', ctx)).toBe(false);
+    expect(evaluatePbExpression('"x&&y" contains "&&"', ctx)).toBe(true);
+  });
 });
 
 // ─── executePbDirectives ────────────────────────────────────────────────────

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -750,6 +750,27 @@ interface PbEvalContext {
  *   pb.response.body.$.name != null
  *   pb.response.body.$.items.length > 0
  */
+/**
+ * Find the first occurrence of `op` in `s` that is outside of any
+ * single- or double-quoted string literal. Returns -1 if not found.
+ */
+function findTopLevelOperator(s: string, op: string): number {
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (s.startsWith(op, i)) return i;
+  }
+  return -1;
+}
+
 export function evaluatePbExpression(expr: string, ctx: PbEvalContext): unknown {
   // Resolve {{variable}} references inline before evaluation
   let trimmed = expr.trim();
@@ -766,10 +787,25 @@ export function evaluatePbExpression(expr: string, ctx: PbEvalContext): unknown 
     return ctx.variables[name] ?? `{{${name}}}`;
   });
 
+  // ── Logical operators (||, &&) ──
+  // Split on these before comparisons so `a == 1 || b == 2` parses as
+  // `(a == 1) || (b == 2)`. `||` first: it binds loosest, so
+  // `a && b || c && d` parses as `(a && b) || (c && d)`.
+  const orIdx = findTopLevelOperator(trimmed, '||');
+  if (orIdx !== -1) {
+    return evaluatePbExpression(trimmed.slice(0, orIdx), ctx) ||
+           evaluatePbExpression(trimmed.slice(orIdx + 2), ctx);
+  }
+  const andIdx = findTopLevelOperator(trimmed, '&&');
+  if (andIdx !== -1) {
+    return evaluatePbExpression(trimmed.slice(0, andIdx), ctx) &&
+           evaluatePbExpression(trimmed.slice(andIdx + 2), ctx);
+  }
+
   // ── Comparison operators ──
   const compOps = ['==', '!=', '>=', '<=', '>', '<', ' contains ', ' startsWith ', ' endsWith '] as const;
   for (const op of compOps) {
-    const idx = trimmed.indexOf(op);
+    const idx = findTopLevelOperator(trimmed, op);
     if (idx !== -1) {
       const left = evaluatePbExpression(trimmed.slice(0, idx), ctx);
       const right = evaluatePbExpression(trimmed.slice(idx + op.length), ctx);
@@ -787,18 +823,6 @@ export function evaluatePbExpression(expr: string, ctx: PbEvalContext): unknown 
         case 'endsWith': return leftStr.endsWith(rightStr);
       }
     }
-  }
-
-  // ── Logical operators (&&, ||) ──
-  const andIdx = trimmed.indexOf('&&');
-  if (andIdx !== -1) {
-    return evaluatePbExpression(trimmed.slice(0, andIdx), ctx) &&
-           evaluatePbExpression(trimmed.slice(andIdx + 2), ctx);
-  }
-  const orIdx = trimmed.indexOf('||');
-  if (orIdx !== -1) {
-    return evaluatePbExpression(trimmed.slice(0, orIdx), ctx) ||
-           evaluatePbExpression(trimmed.slice(orIdx + 2), ctx);
   }
 
   // ── Negation ──


### PR DESCRIPTION
## Summary

Fixes #158.

`evaluatePbExpression` in `src/lib/parser.ts` checked comparison operators (`==`, `!=`, `>=`, `<=`, `>`, `<`, `contains`, …) **before** logical operators and split at the first `indexOf` hit, so any expression combining a comparison with `&&`/`||` was parsed with the wrong precedence:

- `pb.response.status >= 200 && pb.response.status < 300` **passed on a 404** (split at `>=` → `404 >= Number(false)` → `404 >= 0` → true)
- `pb.response.status == 200 || pb.response.status == 201` **failed on a 200** (split at first `==` → `200 == false` → false)

Operators inside string literals were also matched, so `expr == "a==b"` mis-split.

## Fix

- Split on logical operators **before** comparisons: `||` first (binds loosest, so `a && b || c && d` parses as `(a && b) || (c && d)`), then `&&`, then the comparison cascade.
- All operator scanning now goes through a new quote-aware `findTopLevelOperator` helper that skips anything inside `"..."`/`'...'` literals.

Short-circuit semantics and all single-comparison behavior are unchanged.

## Tests

4 new cases in `src/lib/parser-extended.test.ts`, covering exactly what the issue asked for:

- range check `status >= 200 && status < 300` (true at 200, false at 404) — previously a false pass
- `status == 200 || status == 201` (true at 200, false at 404) — previously a false failure
- `&&` binds tighter than `||`
- operators inside string literals: `== "a==b"`, `contains "&&"`

`pnpm test`: 222/222 passing. `pnpm check`: 0 errors, 0 warnings.

https://claude.ai/code/session_014YjVohcUH6V4Xhb4MmxN8t

---
_Generated by [Claude Code](https://claude.ai/code/session_014YjVohcUH6V4Xhb4MmxN8t)_