### PR TITLE
ci: run Rust test suite (cargo test) in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,6 @@ jobs:
 
       - name: Rust check
         run: cargo check --manifest-path src-tauri/Cargo.toml
+
+      - name: Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml


### PR DESCRIPTION
Fixes #162

## Problem

`ci.yml` ran `pnpm check`, `pnpm test`, and `cargo check` — but never `cargo test`. `cargo check` doesn't compile or execute `#[cfg(test)]` code, and `release.yml` has no test step, so the ~32 Rust tests (SSRF guard in `lib.rs`, MCP bearer-auth/JSON-RPC suite in `mcp.rs`) ran nowhere in automation. A regression in any of them — or a compile error confined to the test modules — would merge green.

## Fix

Add a `Rust tests` step (`cargo test --manifest-path src-tauri/Cargo.toml`) to the `check` job, right after the existing `cargo check` step, exactly as the issue suggests. Kept the `cargo check` step for faster failure feedback on plain compile errors.

## Verification

Ran `cargo test --manifest-path src-tauri/Cargo.toml` locally in a clean environment with **no frontend build / no `dist/` directory**: **32 passed, 0 failed** — confirming the issue's note that `tauri::generate_context!` only embeds frontend assets in release/`custom-protocol` builds, so no workflow ordering changes are needed.

This also means the new Rust tests in #165 will actually execute in CI once both are merged.

https://claude.ai/code/session_014YjVohcUH6V4Xhb4MmxN8t

---
_Generated by [Claude Code](https://claude.ai/code/session_014YjVohcUH6V4Xhb4MmxN8t)_