### PR TITLE
fix(parser): evaluate pb.assert logical operators before comparisons

### DIFF
--- a/src/lib/parser-extended.test.ts
+++ b/src/lib/parser-extended.test.ts
@@ -506,6 +506,59 @@ describe('evaluatePbExpression', () => {
     expect(evaluatePbExpression('!true', ctx)).toBe(false);
   });
 
+  it('evaluates comparison combined with && (range check)', () => {
+    // status 200 is within [200, 300)
+    expect(
+      evaluatePbExpression('pb.response.status >= 200 && pb.response.status < 300', ctx)
+    ).toBe(true);
+
+    const notOk = { ...ctx, response: { ...mockResponse, status: 404 } };
+    expect(
+      evaluatePbExpression('pb.response.status >= 200 && pb.response.status < 300', notOk)
+    ).toBe(false);
+
+    const noContent = { ...ctx, response: { ...mockResponse, status: 204 } };
+    expect(
+      evaluatePbExpression('pb.response.status >= 200 && pb.response.status < 300', noContent)
+    ).toBe(true);
+  });
+
+  it('evaluates comparison combined with || (created-or-ok check)', () => {
+    // status 200 satisfies the left branch
+    expect(
+      evaluatePbExpression('pb.response.status == 200 || pb.response.status == 201', ctx)
+    ).toBe(true);
+
+    const created = { ...ctx, response: { ...mockResponse, status: 201 } };
+    expect(
+      evaluatePbExpression('pb.response.status == 200 || pb.response.status == 201', created)
+    ).toBe(true);
+
+    const serverError = { ...ctx, response: { ...mockResponse, status: 500 } };
+    expect(
+      evaluatePbExpression('pb.response.status == 200 || pb.response.status == 201', serverError)
+    ).toBe(false);
+  });
+
+  it('respects && binding tighter than || in mixed expressions', () => {
+    // (false && X) || (true) => true; a naive first-operator split would mis-handle this
+    expect(
+      evaluatePbExpression(
+        'pb.response.status == 404 && pb.response.status == 200 || pb.response.status == 200',
+        ctx
+      )
+    ).toBe(true);
+  });
+
+  it('ignores comparison operators inside string literals', () => {
+    const eq = {
+      ...ctx,
+      response: { ...mockResponse, body: '{"msg":"a==b"}' },
+    };
+    expect(evaluatePbExpression('pb.response.body.$.msg == "a==b"', eq)).toBe(true);
+    expect(evaluatePbExpression('pb.response.body.$.msg == "a!=b"', eq)).toBe(false);
+  });
+
   it('resolves {{variable}} references in expressions', () => {
     expect(evaluatePbExpression('{{myVar}}', ctx)).toBe('hello');
   });

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -750,6 +750,29 @@ interface PbEvalContext {
  *   pb.response.body.$.name != null
  *   pb.response.body.$.items.length > 0
  */
+/**
+ * Find the first index of `op` in `str` that lies outside of any single- or
+ * double-quoted string literal. Returns -1 if `op` only appears inside quotes
+ * (or not at all). Used so logical/comparison operators inside string literals
+ * (e.g. `body.$.msg == "a==b"`) are not mistaken for real operators.
+ */
+function indexOfOutsideQuotes(str: string, op: string): number {
+  let quote: string | null = null;
+  for (let i = 0; i <= str.length - op.length; i++) {
+    const ch = str[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (str.startsWith(op, i)) return i;
+  }
+  return -1;
+}
+
 export function evaluatePbExpression(expr: string, ctx: PbEvalContext): unknown {
   // Resolve {{variable}} references inline before evaluation
   let trimmed = expr.trim();
@@ -766,10 +789,25 @@ export function evaluatePbExpression(expr: string, ctx: PbEvalContext): unknown 
     return ctx.variables[name] ?? `{{${name}}}`;
   });
 
+  // ── Logical operators (||, &&) ──
+  // Split logical operators before comparisons so that precedence is correct:
+  // `||` binds loosest (split first), then `&&`, then comparison operators.
+  // Operator scanning is quote-aware so operators inside string literals are ignored.
+  const orIdx = indexOfOutsideQuotes(trimmed, '||');
+  if (orIdx !== -1) {
+    return evaluatePbExpression(trimmed.slice(0, orIdx), ctx) ||
+           evaluatePbExpression(trimmed.slice(orIdx + 2), ctx);
+  }
+  const andIdx = indexOfOutsideQuotes(trimmed, '&&');
+  if (andIdx !== -1) {
+    return evaluatePbExpression(trimmed.slice(0, andIdx), ctx) &&
+           evaluatePbExpression(trimmed.slice(andIdx + 2), ctx);
+  }
+
   // ── Comparison operators ──
   const compOps = ['==', '!=', '>=', '<=', '>', '<', ' contains ', ' startsWith ', ' endsWith '] as const;
   for (const op of compOps) {
-    const idx = trimmed.indexOf(op);
+    const idx = indexOfOutsideQuotes(trimmed, op);
     if (idx !== -1) {
       const left = evaluatePbExpression(trimmed.slice(0, idx), ctx);
       const right = evaluatePbExpression(trimmed.slice(idx + op.length), ctx);
@@ -787,18 +825,6 @@ export function evaluatePbExpression(expr: string, ctx: PbEvalContext): unknown 
         case 'endsWith': return leftStr.endsWith(rightStr);
       }
     }
-  }
-
-  // ── Logical operators (&&, ||) ──
-  const andIdx = trimmed.indexOf('&&');
-  if (andIdx !== -1) {
-    return evaluatePbExpression(trimmed.slice(0, andIdx), ctx) &&
-           evaluatePbExpression(trimmed.slice(andIdx + 2), ctx);
-  }
-  const orIdx = trimmed.indexOf('||');
-  if (orIdx !== -1) {
-    return evaluatePbExpression(trimmed.slice(0, orIdx), ctx) ||
-           evaluatePbExpression(trimmed.slice(orIdx + 2), ctx);
   }
 
   // ── Negation ──


### PR DESCRIPTION
Closes #158

## Problem

`evaluatePbExpression` in `src/lib/parser.ts` checked comparison operators (`==`, `!=`, `>=`, `<=`, `>`, `<`, `contains`, ...) **before** logical operators (`&&`, `||`), splitting at the first `indexOf` match. Any expression combining a comparison with `&&`/`||` parsed with the wrong precedence and silently evaluated to the wrong boolean:

- With status 404: `status >= 200 && status < 300` **passed** (should fail) - split at `>=` made the RHS `200 && status < 300` reduce to `false`, then `404 >= 0` -> true.
- With status 200: `status == 200 || status == 201` **failed** (should pass) - split at first `==` gave `200 == 201` -> false.

`indexOf` also matched operators inside string literals, so `body.$.msg == "a==b"` evaluated incorrectly.

## Fix

- Split on logical operators **first** (`||` then `&&`, so `&&` binds tighter than `||`), then comparison operators.
- Added a quote-aware `indexOfOutsideQuotes` scanner so operators inside `"..."`/`'...'` literals are ignored.

## Tests

Added cases to `parser-extended.test.ts`:
- `status >= 200 && status < 300` (200/204 -> true, 404 -> false)
- `status == 200 || status == 201` (200/201 -> true, 500 -> false)
- mixed `&&`/`||` precedence
- comparison operators inside string literals (`msg == "a==b"`)

All 222 tests pass; `pnpm check` clean (0 errors).