### PR TITLE
feat(favorites): name a favorite when adding it

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,6 +12,7 @@
   import TabBar from './components/TabBar.svelte';
   import FlowEditor from './components/FlowEditor.svelte';
   import SettingsModal from './components/SettingsModal.svelte';
+  import AddFavoriteModal from './components/AddFavoriteModal.svelte';
   import { loadTheme, setTheme, loadFavorites, saveFavorites, type ThemeId } from './lib/theme';
   import logoUrl from './assets/logo.png';
   import {
@@ -696,27 +697,61 @@
 
   // ─── Favorites ───
 
-  /** Toggle the currently open workspace folder in/out of the favorites list. */
+  let showAddFavoriteModal = false;
+  let pendingFavoritePath = '';
+  let pendingFavoriteName = '';
+
+  /**
+   * Toggle the currently open workspace folder in/out of the favorites list.
+   * Removing is immediate; adding opens a modal to name the favorite first.
+   */
   function toggleFavorite() {
-    const rootPath = get(workspace).rootPath;
+    const ws = get(workspace);
+    const rootPath = ws.rootPath;
     if (!rootPath) return;
+    if (get(favorites).some(f => f.path === rootPath)) {
+      removeFavorite(rootPath);
+    } else {
+      pendingFavoritePath = rootPath;
+      pendingFavoriteName = ws.rootName;
+      showAddFavoriteModal = true;
+    }
+  }
+
+  /** Create the pending favorite with the chosen name. */
+  function confirmAddFavorite(name: string) {
+    const path = pendingFavoritePath;
+    showAddFavoriteModal = false;
+    if (!path) return;
     favorites.update(list => {
-      const next = list.includes(rootPath)
-        ? list.filter(p => p !== rootPath)
-        : [...list, rootPath];
+      if (list.some(f => f.path === path)) return list;
+      const next = [...list, { path, name }];
       saveFavorites(next);
       return next;
     });
+    pendingFavoritePath = '';
+  }
+
+  function cancelAddFavorite() {
+    showAddFavoriteModal = false;
+    pendingFavoritePath = '';
   }
 
   /** Remove a path from the favorites list. */
   function removeFavorite(path: string) {
     favorites.update(list => {
-      const next = list.filter(p => p !== path);
+      const next = list.filter(f => f.path !== path);
       saveFavorites(next);
       return next;
     });
   }
+
+  /**
+   * Name shown for the open folder: the favorite's custom name when the open
+   * folder is favorited, otherwise the folder basename.
+   */
+  $: rootDisplayName =
+    $favorites.find(f => f.path === $workspace.rootPath)?.name ?? $workspace.rootName;
 
   /** Open a favorited folder, surfacing an error toast if it can no longer be read. */
   async function openFavorite(path: string) {
@@ -1669,6 +1704,13 @@
   on:importUrl={handleImportUrl}
   on:cancel={() => showImportCollectionModal = false}
 />
+<AddFavoriteModal
+  visible={showAddFavoriteModal}
+  folderPath={pendingFavoritePath}
+  defaultName={pendingFavoriteName}
+  on:confirm={(e) => confirmAddFavorite(e.detail.name)}
+  on:cancel={cancelAddFavorite}
+/>
 
 <svelte:window
   on:dragover|preventDefault={() => {}}
@@ -1694,7 +1736,7 @@
       <TreeSidebar
         tree={$workspace.tree}
         selected={$selectedLocation}
-        rootName={$workspace.rootName}
+        rootName={rootDisplayName}
         hasWorkspace={!!$workspace.rootPath}
         rootPath={$workspace.rootPath}
         favorites={$favorites}

--- a/src/components/AddFavoriteModal.svelte
+++ b/src/components/AddFavoriteModal.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  /** Whether the modal is visible */
+  export let visible: boolean = false;
+  /** Absolute path of the folder being favorited (shown as a hint) */
+  export let folderPath: string = '';
+  /** Default name to prefill (the folder basename) */
+  export let defaultName: string = '';
+
+  const dispatch = createEventDispatcher<{
+    confirm: { name: string };
+    cancel: void;
+  }>();
+
+  let name = '';
+  let inputEl: HTMLInputElement | null = null;
+
+  // Reset and focus when the modal opens.
+  $: if (visible) {
+    name = defaultName;
+    queueMicrotask(() => {
+      inputEl?.focus();
+      inputEl?.select();
+    });
+  }
+
+  function confirm() {
+    // Empty/whitespace name falls back to the folder basename.
+    const trimmed = name.trim() || defaultName;
+    dispatch('confirm', { name: trimmed });
+  }
+
+  function cancel() {
+    dispatch('cancel');
+  }
+</script>
+
+{#if visible}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div class="overlay" on:click|self={cancel} role="dialog" tabindex="-1">
+    <div class="modal">
+      <div class="modal-header">
+        <span class="modal-title">Name this favorite</span>
+        <button class="btn-close" on:click={cancel}>&times;</button>
+      </div>
+
+      <div class="modal-body">
+        <p class="description">Choose a name for this favorite. It is shown instead of the folder name.</p>
+        <input
+          class="name-input"
+          bind:this={inputEl}
+          bind:value={name}
+          placeholder="Favorite name..."
+          on:keydown={(e) => {
+            if (e.key === 'Enter') confirm();
+            else if (e.key === 'Escape') cancel();
+          }}
+        />
+        {#if folderPath}
+          <p class="path-hint" title={folderPath}>{folderPath}</p>
+        {/if}
+      </div>
+
+      <div class="modal-footer">
+        <button class="btn-skip" on:click={cancel}>Cancel</button>
+        <button class="btn-confirm" on:click={confirm}>Save</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  /* Modal base from shared.css; only overrides here */
+  .modal {
+    width: 420px;
+  }
+
+  .description {
+    font-size: var(--text-base);
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    margin-bottom: var(--space-2\.5);
+  }
+
+  .name-input {
+    width: 100%;
+    padding: 7px var(--space-2\.5);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-default);
+    background: var(--color-bg-surface);
+    color: var(--color-text);
+    font-family: inherit;
+    font-size: var(--text-base);
+    outline: none;
+  }
+  .name-input:focus { border-color: var(--color-primary); }
+
+  .path-hint {
+    font-size: var(--text-sm);
+    color: var(--slate-350);
+    margin-top: var(--space-1\.5);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .btn-skip {
+    padding: var(--space-1\.5) var(--space-3\.5);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-default);
+    background: transparent;
+    color: var(--slate-450);
+    font-family: inherit;
+    font-size: var(--text-base);
+    cursor: pointer;
+    transition: all var(--duration-normal);
+  }
+  .btn-skip:hover { border-color: var(--color-text-faint); color: var(--color-text); }
+  .btn-confirm {
+    padding: var(--space-1\.5) var(--space-3\.5);
+    border: none;
+    border-radius: var(--radius-default);
+    background: var(--color-primary);
+    color: var(--color-primary-fg);
+    font-family: inherit;
+    font-size: var(--text-base);
+    font-weight: var(--weight-semibold);
+    cursor: pointer;
+    transition: background var(--duration-normal);
+  }
+  .btn-confirm:hover { background: var(--color-primary-active); }
+</style>

--- a/src/components/TreeSidebar.svelte
+++ b/src/components/TreeSidebar.svelte
@@ -2,7 +2,7 @@
   import { createEventDispatcher, onMount } from 'svelte';
   import { getVersion } from '@tauri-apps/api/app';
   import TreeNode from './TreeNode.svelte';
-  import type { TreeNode as TNode, RequestLocation, FlowDefinition } from '../lib/types';
+  import type { TreeNode as TNode, RequestLocation, FlowDefinition, Favorite } from '../lib/types';
   import { getAllFileNodes } from '../lib/parser';
 
   let appVersion = '';
@@ -25,7 +25,7 @@
   export let activeFlowPath: string | null = null;
 
   // Favorites props
-  export let favorites: string[] = [];
+  export let favorites: Favorite[] = [];
   export let rootPath: string | null = null;
 
   const dispatch = createEventDispatcher();
@@ -42,7 +42,7 @@
   let showFavorites = false;
   let favBtnEl: HTMLButtonElement;
   let favMenuPos = { top: 0, left: 0 };
-  $: isFavorite = !!rootPath && favorites.includes(rootPath);
+  $: isFavorite = !!rootPath && favorites.some(f => f.path === rootPath);
 
   function toggleFavorites() {
     showFavorites = !showFavorites;
@@ -52,10 +52,6 @@
     }
   }
 
-  function favName(p: string): string {
-    const parts = p.split(/[\\/]/).filter(Boolean);
-    return parts[parts.length - 1] || p;
-  }
   function filterTree(nodes: TNode[], query: string): TNode[] {
     const q = query.toLowerCase();
     const result: TNode[] = [];
@@ -174,23 +170,23 @@
           {#if favorites.length === 0}
             <div class="favorites-empty">No favorites yet</div>
           {:else}
-            {#each favorites as path}
-              <div class="favorite-item" class:current={path === rootPath}>
+            {#each favorites as fav (fav.path)}
+              <div class="favorite-item" class:current={fav.path === rootPath}>
                 <!-- svelte-ignore a11y_no_static_element_interactions -->
                 <div
                   class="favorite-open"
-                  on:click={() => { dispatch('openFavorite', path); showFavorites = false; }}
-                  on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); dispatch('openFavorite', path); showFavorites = false; } }}
+                  on:click={() => { dispatch('openFavorite', fav.path); showFavorites = false; }}
+                  on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); dispatch('openFavorite', fav.path); showFavorites = false; } }}
                   role="button"
                   tabindex="0"
-                  title={path}
+                  title={fav.path}
                 >
-                  <span class="favorite-name">{favName(path)}</span>
-                  <span class="favorite-path">{path}</span>
+                  <span class="favorite-name">{fav.name}</span>
+                  <span class="favorite-path">{fav.path}</span>
                 </div>
                 <button
                   class="btn-remove-fav"
-                  on:click|stopPropagation={() => dispatch('removeFavorite', path)}
+                  on:click|stopPropagation={() => dispatch('removeFavorite', fav.path)}
                   title="Remove from favorites"
                 >&times;</button>
               </div>

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -2,7 +2,7 @@ import { writable, derived, get } from 'svelte/store';
 import type {
   HttpFile, HttpRequest, HttpResponse, Variable,
   EnvironmentFile, NamedRequestResult, PbAssertionResult,
-  Workspace, TreeNode, FileNode, FolderNode, RequestLocation,
+  Workspace, Favorite, TreeNode, FileNode, FolderNode, RequestLocation,
   FlowDefinition, FlowRunRecord, FlowRunStatus, FlowStepResult,
   KeyVaultState, VarSource, ResolvedVarWithCascade,
 } from './types';
@@ -20,8 +20,8 @@ export const workspace = writable<Workspace>({
 /** Currently selected request location (file path + request index). */
 export const selectedLocation = writable<RequestLocation | null>(null);
 
-/** Favorited workspace folder paths (absolute), in insertion order. Persisted in settings.json. */
-export const favorites = writable<string[]>([]);
+/** Favorited workspace folders with display names, in insertion order. Persisted in settings.json. */
+export const favorites = writable<Favorite[]>([]);
 
 /** The active response (from the last executed request). */
 export const currentResponse = writable<HttpResponse | null>(null);

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -5,6 +5,13 @@
 
 import { readTextFile, writeTextFile, mkdir } from '@tauri-apps/plugin-fs';
 import { appConfigDir, join } from '@tauri-apps/api/path';
+import type { Favorite } from './types';
+
+/** Derive a folder's display name from its absolute path (last path segment). */
+function pathBasename(p: string): string {
+  const parts = p.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] || p;
+}
 
 /** HTTP method color map using CSS variable references. */
 export const METHOD_COLORS: Record<string, string> = {
@@ -37,8 +44,11 @@ const SETTINGS_FILE = 'settings.json';
 
 interface Settings {
   theme?: ThemeId;
-  /** Absolute paths of favorited workspace folders, in insertion order. */
-  favorites?: string[];
+  /**
+   * Favorited workspace folders, in insertion order.
+   * Stored as `{ path, name }` objects. Legacy bare strings are migrated on load.
+   */
+  favorites?: (Favorite | string)[];
 }
 
 async function getSettingsPath(): Promise<string> {
@@ -93,17 +103,30 @@ export async function loadTheme(): Promise<ThemeId> {
 
 /* ---- Favorites ---- */
 
-/** Load the list of favorited workspace folder paths. */
-export async function loadFavorites(): Promise<string[]> {
+/** Load the list of favorited workspace folders, migrating legacy bare-string entries. */
+export async function loadFavorites(): Promise<Favorite[]> {
   const settings = await readSettings();
   const favorites = settings.favorites;
   if (!Array.isArray(favorites)) return [];
-  // Dedupe while preserving insertion order.
-  return [...new Set(favorites.filter((p): p is string => typeof p === 'string'))];
+  const result: Favorite[] = [];
+  const seen = new Set<string>();
+  for (const entry of favorites) {
+    // Legacy format: a bare path string. Migrate to { path, name: basename }.
+    const fav: Favorite | null =
+      typeof entry === 'string'
+        ? { path: entry, name: pathBasename(entry) }
+        : entry && typeof entry.path === 'string'
+          ? { path: entry.path, name: typeof entry.name === 'string' && entry.name ? entry.name : pathBasename(entry.path) }
+          : null;
+    if (!fav || seen.has(fav.path)) continue;
+    seen.add(fav.path);
+    result.push(fav);
+  }
+  return result;
 }
 
-/** Persist the list of favorited workspace folder paths. */
-export async function saveFavorites(favorites: string[]): Promise<void> {
+/** Persist the list of favorited workspace folders. */
+export async function saveFavorites(favorites: Favorite[]): Promise<void> {
   const settings = await readSettings();
   await writeSettings({ ...settings, favorites });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -88,6 +88,14 @@ export interface Workspace {
   tree: TreeNode[];
 }
 
+/** A favorited workspace folder with a user-chosen display name. */
+export interface Favorite {
+  /** Absolute path of the favorited workspace folder. Unique key. */
+  path: string;
+  /** User-chosen display name, shown instead of the folder basename. */
+  name: string;
+}
+
 // ─── Variables ──────────────────────────────────────────────────────────────
 
 export interface Variable {


### PR DESCRIPTION
## Summary

Adds a naming step when favoriting a folder. Clicking the star on a non-favorite folder now opens a modal to name the favorite. The custom name is shown instead of the folder basename in two places: the favorites dropdown list and the open-folder display in the sidebar.

## Changes

- **types**: add `Favorite { path, name }`
- **stores/theme**: favorites are stored as `{ path, name }` objects; `loadFavorites()` migrates legacy bare-string entries on load (name defaults to the folder basename) and dedupes by path
- **AddFavoriteModal** (new): rendered top-level in `App.svelte` so it overlays the window and cannot be clipped by the sidebar. Name input is prefilled with the basename and auto-selected; Enter saves, Esc/backdrop/Cancel aborts; an empty name falls back to the basename
- **App.svelte**: star toggles remove immediately, but add opens the modal (favorite is created only on confirm); `rootDisplayName` shows the favorite name when the open folder is favorited, else the basename
- **TreeSidebar**: favorites list renders `fav.name` + `fav.path`; removed the path-derived `favName()` helper

## Behavior notes

- Naming happens on add only; renaming an existing favorite is out of scope
- Duplicate names allowed (path is the unique key); removing a favorite reverts the open-folder display to the basename

## Verification

- `pnpm check` - 0 errors
- `pnpm test` - 239 passed