### PR TITLE
feat: persist window size/position and pane divider layout

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3063,6 +3063,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-opener",
+ "tauri-plugin-window-state",
  "tokio",
  "url",
  "uuid",
@@ -4358,6 +4359,21 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-http = "2"
+tauri-plugin-window-state = "2"
 reqwest = { version = "0.13", features = ["json", "stream"] }
 futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -229,6 +229,8 @@
       ]
     },
 
-    "http:default"
+    "http:default",
+
+    "window-state:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -385,6 +385,7 @@ async fn extract_getting_started(app_handle: tauri::AppHandle) -> Result<String,
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let mut builder = tauri::Builder::default()
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -134,9 +134,36 @@
     pendingImportVars = [];
   }
 
+  // ─── Layout persistence ───
+  // Pane/sidebar sizes are persisted to the webview's localStorage, which Tauri
+  // keeps across app restarts. Window size/position is handled separately by the
+  // tauri-plugin-window-state plugin (see src-tauri).
+
+  const LAYOUT_KEY_EDITOR_PCT = 'pb.layout.editorWidthPercent';
+  const LAYOUT_KEY_SIDEBAR_PX = 'pb.layout.sidebarWidth';
+
+  function loadLayoutNumber(key: string, fallback: number): number {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw === null) return fallback;
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  function saveLayoutNumber(key: string, value: number) {
+    try {
+      localStorage.setItem(key, String(value));
+    } catch {
+      // ignore (e.g. storage disabled) - persistence is best-effort
+    }
+  }
+
   // ─── Resizable Panes ───
 
-  let editorWidthPercent = 50;
+  let editorWidthPercent = loadLayoutNumber(LAYOUT_KEY_EDITOR_PCT, 50);
   let dragging = false;
   let mainPanelsEl: HTMLDivElement;
 
@@ -159,11 +186,12 @@
     dragging = false;
     document.removeEventListener('mousemove', onDividerMove);
     document.removeEventListener('mouseup', onDividerUp);
+    saveLayoutNumber(LAYOUT_KEY_EDITOR_PCT, editorWidthPercent);
   }
 
   // ─── Resizable Sidebar ───
 
-  let sidebarWidth = 260;
+  let sidebarWidth = loadLayoutNumber(LAYOUT_KEY_SIDEBAR_PX, 260);
   let sidebarDragging = false;
   let layoutEl: HTMLDivElement;
 
@@ -185,6 +213,7 @@
     sidebarDragging = false;
     document.removeEventListener('mousemove', onSidebarDividerMove);
     document.removeEventListener('mouseup', onSidebarDividerUp);
+    saveLayoutNumber(LAYOUT_KEY_SIDEBAR_PX, sidebarWidth);
   }
 
   // ─── Key Vault ───


### PR DESCRIPTION
## What

Window size, position, and maximized state, plus the pane divider and sidebar widths, now survive app restarts.

## Changes

**Window state** - added the official `tauri-plugin-window-state` plugin:
- `src-tauri/Cargo.toml` - new `tauri-plugin-window-state = "2"` dependency
- `src-tauri/src/lib.rs` - registered the plugin in the builder
- `src-tauri/capabilities/default.json` - added `window-state:default` permission

The plugin auto-saves window geometry on exit and restores it on launch. The `tauri.conf.json` 1280x800 now only applies on first run.

**Divider layout** - persisted to the webview `localStorage` in `src/App.svelte`:
- `editorWidthPercent` (editor/response split) and `sidebarWidth` initialize from `localStorage`, falling back to the prior 50% / 260px defaults
- Saved when a drag ends (`onDividerUp` / `onSidebarDividerUp`)
- All access is try/catch guarded so storage failures degrade gracefully

## Verification

- `cargo check` - clean
- `pnpm check` - 0 errors, 0 warnings

Manual: run `pnpm tauri dev`, resize the window and drag the dividers, close and reopen - state is restored.