### PR TITLE
fix: request execution and response fidelity

### DIFF
--- a/http-client.env.json.user
+++ b/http-client.env.json.user
@@ -1,9 +1,0 @@
-{
-  "dev": {
-    "Token": "my-personal-dev-token-OVERRIDE",
-    "UserId": "7"
-  },
-  "staging": {
-    "Token": "my-personal-staging-token-OVERRIDE"
-  }
-}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3053,6 +3053,7 @@ dependencies = [
  "axum",
  "azure_identity",
  "azure_security_keyvault_secrets",
+ "base64 0.22.1",
  "futures-util",
  "reqwest 0.13.4",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-http = "2"
 reqwest = { version = "0.13", features = ["json", "stream"] }
+base64 = "0.22"
 futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
 use std::time::Duration;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
 use futures_util::StreamExt;
@@ -26,6 +27,40 @@ struct HttpResponsePayload {
     status_text: String,
     headers: HashMap<String, String>,
     body: String,
+    /// "utf8" when `body` is the response text as-is, "base64" when the raw
+    /// bytes were not valid UTF-8 and `body` holds their base64 encoding.
+    body_encoding: String,
+    /// Byte length of the raw response body (before any base64 encoding).
+    size: usize,
+}
+
+/// Collect response headers into the map the frontend expects, joining
+/// repeated headers (e.g. multiple Set-Cookie) with ", " so no value is
+/// silently dropped.
+fn collect_headers(map: &reqwest::header::HeaderMap) -> HashMap<String, String> {
+    let mut headers: HashMap<String, String> = HashMap::new();
+    for (key, value) in map {
+        if let Ok(v) = value.to_str() {
+            headers
+                .entry(key.to_string())
+                .and_modify(|existing| {
+                    existing.push_str(", ");
+                    existing.push_str(v);
+                })
+                .or_insert_with(|| v.to_string());
+        }
+    }
+    headers
+}
+
+/// Encode a response body for the JSON bridge: valid UTF-8 passes through
+/// unchanged; binary bodies (images, gzip, protobuf) are base64-encoded so
+/// the bytes survive instead of being mangled by lossy conversion.
+fn encode_body(bytes: Vec<u8>) -> (String, &'static str) {
+    match String::from_utf8(bytes) {
+        Ok(text) => (text, "utf8"),
+        Err(err) => (BASE64_STANDARD.encode(err.as_bytes()), "base64"),
+    }
 }
 
 /// Check whether an IP address should be blocked even in a developer HTTP client.
@@ -199,12 +234,7 @@ async fn http_request(payload: HttpRequestPayload) -> Result<HttpResponsePayload
     let status = res.status().as_u16();
     let status_text = res.status().canonical_reason().unwrap_or("").to_string();
 
-    let mut headers = HashMap::new();
-    for (key, value) in res.headers() {
-        if let Ok(v) = value.to_str() {
-            headers.insert(key.to_string(), v.to_string());
-        }
-    }
+    let headers = collect_headers(res.headers());
 
     // Stream the response body with a size limit to prevent OOM from
     // malicious or unexpectedly large responses.
@@ -223,13 +253,16 @@ async fn http_request(payload: HttpRequestPayload) -> Result<HttpResponsePayload
             ));
         }
     }
-    let body = String::from_utf8_lossy(&body_bytes).to_string();
+    let size = body_bytes.len();
+    let (body, body_encoding) = encode_body(body_bytes);
 
     Ok(HttpResponsePayload {
         status,
         status_text,
         headers,
         body,
+        body_encoding: body_encoding.to_string(),
+        size,
     })
 }
 
@@ -542,6 +575,32 @@ mod tests {
     #[test]
     fn check_resolved_addrs_rejects_empty() {
         assert!(check_resolved_addrs(&[]).is_err());
+    }
+
+    #[test]
+    fn collect_headers_joins_duplicates() {
+        let mut map = reqwest::header::HeaderMap::new();
+        map.append("set-cookie", "a=1".parse().unwrap());
+        map.append("set-cookie", "b=2".parse().unwrap());
+        map.insert("content-type", "text/plain".parse().unwrap());
+        let headers = collect_headers(&map);
+        assert_eq!(headers.get("set-cookie").unwrap(), "a=1, b=2");
+        assert_eq!(headers.get("content-type").unwrap(), "text/plain");
+    }
+
+    #[test]
+    fn encode_body_passes_utf8_through() {
+        let (body, encoding) = encode_body("hello åäö".as_bytes().to_vec());
+        assert_eq!(body, "hello åäö");
+        assert_eq!(encoding, "utf8");
+    }
+
+    #[test]
+    fn encode_body_base64_encodes_binary() {
+        let bytes = vec![0xff, 0xd8, 0xff, 0xe0, 0x00];
+        let (body, encoding) = encode_body(bytes.clone());
+        assert_eq!(encoding, "base64");
+        assert_eq!(BASE64_STANDARD.decode(&body).unwrap(), bytes);
     }
 
     #[tokio::test]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -35,7 +35,7 @@
   import {
     serializeHttpFile, substituteAll, parseEnvironmentFile, ensureSharedEnvironment,
     buildWorkspaceTree, createFileNode, createEmptyFileNode, getAllFileNodes,
-    executePbDirectives, parseScriptText, applyRequestMutations, resolveEnvironmentVariables,
+    resolveEnvironmentVariables,
   } from './lib/parser';
   import type { SubstitutionContext } from './lib/parser';
   import { importPostmanCollection } from './lib/postman';
@@ -47,6 +47,8 @@
   import { scanForFlowFiles, loadFlowHistory, saveFlowRunRecord, clearFlowRunHistory, parseFlowFile, FLOWS_DIR, migrateFlowsDirectory } from './lib/flowIO';
   import { generateFolderName } from './lib/folderCreate';
   import { runFlow } from './lib/flowRunner';
+  import { executeHttpRequest } from './lib/requestExec';
+  import type { PbVarEffects } from './lib/requestExec';
   import type { FlowStepResult, FlowRunRecord } from './lib/types';
 
   import { open } from '@tauri-apps/plugin-dialog';
@@ -337,81 +339,17 @@
       dotenvVariables: get(dotenvVariables),
     };
 
-    const startTime = performance.now();
-    let url = substituteAll(request.url, ctx);
-    let body = substituteAll(request.body, ctx);
-    let headers: Record<string, string> = {};
-    for (const h of request.headers) {
-      if (h.enabled) headers[substituteAll(h.key, ctx)] = substituteAll(h.value, ctx);
-    }
-
-    // beforeSend scripts — runtime vars stay local and never reach the stores.
-    const localEnvOverrides: Record<string, string> = {};
-    const localGlobals: Record<string, string> = {};
-    const beforeSendDirectives = parseScriptText(request.beforeSend ?? '');
-    if (beforeSendDirectives.length > 0) {
-      const mergedVars: Record<string, string> = { ...ctx.environmentVariables };
-      for (const v of ctx.fileVariables) mergedVars[v.key] = v.value;
-      const dummyResponse: HttpResponse = { status: 0, statusText: '', headers: {}, body: '', time: 0, size: 0 };
-      const bsResult = executePbDirectives(
-        beforeSendDirectives, dummyResponse,
-        { url, method: request.method, headers, body },
-        mergedVars, ctx.namedResults,
-      );
-      const mutated = applyRequestMutations(
-        { url, method: request.method, headers, body },
-        bsResult.requestMutations,
-      );
-      url = mutated.url;
-      headers = mutated.headers;
-      body = mutated.body;
-      Object.assign(localEnvOverrides, bsResult.setVars);
-      Object.assign(localGlobals, bsResult.globalVars);
-      Object.assign(localEnvOverrides, bsResult.globalVars);
-    }
-
-    const sentRequest = { method: request.method, url, headers, body };
-    const res: { status: number; status_text: string; headers: Record<string, string>; body: string } =
-      await invoke('http_request', {
-        payload: {
-          method: request.method,
-          url,
-          headers,
-          body: ['GET', 'HEAD', 'OPTIONS'].includes(request.method) ? null : body || null,
-        },
-      });
-
-    const elapsed = performance.now() - startTime;
-    const response: HttpResponse = {
-      status: res.status,
-      statusText: res.status_text,
-      headers: res.headers,
-      body: res.body,
-      time: Math.round(elapsed),
-      size: new TextEncoder().encode(res.body).length,
-    };
-
-    // pb directives + afterReceive scripts — assertion results only; no store writes.
-    const afterReceiveDirectives = parseScriptText(request.afterReceive ?? '');
-    const allDirectives = [
-      ...(request.directives || []).filter((d) => d.enabled !== false),
-      ...afterReceiveDirectives,
-    ];
-    let assertionResults: PbAssertionResult[] = [];
-    if (allDirectives.length > 0) {
-      const mergedVars: Record<string, string> = { ...ctx.environmentVariables, ...localEnvOverrides, ...localGlobals };
-      for (const v of ctx.fileVariables) mergedVars[v.key] = v.value;
-      const pbResult = executePbDirectives(allDirectives, response, sentRequest, mergedVars, ctx.namedResults);
-      assertionResults = pbResult.assertionResults;
-    }
+    // All pb effects (set/global vars, named result) stay in the returned
+    // locals and are discarded - a silent run never reaches the stores.
+    const result = await executeHttpRequest(request, ctx, { alias: request.varName });
 
     return {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-      body: response.body,
-      time: response.time,
-      assertions: assertionResults.map((a) => ({ label: a.label, passed: a.passed })),
+      status: result.response.status,
+      statusText: result.response.statusText,
+      headers: result.response.headers,
+      body: result.response.body,
+      time: result.response.time,
+      assertions: result.assertionResults.map((a) => ({ label: a.label, passed: a.passed })),
     };
   }
 
@@ -1007,6 +945,20 @@
 
   // ─── Send Request ───
 
+  /** Commit pb.set (file-scoped) and pb.global effects from a manual send to the stores. */
+  function commitPbVars(effects: PbVarEffects) {
+    if (Object.keys(effects.setVars).length > 0 && $selectedLocation) {
+      const filePath = $selectedLocation.filePath;
+      pbFileOverrides.update(ev => ({
+        ...ev,
+        [filePath]: { ...(ev[filePath] ?? {}), ...effects.setVars },
+      }));
+    }
+    if (Object.keys(effects.globalVars).length > 0) {
+      pbGlobals.update(g => ({ ...g, ...effects.globalVars }));
+    }
+  }
+
   async function sendRequest(request: HttpRequest) {
     isLoading.set(true);
     currentResponse.set(null);
@@ -1017,127 +969,21 @@
     const startTime = performance.now();
 
     try {
-      let url = substituteAll(request.url, ctx);
-      let body = substituteAll(request.body, ctx);
-      let headers: Record<string, string> = {};
-      for (const h of request.headers) {
-        if (h.enabled) {
-          headers[substituteAll(h.key, ctx)] = substituteAll(h.value, ctx);
-        }
+      const result = await executeHttpRequest(request, ctx, {
+        alias: request.varName,
+        onBeforeInvoke(sent, beforeSend) {
+          currentSentRequest.set(sent);
+          commitPbVars(beforeSend);
+        },
+      });
+
+      currentResponse.set(result.response);
+      if (result.namedResult) {
+        const { name, result: named } = result.namedResult;
+        namedResults.update(nr => ({ ...nr, [name]: named }));
       }
-
-      // ── Execute beforeSend scripts ──
-      const beforeSendDirectives = parseScriptText(request.beforeSend ?? '');
-      if (beforeSendDirectives.length > 0) {
-        const mergedVars: Record<string, string> = { ...$resolvedEnvVars, ...$pbGlobals };
-        for (const v of $activeFileVariables) mergedVars[v.key] = v.value;
-
-        const dummyResponse = { status: 0, statusText: '', headers: {}, body: '', time: 0, size: 0 };
-        const bsResult = executePbDirectives(
-          beforeSendDirectives, dummyResponse,
-          { url, method: request.method, headers, body },
-          mergedVars, $namedResults,
-        );
-
-        // Apply request mutations
-        const mutated = applyRequestMutations(
-          { url, method: request.method, headers, body },
-          bsResult.requestMutations,
-        );
-        url = mutated.url;
-        headers = mutated.headers;
-        body = mutated.body;
-
-        // Apply set vars from beforeSend (file-scoped)
-        if (Object.keys(bsResult.setVars).length > 0) {
-          const filePath = $selectedLocation!.filePath;
-          pbFileOverrides.update(ev => ({
-            ...ev,
-            [filePath]: { ...(ev[filePath] ?? {}), ...bsResult.setVars },
-          }));
-        }
-        if (Object.keys(bsResult.globalVars).length > 0) {
-          pbGlobals.update(g => ({ ...g, ...bsResult.globalVars }));
-        }
-      }
-
-      currentSentRequest.set({ method: request.method, url, headers, body });
-
-      const res: { status: number; status_text: string; headers: Record<string, string>; body: string } =
-        await invoke('http_request', {
-          payload: {
-            method: request.method,
-            url,
-            headers,
-            body: ['GET','HEAD','OPTIONS'].includes(request.method) ? null : body || null,
-          },
-        });
-
-      const elapsed = performance.now() - startTime;
-
-      const response: HttpResponse = {
-        status: res.status,
-        statusText: res.status_text,
-        headers: res.headers,
-        body: res.body,
-        time: Math.round(elapsed),
-        size: new TextEncoder().encode(res.body).length,
-      };
-      currentResponse.set(response);
-
-      if (request.varName) {
-        namedResults.update(nr => ({
-          ...nr,
-          [request.varName!]: {
-            request: { url, method: request.method, headers, body },
-            response,
-          },
-        }));
-      }
-
-      // ── Execute pb directives + afterReceive scripts ──
-      const afterReceiveDirectives = parseScriptText(request.afterReceive ?? '');
-      const allDirectives = [...(request.directives || []), ...afterReceiveDirectives];
-      if (allDirectives.length > 0) {
-        const mergedVars: Record<string, string> = { ...$resolvedEnvVars, ...$pbGlobals };
-        for (const v of $activeFileVariables) mergedVars[v.key] = v.value;
-
-        const pbResult = executePbDirectives(
-          allDirectives, response,
-          { url, method: request.method, headers, body },
-          mergedVars,
-          $namedResults,
-        );
-
-        pbAssertionResults.set(pbResult.assertionResults);
-
-        // Apply set vars as named results so {{key}} resolves in later requests
-        if (Object.keys(pbResult.setVars).length > 0) {
-          namedResults.update(nr => {
-            const updated = { ...nr };
-            for (const [key, value] of Object.entries(pbResult.setVars)) {
-              // Store as a pseudo named result so substituteAll can pick it up.
-              // We also inject into env vars for simpler resolution.
-              updated[`__pb_${key}`] = {
-                request: { url, method: request.method, headers, body },
-                response,
-              };
-            }
-            return updated;
-          });
-          // Inject set vars into file-scoped overrides so {{key}} works in this file
-          const filePath = $selectedLocation!.filePath;
-          pbFileOverrides.update(ev => ({
-            ...ev,
-            [filePath]: { ...(ev[filePath] ?? {}), ...pbResult.setVars },
-          }));
-        }
-
-        // Apply global vars (workspace-scoped)
-        if (Object.keys(pbResult.globalVars).length > 0) {
-          pbGlobals.update(g => ({ ...g, ...pbResult.globalVars }));
-        }
-      }
+      pbAssertionResults.set(result.assertionResults);
+      commitPbVars(result.afterReceive);
     } catch (e: any) {
       currentResponse.set({
         status: 0, statusText: 'Error', headers: {},

--- a/src/components/ImportCollectionModal.svelte
+++ b/src/components/ImportCollectionModal.svelte
@@ -5,6 +5,7 @@
   import { readTextFile } from '@tauri-apps/plugin-fs';
   import { basename } from '@tauri-apps/api/path';
   import { detectImportFormat, formatLabel, type ImportFormat } from '../lib/detect';
+  import type { HttpInvokeResult } from '../lib/requestExec';
 
   export let visible: boolean = false;
 
@@ -162,7 +163,7 @@
     urlError = '';
 
     try {
-      const res: { status: number; status_text: string; headers: Record<string, string>; body: string } =
+      const res: HttpInvokeResult =
         await invoke('http_request', {
           payload: {
             method: 'GET',
@@ -174,6 +175,11 @@
 
       if (res.status >= 400) {
         urlError = `Server returned ${res.status} ${res.status_text}`;
+        return;
+      }
+
+      if (res.body_encoding === 'base64') {
+        urlError = 'URL returned binary content, not a text spec';
         return;
       }
 

--- a/src/components/ResponseViewer.svelte
+++ b/src/components/ResponseViewer.svelte
@@ -18,6 +18,9 @@
 
   $: passedCount = assertionResults.filter(t => t.passed).length;
   $: failedCount = assertionResults.filter(t => !t.passed).length;
+  // Binary bodies arrive base64-encoded from the backend; show a notice
+  // instead of the (useless) base64 text.
+  $: isBinaryBody = response?.bodyEncoding === 'base64';
 
   function getStatusClass(status: number): string {
     if (status >= 200 && status < 300) return 'status-success';
@@ -117,8 +120,10 @@
         on:click={() => setTab('body')}
       >
         Body
-        {#if isJson(response.body)}
+        {#if !isBinaryBody && isJson(response.body)}
           <span class="tab-badge">JSON</span>
+        {:else if isBinaryBody}
+          <span class="tab-badge">Binary</span>
         {/if}
       </button>
       <button
@@ -155,7 +160,13 @@
     <!-- Content -->
     <div class="content">
       {#if activeTab === 'body'}
-        <pre class="body-output" class:json={isJson(response.body)}>{formatBody(response.body)}</pre>
+        {#if isBinaryBody}
+          <div class="binary-note">
+            Binary response body ({formatSize(response.size)}). Text preview is not available.
+          </div>
+        {:else}
+          <pre class="body-output" class:json={isJson(response.body)}>{formatBody(response.body)}</pre>
+        {/if}
       {:else if activeTab === 'headers'}
         <div class="headers-table">
           {#each Object.entries(response.headers) as [key, value]}
@@ -411,6 +422,16 @@
     color: var(--zinc-300);
     font-size: var(--text-base);
     background: var(--color-bg-surface);
+  }
+
+  .binary-note {
+    padding: var(--space-5);
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: var(--text-base);
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-divider);
+    border-radius: var(--radius-lg);
   }
 
   /* Assertion Results */

--- a/src/components/VariableInspector.svelte
+++ b/src/components/VariableInspector.svelte
@@ -79,7 +79,7 @@
   );
   $: overrideEntries = Object.entries(pbOverrides).filter(([k]) => !(k in pbGlobals));
   $: globalEntries = Object.entries(pbGlobals);
-  $: namedEntries = Object.entries(namedResults).filter(([k]) => !k.startsWith('__pb_'));
+  $: namedEntries = Object.entries(namedResults);
 
   $: runtimeCount = overrideEntries.length + globalEntries.length + namedEntries.length;
   $: hasRuntime = runtimeCount > 0;

--- a/src/lib/flowRunner.ts
+++ b/src/lib/flowRunner.ts
@@ -1,6 +1,6 @@
-import { invoke } from '@tauri-apps/api/core';
-import { substituteAll, executePbDirectives, getAllFileNodes, parseScriptText, applyRequestMutations } from './parser';
+import { getAllFileNodes } from './parser';
 import type { SubstitutionContext } from './parser';
+import { executeHttpRequest } from './requestExec';
 import type {
   FlowDefinition, FlowStep, FlowStepResult, FlowStepStatus,
   FlowRunRecord, FlowRunStatus,
@@ -152,103 +152,25 @@ async function executeStep(
   const startTime = performance.now();
 
   try {
-    let url = substituteAll(request.url, ctx);
-    let body = substituteAll(request.body, ctx);
-    let headers: Record<string, string> = {};
-    for (const h of request.headers) {
-      if (h.enabled) {
-        headers[substituteAll(h.key, ctx)] = substituteAll(h.value, ctx);
-      }
+    // The flow step's alias (if any) wins over the underlying request's
+    // `# @name`, so flows can name responses independently of .http files.
+    const result = await executeHttpRequest(request, ctx, {
+      alias: effectiveAlias,
+      onBeforeInvoke(_sent, beforeSend) {
+        Object.assign(localEnvOverrides, beforeSend.setVars);
+        Object.assign(localGlobals, beforeSend.globalVars);
+        Object.assign(localEnvOverrides, beforeSend.globalVars);
+      },
+    });
+
+    if (result.namedResult) {
+      localNamedResults[result.namedResult.name] = result.namedResult.result;
     }
+    Object.assign(localEnvOverrides, result.afterReceive.setVars);
+    Object.assign(localGlobals, result.afterReceive.globalVars);
+    Object.assign(localEnvOverrides, result.afterReceive.globalVars);
 
-    // Execute beforeSend scripts
-    const beforeSendDirectives = parseScriptText(request.beforeSend ?? '');
-    if (beforeSendDirectives.length > 0) {
-      const mergedVars: Record<string, string> = { ...ctx.environmentVariables };
-      for (const v of ctx.fileVariables) mergedVars[v.key] = v.value;
-
-      const dummyResponse: HttpResponse = { status: 0, statusText: '', headers: {}, body: '', time: 0, size: 0 };
-      const bsResult = executePbDirectives(
-        beforeSendDirectives, dummyResponse,
-        { url, method: request.method, headers, body },
-        mergedVars, localNamedResults,
-      );
-
-      const mutated = applyRequestMutations(
-        { url, method: request.method, headers, body },
-        bsResult.requestMutations,
-      );
-      url = mutated.url;
-      headers = mutated.headers;
-      body = mutated.body;
-
-      if (Object.keys(bsResult.setVars).length > 0) {
-        Object.assign(localEnvOverrides, bsResult.setVars);
-      }
-      if (Object.keys(bsResult.globalVars).length > 0) {
-        Object.assign(localGlobals, bsResult.globalVars);
-        Object.assign(localEnvOverrides, bsResult.globalVars);
-      }
-    }
-
-    const sentRequest = { method: request.method, url, headers, body };
-
-    const res: { status: number; status_text: string; headers: Record<string, string>; body: string } =
-      await invoke('http_request', {
-        payload: {
-          method: request.method,
-          url,
-          headers,
-          body: ['GET', 'HEAD', 'OPTIONS'].includes(request.method) ? null : body || null,
-        },
-      });
-
-    const elapsed = performance.now() - startTime;
-
-    const response: HttpResponse = {
-      status: res.status,
-      statusText: res.status_text,
-      headers: res.headers,
-      body: res.body,
-      time: Math.round(elapsed),
-      size: new TextEncoder().encode(res.body).length,
-    };
-
-    // Store named result for chaining. The flow step's alias (if any) wins over the
-    // underlying request's `# @name`, so flows can name responses independently of .http files.
-    if (effectiveAlias) {
-      localNamedResults[effectiveAlias] = { request: sentRequest, response };
-    }
-
-    // Execute pb directives + afterReceive scripts
-    const afterReceiveDirectives = parseScriptText(request.afterReceive ?? '');
-    const allDirectives = [
-      ...(request.directives || []).filter(d => d.enabled !== false),
-      ...afterReceiveDirectives,
-    ];
-
-    let assertionResults: PbAssertionResult[] = [];
-    if (allDirectives.length > 0) {
-      const mergedVars: Record<string, string> = { ...ctx.environmentVariables };
-      for (const v of ctx.fileVariables) mergedVars[v.key] = v.value;
-
-      const pbResult = executePbDirectives(
-        allDirectives, response, sentRequest, mergedVars, localNamedResults,
-      );
-
-      assertionResults = pbResult.assertionResults;
-
-      // Apply set vars
-      if (Object.keys(pbResult.setVars).length > 0) {
-        Object.assign(localEnvOverrides, pbResult.setVars);
-      }
-
-      // Apply global vars
-      if (Object.keys(pbResult.globalVars).length > 0) {
-        Object.assign(localGlobals, pbResult.globalVars);
-        Object.assign(localEnvOverrides, pbResult.globalVars);
-      }
-    }
+    const { response, sentRequest, assertionResults } = result;
 
     // Determine pass/fail
     const allAssertionsPassed = assertionResults.length === 0 || assertionResults.every(a => a.passed);
@@ -261,7 +183,7 @@ async function executeStep(
       response,
       sentRequest,
       assertionResults,
-      durationMs: Math.round(elapsed),
+      durationMs: Math.round(performance.now() - startTime),
       error: null,
     };
   } catch (e: any) {

--- a/src/lib/requestExec.test.ts
+++ b/src/lib/requestExec.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { executeHttpRequest } from './requestExec';
+import type { HttpInvokeResult } from './requestExec';
+import type { SubstitutionContext } from './parser';
+import type { HttpRequest } from './types';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+import { invoke } from '@tauri-apps/api/core';
+const invokeMock = vi.mocked(invoke);
+
+function makeRequest(overrides: Partial<HttpRequest> = {}): HttpRequest {
+  return {
+    id: 'r1',
+    name: 'Test request',
+    varName: null,
+    method: 'GET',
+    url: 'https://example.com/api',
+    headers: [],
+    body: '',
+    directives: [],
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: Partial<SubstitutionContext> = {}): SubstitutionContext {
+  return {
+    fileVariables: [],
+    environmentVariables: {},
+    namedResults: {},
+    dotenvVariables: {},
+    ...overrides,
+  };
+}
+
+function mockResponse(overrides: Partial<HttpInvokeResult> = {}): void {
+  invokeMock.mockResolvedValueOnce({
+    status: 200,
+    status_text: 'OK',
+    headers: { 'content-type': 'application/json' },
+    body: '{"id": 7}',
+    body_encoding: 'utf8',
+    size: 9,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+describe('executeHttpRequest', () => {
+  it('substitutes variables into url, headers, and body', async () => {
+    mockResponse();
+    const request = makeRequest({
+      method: 'POST',
+      url: '{{baseUrl}}/users',
+      headers: [
+        { key: 'Authorization', value: 'Bearer {{token}}', enabled: true },
+        { key: 'X-Disabled', value: 'nope', enabled: false },
+      ],
+      body: '{"name": "{{userName}}"}',
+    });
+    const ctx = makeCtx({
+      environmentVariables: { baseUrl: 'https://api.test', token: 'abc123' },
+      fileVariables: [{ key: 'userName', value: 'mikael' }],
+    });
+
+    const result = await executeHttpRequest(request, ctx);
+
+    expect(result.sentRequest.url).toBe('https://api.test/users');
+    expect(result.sentRequest.headers).toEqual({ Authorization: 'Bearer abc123' });
+    expect(result.sentRequest.body).toBe('{"name": "mikael"}');
+    expect(invokeMock).toHaveBeenCalledWith('http_request', {
+      payload: {
+        method: 'POST',
+        url: 'https://api.test/users',
+        headers: { Authorization: 'Bearer abc123' },
+        body: '{"name": "mikael"}',
+      },
+    });
+  });
+
+  it('sends null body for bodyless methods', async () => {
+    mockResponse();
+    await executeHttpRequest(makeRequest({ method: 'GET', body: 'ignored' }), makeCtx());
+    expect(invokeMock.mock.calls[0][1]).toMatchObject({ payload: { body: null } });
+  });
+
+  it('skips directives the user has disabled', async () => {
+    mockResponse();
+    const request = makeRequest({
+      directives: [
+        { type: 'assert', expr: 'pb.response.status == 500', label: 'disabled assert', enabled: false },
+        { type: 'set', key: 'userId', expr: 'pb.response.body.$.id', enabled: false },
+      ],
+    });
+
+    const result = await executeHttpRequest(request, makeCtx());
+
+    expect(result.assertionResults).toEqual([]);
+    expect(result.afterReceive.setVars).toEqual({});
+  });
+
+  it('runs enabled directives and returns their effects without mutating the context', async () => {
+    mockResponse();
+    const ctx = makeCtx();
+    const request = makeRequest({
+      directives: [
+        { type: 'assert', expr: 'pb.response.status == 200', label: 'status ok' },
+        { type: 'set', key: 'userId', expr: 'pb.response.body.$.id' },
+        { type: 'global', key: 'lastStatus', expr: 'pb.response.status' },
+      ],
+    });
+
+    const result = await executeHttpRequest(request, ctx);
+
+    expect(result.assertionResults).toEqual([{ label: 'status ok', passed: true }]);
+    expect(result.afterReceive.setVars).toEqual({ userId: '7' });
+    expect(result.afterReceive.globalVars).toEqual({ lastStatus: '200' });
+    expect(ctx.environmentVariables).toEqual({});
+    expect(ctx.namedResults).toEqual({});
+  });
+
+  it('returns a named result for the alias without mutating the caller map', async () => {
+    mockResponse();
+    const ctx = makeCtx();
+    const result = await executeHttpRequest(makeRequest(), ctx, { alias: 'login' });
+
+    expect(result.namedResult?.name).toBe('login');
+    expect(result.namedResult?.result.response.status).toBe(200);
+    expect(ctx.namedResults).toEqual({});
+  });
+
+  it('lets directives reference the request\'s own alias', async () => {
+    mockResponse();
+    const request = makeRequest({
+      directives: [
+        { type: 'assert', expr: '{{login.response.body.$.id}} == 7', label: 'own alias resolves' },
+      ],
+    });
+
+    const result = await executeHttpRequest(request, makeCtx(), { alias: 'login' });
+
+    expect(result.assertionResults).toEqual([{ label: 'own alias resolves', passed: true }]);
+  });
+
+  it('applies beforeSend mutations and reports beforeSend vars via onBeforeInvoke', async () => {
+    mockResponse();
+    const request = makeRequest({
+      beforeSend: 'pb.set("request.header.X-Trace", "trace-1")\npb.set("runId", "42")',
+    });
+    const seen: Array<{ headers: Record<string, string>; setVars: Record<string, string> }> = [];
+
+    const result = await executeHttpRequest(request, makeCtx(), {
+      onBeforeInvoke(sent, beforeSend) {
+        seen.push({ headers: sent.headers, setVars: beforeSend.setVars });
+      },
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].headers['X-Trace']).toBe('trace-1');
+    expect(seen[0].setVars).toEqual({ runId: '42' });
+    expect(result.sentRequest.headers['X-Trace']).toBe('trace-1');
+    expect(result.beforeSend.setVars).toEqual({ runId: '42' });
+  });
+
+  it('passes through binary body metadata from the backend', async () => {
+    mockResponse({ body: 'AAEC/w==', body_encoding: 'base64', size: 4 });
+
+    const result = await executeHttpRequest(makeRequest(), makeCtx());
+
+    expect(result.response.bodyEncoding).toBe('base64');
+    expect(result.response.body).toBe('AAEC/w==');
+    expect(result.response.size).toBe(4);
+  });
+
+  it('defaults to utf8 and computed size when the backend omits the new fields', async () => {
+    invokeMock.mockResolvedValueOnce({
+      status: 200,
+      status_text: 'OK',
+      headers: {},
+      body: 'hello',
+    });
+
+    const result = await executeHttpRequest(makeRequest(), makeCtx());
+
+    expect(result.response.bodyEncoding).toBe('utf8');
+    expect(result.response.size).toBe(5);
+  });
+
+  it('propagates network failures to the caller', async () => {
+    invokeMock.mockRejectedValueOnce('Connection failed - check that the server is reachable');
+    await expect(executeHttpRequest(makeRequest(), makeCtx())).rejects.toBe(
+      'Connection failed - check that the server is reachable',
+    );
+  });
+});

--- a/src/lib/requestExec.ts
+++ b/src/lib/requestExec.ts
@@ -1,0 +1,178 @@
+import { invoke } from '@tauri-apps/api/core';
+import { substituteAll, executePbDirectives, parseScriptText, applyRequestMutations } from './parser';
+import type { SubstitutionContext } from './parser';
+import type { HttpRequest, HttpResponse, PbAssertionResult, NamedRequestResult } from './types';
+
+// ─── Shared request execution pipeline ───────────────────────────────────────
+// Single implementation of the substitute -> beforeSend -> http_request ->
+// afterReceive sequence used by the manual send (App.svelte), the MCP bridge's
+// silent execution (App.svelte), and the flow runner (flowRunner.ts). The
+// executor is pure with respect to stores: every side effect (variables set by
+// pb directives, the named result for chaining) is returned to the caller,
+// which decides how to commit it.
+
+/** The fully-resolved request that was actually sent over the wire. */
+export interface SentRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/** Raw payload returned by the Rust `http_request` command. */
+export interface HttpInvokeResult {
+  status: number;
+  status_text: string;
+  headers: Record<string, string>;
+  body: string;
+  /** "utf8" for text bodies; "base64" when the raw bytes were not valid UTF-8. */
+  body_encoding?: 'utf8' | 'base64';
+  /** Byte length of the raw response body. */
+  size?: number;
+}
+
+/** Variables produced by pb directives during one phase of execution. */
+export interface PbVarEffects {
+  /** File-scoped variables from `pb.set` (flow-local overrides in a flow run). */
+  setVars: Record<string, string>;
+  /** Workspace-global variables from `pb.global`. */
+  globalVars: Record<string, string>;
+}
+
+export interface ExecutedRequest {
+  sentRequest: SentRequest;
+  response: HttpResponse;
+  assertionResults: PbAssertionResult[];
+  /** Variables set by beforeSend scripts. */
+  beforeSend: PbVarEffects;
+  /** Variables set by request directives and afterReceive scripts. */
+  afterReceive: PbVarEffects;
+  /** Named result for request chaining when an alias was provided. */
+  namedResult: { name: string; result: NamedRequestResult } | null;
+}
+
+export interface ExecuteOptions {
+  /** Alias under which the result is exposed for chaining. Flow steps pass the
+   *  step alias; the manual send passes the request's `# @name`. The alias entry
+   *  is visible to this request's own directives but committing it to shared
+   *  state is the caller's job (via `namedResult`). */
+  alias?: string | null;
+  /** Called with the fully-resolved request and beforeSend variable effects just
+   *  before the network call, so callers can surface or commit them early. */
+  onBeforeInvoke?(sent: SentRequest, beforeSend: PbVarEffects): void;
+}
+
+/** Methods that must not carry a request body. */
+const BODYLESS_METHODS = ['GET', 'HEAD', 'OPTIONS'];
+
+function mergeVars(ctx: SubstitutionContext, ...overrides: Record<string, string>[]): Record<string, string> {
+  const merged: Record<string, string> = Object.assign({ ...ctx.environmentVariables }, ...overrides);
+  for (const v of ctx.fileVariables) merged[v.key] = v.value;
+  return merged;
+}
+
+/**
+ * Execute a single HTTP request end to end: variable substitution, beforeSend
+ * scripts (with request mutations), the actual network call via the Rust
+ * proxy, and pb directives + afterReceive scripts against the response.
+ *
+ * Only directives with `enabled !== false` run - a directive the user toggled
+ * off in the UI never executes, in any execution path.
+ *
+ * Throws on network-level failure (the `http_request` invoke rejecting);
+ * callers translate that into their own error shape.
+ */
+export async function executeHttpRequest(
+  request: HttpRequest,
+  ctx: SubstitutionContext,
+  options: ExecuteOptions = {},
+): Promise<ExecutedRequest> {
+  const startTime = performance.now();
+
+  let url = substituteAll(request.url, ctx);
+  let body = substituteAll(request.body, ctx);
+  let headers: Record<string, string> = {};
+  for (const h of request.headers) {
+    if (h.enabled) {
+      headers[substituteAll(h.key, ctx)] = substituteAll(h.value, ctx);
+    }
+  }
+
+  // Directives can chain against existing named results; the alias entry for
+  // this request is added after the response arrives. Work on a copy so the
+  // caller's map is never mutated.
+  const namedResults: Record<string, NamedRequestResult> = { ...ctx.namedResults };
+
+  // ── beforeSend scripts ──
+  const beforeSend: PbVarEffects = { setVars: {}, globalVars: {} };
+  const beforeSendDirectives = parseScriptText(request.beforeSend ?? '');
+  if (beforeSendDirectives.length > 0) {
+    const dummyResponse: HttpResponse = { status: 0, statusText: '', headers: {}, body: '', time: 0, size: 0 };
+    const bsResult = executePbDirectives(
+      beforeSendDirectives, dummyResponse,
+      { url, method: request.method, headers, body },
+      mergeVars(ctx), namedResults,
+    );
+
+    const mutated = applyRequestMutations(
+      { url, method: request.method, headers, body },
+      bsResult.requestMutations,
+    );
+    url = mutated.url;
+    headers = mutated.headers;
+    body = mutated.body;
+
+    Object.assign(beforeSend.setVars, bsResult.setVars);
+    Object.assign(beforeSend.globalVars, bsResult.globalVars);
+  }
+
+  const sentRequest: SentRequest = { method: request.method, url, headers, body };
+  options.onBeforeInvoke?.(sentRequest, beforeSend);
+
+  const res: HttpInvokeResult = await invoke('http_request', {
+    payload: {
+      method: request.method,
+      url,
+      headers,
+      body: BODYLESS_METHODS.includes(request.method) ? null : body || null,
+    },
+  });
+
+  const elapsed = performance.now() - startTime;
+  const response: HttpResponse = {
+    status: res.status,
+    statusText: res.status_text,
+    headers: res.headers,
+    body: res.body,
+    bodyEncoding: res.body_encoding ?? 'utf8',
+    time: Math.round(elapsed),
+    size: res.size ?? new TextEncoder().encode(res.body).length,
+  };
+
+  // Store the alias entry before running directives so a request's own
+  // directives can reference its response by name.
+  let namedResult: ExecutedRequest['namedResult'] = null;
+  if (options.alias) {
+    namedResult = { name: options.alias, result: { request: sentRequest, response } };
+    namedResults[options.alias] = namedResult.result;
+  }
+
+  // ── pb directives + afterReceive scripts ──
+  const afterReceive: PbVarEffects = { setVars: {}, globalVars: {} };
+  let assertionResults: PbAssertionResult[] = [];
+  const allDirectives = [
+    ...(request.directives || []).filter((d) => d.enabled !== false),
+    ...parseScriptText(request.afterReceive ?? ''),
+  ];
+  if (allDirectives.length > 0) {
+    const pbResult = executePbDirectives(
+      allDirectives, response, sentRequest,
+      mergeVars(ctx, beforeSend.setVars, beforeSend.globalVars), namedResults,
+    );
+    assertionResults = pbResult.assertionResults;
+    Object.assign(afterReceive.setVars, pbResult.setVars);
+    Object.assign(afterReceive.globalVars, pbResult.globalVars);
+  }
+
+  return { sentRequest, response, assertionResults, beforeSend, afterReceive, namedResult };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,6 +36,9 @@ export interface HttpResponse {
   statusText: string;
   headers: Record<string, string>;
   body: string;
+  /** "utf8" (default) when `body` is response text; "base64" when the raw
+   *  bytes were not valid UTF-8 and `body` holds their base64 encoding. */
+  bodyEncoding?: 'utf8' | 'base64';
   time: number;
   size: number;
 }


### PR DESCRIPTION
## Summary

First batch of fixes from the 2026-07-07 project review (items 1, 2, 3, 8, 9 in docs/plans/review-remediation.md):

- Disabled pb directives no longer run on manual send; manual send, flow runner, and MCP bridge now share one executor (`src/lib/requestExec.ts`)
- Duplicate response headers are preserved (joined with ", ") instead of collapsed
- Binary response bodies are returned base64-encoded with a `body_encoding` flag instead of being mangled by lossy UTF-8 conversion
- `http-client.env.json.user` untracked (already gitignored)

## Test plan

- `pnpm check`, `pnpm test` green (includes new `requestExec.test.ts`)
- `cargo check` green; Rust tests run in CI (local cargo test broken on this machine, pre-existing)