### PR TITLE
ci: run on pushes to develop/main and add windows/macos cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [develop, main]
   pull_request:
     branches: [develop, main]
 
@@ -50,3 +52,25 @@ jobs:
 
       - name: Rust tests
         run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  # Compile-only on the other release platforms; tests stay on ubuntu.
+  rust-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Rust check
+        run: cargo check --manifest-path src-tauri/Cargo.toml


### PR DESCRIPTION
## Summary
- Add a `push` trigger for `develop` and `main` so the README's `?branch=develop` badge resolves (the workflow previously only ran on pull requests, so no push runs existed for the badge to point at)
- Add a `rust-check` matrix job that compile-checks the Rust backend (`cargo check`) on `windows-latest` and `macos-latest`, matching the release platforms; tests remain on ubuntu

## Test plan
- CI on this PR exercises the changed workflow, including the new matrix job
- After merge, verify the push-triggered run appears on `develop` and the README badge resolves