### PR TITLE
refactor: phase 3 items 16-17 - shared helpers, tree utilities, unknown at boundaries

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -82,10 +82,10 @@
     buildWorkspaceTree,
     createFileNode,
     createEmptyFileNode,
-    getAllFileNodes,
     resolveEnvironmentVariables,
   } from './lib/parser';
   import type { SubstitutionContext } from './lib/parser';
+  import { getAllFileNodes, findFile, findFolder, collectFilePaths } from './lib/tree';
   import { importPostmanCollection } from './lib/postman';
   import { importInsomniaExport } from './lib/insomnia';
   import { importOpenApiSpec } from './lib/openapi';
@@ -93,7 +93,6 @@
     HttpRequest,
     RequestLocation,
     EnvironmentFile,
-    TreeNode,
     ImportResult,
     KeyVaultState,
   } from './lib/types';
@@ -1044,17 +1043,6 @@
 
   // ─── Save File ───
 
-  function findFileInTree(nodes: TreeNode[], path: string): any {
-    for (const n of nodes) {
-      if (n.type === 'file' && n.path === path) return n;
-      if (n.type === 'folder') {
-        const f = findFileInTree(n.children, path);
-        if (f) return f;
-      }
-    }
-    return null;
-  }
-
   async function saveActiveFile() {
     const file = $activeFile;
     if (!file || !file.dirty) return;
@@ -1237,14 +1225,7 @@
     let counter = 2;
 
     // Check for collisions in the tree
-    const existingNames = new Set<string>();
-    function collectNames(nodes: TreeNode[]) {
-      for (const n of nodes) {
-        if (n.type === 'file') existingNames.add(n.path);
-        if (n.type === 'folder') collectNames(n.children);
-      }
-    }
-    collectNames($workspace.tree);
+    const existingNames = new Set(collectFilePaths($workspace.tree));
 
     while (existingNames.has(filePath)) {
       fileName = `${stem}-${counter}.http`;
@@ -1276,19 +1257,11 @@
 
     // Collect sibling names in the target parent
     const siblings = new Set<string>();
-    function collectSiblings(nodes: TreeNode[], targetPath: string) {
-      for (const n of nodes) {
-        if (n.type === 'folder' && n.path === targetPath) {
-          for (const c of n.children) siblings.add(c.name);
-          return;
-        }
-        if (n.type === 'folder') collectSiblings(n.children, targetPath);
-      }
-    }
     if (parentDir === rootPath) {
       for (const n of $workspace.tree) siblings.add(n.name);
     } else {
-      collectSiblings($workspace.tree, parentDir);
+      const parent = findFolder($workspace.tree, parentDir);
+      for (const c of parent?.children ?? []) siblings.add(c.name);
     }
 
     const folderName = generateFolderName(siblings);
@@ -1332,7 +1305,7 @@
     const { oldPath, newName } = e.detail;
 
     // If file is dirty, save first
-    const file = findFileInTree($workspace.tree, oldPath);
+    const file = findFile($workspace.tree, oldPath);
     if (file && file.dirty) {
       try {
         const content = serializeHttpFile(file.requests, file.variables);
@@ -1382,14 +1355,7 @@
     let copyPath = await join(dir, copyName);
     let counter = 2;
 
-    const existingNames = new Set<string>();
-    function collectNames(nodes: TreeNode[]) {
-      for (const n of nodes) {
-        if (n.type === 'file') existingNames.add(n.path);
-        if (n.type === 'folder') collectNames(n.children);
-      }
-    }
-    collectNames($workspace.tree);
+    const existingNames = new Set(collectFilePaths($workspace.tree));
 
     while (existingNames.has(copyPath)) {
       copyStem = `${sourceStem} (copy ${counter})`;
@@ -1469,7 +1435,7 @@
     e: CustomEvent<{ filePath: string; requestIndex: number; varName: string }>,
   ) {
     const { filePath, requestIndex, varName } = e.detail;
-    const file = findFileInTree($workspace.tree, filePath);
+    const file = findFile($workspace.tree, filePath);
     if (!file) return;
     const req = file.requests[requestIndex];
     if (!req) return;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -86,6 +86,7 @@
   } from './lib/parser';
   import type { SubstitutionContext } from './lib/parser';
   import { getAllFileNodes, findFile, findFolder, collectFilePaths } from './lib/tree';
+  import { errorMessage } from './lib/errors';
   import { importPostmanCollection } from './lib/postman';
   import { importInsomniaExport } from './lib/insomnia';
   import { importOpenApiSpec } from './lib/openapi';
@@ -191,8 +192,8 @@
         `Added ${pendingImportVars.length} variable${pendingImportVars.length !== 1 ? 's' : ''} to "${envName}" environment.`,
         'info',
       );
-    } catch (e: any) {
-      addToast(`Failed to update environment file: ${e.message || e}`, 'error');
+    } catch (e) {
+      addToast(`Failed to update environment file: ${errorMessage(e)}`, 'error');
     }
 
     pendingImportVars = [];
@@ -730,8 +731,8 @@
       const rootPath = await open({ directory: true, title: 'Select workspace folder' });
       if (!rootPath) return;
       await openFolderByPath(rootPath as string);
-    } catch (e: any) {
-      addToast(`Failed to open folder: ${e.message || e}`, 'error');
+    } catch (e) {
+      addToast(`Failed to open folder: ${errorMessage(e)}`, 'error');
     }
   }
 
@@ -797,8 +798,8 @@
   async function openFavorite(path: string) {
     try {
       await openFolderByPath(path);
-    } catch (e: any) {
-      addToast(`Could not open favorite "${path}": ${e.message || e}`, 'error');
+    } catch (e) {
+      addToast(`Could not open favorite "${path}": ${errorMessage(e)}`, 'error');
     }
   }
 
@@ -806,8 +807,8 @@
     try {
       const path = await invoke<string>('extract_getting_started');
       await openFolderByPath(path);
-    } catch (e: any) {
-      addToast(`Failed to open getting-started folder: ${e.message || e}`, 'error');
+    } catch (e) {
+      addToast(`Failed to open getting-started folder: ${errorMessage(e)}`, 'error');
     }
   }
 
@@ -982,8 +983,8 @@
         `Imported ${envNames.length} environment${envNames.length !== 1 ? 's' : ''}: ${envNames.join(', ')}`,
         'info',
       );
-    } catch (e: any) {
-      addToast(`Failed to write environment file: ${e.message || e}`, 'error');
+    } catch (e) {
+      addToast(`Failed to write environment file: ${errorMessage(e)}`, 'error');
     }
   }
 
@@ -1015,8 +1016,8 @@
         'info',
       );
       await showEnvModalIfNeeded(result);
-    } catch (e: any) {
-      addToast(`Import failed: ${e.message || e}`, 'error');
+    } catch (e) {
+      addToast(`Import failed: ${errorMessage(e)}`, 'error');
     }
   }
 
@@ -1036,8 +1037,8 @@
         'info',
       );
       await showEnvModalIfNeeded(result);
-    } catch (e: any) {
-      addToast(`Import failed: ${e.message || e}`, 'error');
+    } catch (e) {
+      addToast(`Import failed: ${errorMessage(e)}`, 'error');
     }
   }
 
@@ -1051,8 +1052,8 @@
       const content = serializeHttpFile(file.requests, file.variables);
       await writeTextFile(file.path, content);
       markFileSaved(file.path);
-    } catch (e: any) {
-      addToast(`Failed to save file: ${e.message || e}`, 'error');
+    } catch (e) {
+      addToast(`Failed to save file: ${errorMessage(e)}`, 'error');
     }
   }
 
@@ -1064,8 +1065,8 @@
     try {
       const envPath = await join(rootPath, 'http-client.env.json');
       await writeTextFile(envPath, JSON.stringify(data, null, 2));
-    } catch (e: any) {
-      addToast(`Failed to save environment file: ${e.message || e}`, 'error');
+    } catch (e) {
+      addToast(`Failed to save environment file: ${errorMessage(e)}`, 'error');
     }
   }
 
@@ -1110,12 +1111,12 @@
       }
       pbAssertionResults.set(result.assertionResults);
       commitPbVars(result.afterReceive);
-    } catch (e: any) {
+    } catch (e) {
       currentResponse.set({
         status: 0,
         statusText: 'Error',
         headers: {},
-        body: (typeof e === 'string' ? e : e.message) || 'Request failed.',
+        body: errorMessage(e) || 'Request failed.',
         time: Math.round(performance.now() - startTime),
         size: 0,
       });
@@ -1191,7 +1192,7 @@
       const { remove } = await import('@tauri-apps/plugin-fs');
       await remove(filePath);
     } catch (err) {
-      addToast(`Failed to delete file: ${err instanceof Error ? err.message : err}`, 'error');
+      addToast(`Failed to delete file: ${errorMessage(err)}`, 'error');
       return;
     }
 
@@ -1205,7 +1206,7 @@
       const { remove } = await import('@tauri-apps/plugin-fs');
       await remove(folderPath, { recursive: true });
     } catch (err) {
-      addToast(`Failed to delete folder: ${err instanceof Error ? err.message : err}`, 'error');
+      addToast(`Failed to delete folder: ${errorMessage(err)}`, 'error');
       return;
     }
 
@@ -1239,7 +1240,7 @@
     try {
       await writeTextFile(filePath, content);
     } catch (err) {
-      addToast(`Failed to create file: ${err instanceof Error ? err.message : err}`, 'error');
+      addToast(`Failed to create file: ${errorMessage(err)}`, 'error');
       return;
     }
 
@@ -1271,7 +1272,7 @@
       const { mkdir } = await import('@tauri-apps/plugin-fs');
       await mkdir(folderPath, { recursive: true });
     } catch (err) {
-      addToast(`Failed to create folder: ${err instanceof Error ? err.message : err}`, 'error');
+      addToast(`Failed to create folder: ${errorMessage(err)}`, 'error');
       return;
     }
 
@@ -1293,7 +1294,7 @@
     try {
       await rename(oldPath, newPath);
     } catch (err) {
-      addToast(`Failed to rename folder: ${err instanceof Error ? err.message : err}`, 'error');
+      addToast(`Failed to rename folder: ${errorMessage(err)}`, 'error');
       return;
     }
 
@@ -1312,10 +1313,7 @@
         await writeTextFile(oldPath, content);
         markFileSaved(oldPath);
       } catch (err) {
-        addToast(
-          `Failed to save file before rename: ${err instanceof Error ? err.message : err}`,
-          'error',
-        );
+        addToast(`Failed to save file before rename: ${errorMessage(err)}`, 'error');
         return;
       }
     }
@@ -1326,7 +1324,7 @@
     try {
       await rename(oldPath, newPath);
     } catch (err) {
-      addToast(`Failed to rename file: ${err instanceof Error ? err.message : err}`, 'error');
+      addToast(`Failed to rename file: ${errorMessage(err)}`, 'error');
       return;
     }
 
@@ -1341,7 +1339,7 @@
     try {
       content = await readTextFile(sourcePath);
     } catch (err) {
-      addToast(`Failed to read file: ${err instanceof Error ? err.message : err}`, 'error');
+      addToast(`Failed to read file: ${errorMessage(err)}`, 'error');
       return;
     }
 
@@ -1367,7 +1365,7 @@
     try {
       await writeTextFile(copyPath, content);
     } catch (err) {
-      addToast(`Failed to duplicate file: ${err instanceof Error ? err.message : err}`, 'error');
+      addToast(`Failed to duplicate file: ${errorMessage(err)}`, 'error');
       return;
     }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -204,9 +204,36 @@
     pendingImportVars = [];
   }
 
+  // ─── Layout persistence ───
+  // Pane/sidebar sizes are persisted to the webview's localStorage, which Tauri
+  // keeps across app restarts. Window size/position is handled separately by the
+  // tauri-plugin-window-state plugin (see src-tauri).
+
+  const LAYOUT_KEY_EDITOR_PCT = 'pb.layout.editorWidthPercent';
+  const LAYOUT_KEY_SIDEBAR_PX = 'pb.layout.sidebarWidth';
+
+  function loadLayoutNumber(key: string, fallback: number): number {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw === null) return fallback;
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  function saveLayoutNumber(key: string, value: number) {
+    try {
+      localStorage.setItem(key, String(value));
+    } catch {
+      // ignore (e.g. storage disabled) - persistence is best-effort
+    }
+  }
+
   // ─── Resizable Panes ───
 
-  let editorWidthPercent = 50;
+  let editorWidthPercent = loadLayoutNumber(LAYOUT_KEY_EDITOR_PCT, 50);
   let dragging = false;
   let mainPanelsEl: HTMLDivElement;
 
@@ -229,11 +256,12 @@
     dragging = false;
     document.removeEventListener('mousemove', onDividerMove);
     document.removeEventListener('mouseup', onDividerUp);
+    saveLayoutNumber(LAYOUT_KEY_EDITOR_PCT, editorWidthPercent);
   }
 
   // ─── Resizable Sidebar ───
 
-  let sidebarWidth = 260;
+  let sidebarWidth = loadLayoutNumber(LAYOUT_KEY_SIDEBAR_PX, 260);
   let sidebarDragging = false;
   let layoutEl: HTMLDivElement;
 
@@ -255,6 +283,7 @@
     sidebarDragging = false;
     document.removeEventListener('mousemove', onSidebarDividerMove);
     document.removeEventListener('mouseup', onSidebarDividerUp);
+    saveLayoutNumber(LAYOUT_KEY_SIDEBAR_PX, sidebarWidth);
   }
 
   // ─── Key Vault ───

--- a/src/components/FlowEditor.svelte
+++ b/src/components/FlowEditor.svelte
@@ -17,7 +17,8 @@
     Variable,
     NamedRequestResult,
   } from '../lib/types';
-  import { getAllFileNodes, substituteAll, parseScriptText } from '../lib/parser';
+  import { substituteAll, parseScriptText } from '../lib/parser';
+  import { getAllFileNodes } from '../lib/tree';
   import { applyAliasSync, autoAliasFor } from '../lib/flowAlias';
   import { baseEnvVars, dotenvVariables } from '../lib/stores';
   import { METHOD_COLORS } from '../lib/theme';

--- a/src/components/FlowStepPicker.svelte
+++ b/src/components/FlowStepPicker.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import type { TreeNode, FileNode, FlowStep } from '../lib/types';
-  import { getAllFileNodes } from '../lib/parser';
+  import { getAllFileNodes } from '../lib/tree';
   import { METHOD_COLORS } from '../lib/theme';
 
   export let tree: TreeNode[] = [];

--- a/src/components/ImportCollectionModal.svelte
+++ b/src/components/ImportCollectionModal.svelte
@@ -6,6 +6,7 @@
   import { basename } from '@tauri-apps/api/path';
   import { detectImportFormat, formatLabel, type ImportFormat } from '../lib/detect';
   import type { HttpInvokeResult } from '../lib/requestExec';
+  import { errorMessage } from '../lib/errors';
 
   export let visible: boolean = false;
 
@@ -73,8 +74,8 @@
       if (detectedFormat) {
         doImport();
       }
-    } catch (e: any) {
-      error = `Failed to read dropped file: ${e.message || e}`;
+    } catch (e) {
+      error = `Failed to read dropped file: ${errorMessage(e)}`;
     }
   }
 
@@ -131,8 +132,8 @@
       const content = await readTextFile(filePath as string);
       const name = await basename(filePath as string);
       loadFileContent(name, content);
-    } catch (e: any) {
-      error = `Failed to read file: ${e.message || e}`;
+    } catch (e) {
+      error = `Failed to read file: ${errorMessage(e)}`;
     }
   }
 
@@ -182,8 +183,8 @@
       }
 
       dispatch('importUrl', { content: res.body });
-    } catch (e: any) {
-      urlError = typeof e === 'string' ? e : e.message || 'Failed to fetch spec';
+    } catch (e) {
+      urlError = errorMessage(e) || 'Failed to fetch spec';
     } finally {
       urlLoading = false;
     }

--- a/src/components/TreeSidebar.svelte
+++ b/src/components/TreeSidebar.svelte
@@ -3,7 +3,7 @@
   import { getVersion } from '@tauri-apps/api/app';
   import TreeNode from './TreeNode.svelte';
   import type { TreeNode as TNode, RequestLocation, FlowDefinition, Favorite } from '../lib/types';
-  import { getAllFileNodes } from '../lib/parser';
+  import { getAllFileNodes, filterTreeByQuery } from '../lib/tree';
 
   let appVersion = '';
 
@@ -52,30 +52,6 @@
     }
   }
 
-  function filterTree(nodes: TNode[], query: string): TNode[] {
-    const q = query.toLowerCase();
-    const result: TNode[] = [];
-    for (const node of nodes) {
-      if (node.type === 'file') {
-        const fileMatch = node.name.toLowerCase().includes(q);
-        const reqMatch = node.requests.some(
-          (r) =>
-            r.name.toLowerCase().includes(q) ||
-            r.url.toLowerCase().includes(q) ||
-            r.method.toLowerCase().includes(q) ||
-            (r.varName && r.varName.toLowerCase().includes(q)),
-        );
-        if (fileMatch || reqMatch) result.push(node);
-      } else {
-        const filteredChildren = filterTree(node.children, query);
-        if (filteredChildren.length > 0) {
-          result.push({ ...node, children: filteredChildren, expanded: true });
-        }
-      }
-    }
-    return result;
-  }
-
   onMount(async () => {
     try {
       appVersion = await getVersion();
@@ -87,7 +63,7 @@
     .map((r) => r.varName)
     .filter((n): n is string => !!n);
 
-  $: displayTree = filterText.trim() ? filterTree(tree, filterText.trim()) : tree;
+  $: displayTree = filterText.trim() ? filterTreeByQuery(tree, filterText.trim()) : tree;
 
   $: if (showNewFlow && newFlowInputEl) newFlowInputEl.focus();
 

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { errorMessage } from './errors';
+
+describe('errorMessage', () => {
+  it('returns strings as-is (Tauri command rejections)', () => {
+    expect(errorMessage('file not found')).toBe('file not found');
+  });
+
+  it('returns the message of Error instances', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('returns message from error-like objects', () => {
+    expect(errorMessage({ message: 'object error' })).toBe('object error');
+  });
+
+  it('stringifies everything else', () => {
+    expect(errorMessage(42)).toBe('42');
+    expect(errorMessage(null)).toBe('null');
+    expect(errorMessage(undefined)).toBe('undefined');
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Extract a human-readable message from an unknown thrown value.
+ * Tauri commands reject with plain strings; JS code throws Error instances.
+ */
+export function errorMessage(e: unknown): string {
+  if (typeof e === 'string') return e;
+  if (e instanceof Error) return e.message;
+  if (e && typeof e === 'object' && 'message' in e && typeof e.message === 'string') {
+    return e.message;
+  }
+  return String(e);
+}

--- a/src/lib/flowIO.ts
+++ b/src/lib/flowIO.ts
@@ -1,4 +1,5 @@
 import { readTextFile, writeTextFile, readDir, mkdir, remove, rename } from '@tauri-apps/plugin-fs';
+import type { DirEntry } from '@tauri-apps/plugin-fs';
 import { join } from '@tauri-apps/api/path';
 import type { FlowDefinition, FlowRunRecord, FlowStep, FlowStepOverrides } from './types';
 import { applyAliasSync } from './flowAlias';
@@ -14,48 +15,56 @@ const MAX_HISTORY_PER_FLOW = 20;
 
 /** Parse a .pb-flow.json file's contents into a FlowDefinition. */
 export function parseFlowFile(content: string): FlowDefinition {
-  const raw = JSON.parse(content);
+  const raw = asRecord(JSON.parse(content));
   const steps = Array.isArray(raw.steps) ? raw.steps.map(parseFlowStep) : [];
   // One-time normalization: ensures every step has an auto alias if unlocked.
   // Legacy flows without `aliasLocked`: parseFlowStep infers it from varName presence.
   const normalized = applyAliasSync(steps);
   return {
-    version: raw.version ?? 1,
-    name: raw.name ?? 'Untitled Flow',
-    description: raw.description ?? '',
+    version: typeof raw.version === 'number' ? raw.version : 1,
+    name: typeof raw.name === 'string' ? raw.name : 'Untitled Flow',
+    description: typeof raw.description === 'string' ? raw.description : '',
     steps: normalized,
   };
 }
 
-function parseOverrides(raw: any): FlowStepOverrides | undefined {
-  if (!raw) return undefined;
+/** Narrow an unknown JSON value to a plain record, treating anything else as empty. */
+function asRecord(raw: unknown): Record<string, unknown> {
+  return typeof raw === 'object' && raw !== null ? (raw as Record<string, unknown>) : {};
+}
+
+function parseOverrides(raw: unknown): FlowStepOverrides | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const r = raw as Record<string, unknown>;
   const o: FlowStepOverrides = {};
-  if (raw.url !== undefined) o.url = raw.url;
-  if (Array.isArray(raw.headers)) o.headers = raw.headers;
-  if (raw.body !== undefined) o.body = raw.body;
-  if (Array.isArray(raw.directives)) o.directives = raw.directives;
+  if (typeof r.url === 'string') o.url = r.url;
+  if (Array.isArray(r.headers)) o.headers = r.headers as FlowStepOverrides['headers'];
+  if (typeof r.body === 'string') o.body = r.body;
+  if (Array.isArray(r.directives)) o.directives = r.directives as FlowStepOverrides['directives'];
   return Object.keys(o).length > 0 ? o : undefined;
 }
 
-function parseFlowStep(raw: any): FlowStep {
+function parseFlowStep(raw: unknown): FlowStep {
+  const r = asRecord(raw);
+  const varName = typeof r.varName === 'string' ? r.varName : null;
   // Legacy flows don't carry `aliasLocked`. Infer:
   //   - explicit boolean: honor it
   //   - varName matches auto shape `Step{N}`: treat as auto (re-normalized)
   //   - non-null custom varName: preserve as locked
   //   - null varName: auto
   const aliasLocked =
-    typeof raw.aliasLocked === 'boolean'
-      ? raw.aliasLocked
-      : raw.varName != null && !/^Step\d+$/.test(raw.varName);
+    typeof r.aliasLocked === 'boolean'
+      ? r.aliasLocked
+      : varName != null && !/^Step\d+$/.test(varName);
   return {
-    id: raw.id ?? crypto.randomUUID(),
-    filePath: raw.filePath ?? '',
-    requestIndex: raw.requestIndex ?? 0,
-    varName: raw.varName ?? null,
+    id: typeof r.id === 'string' ? r.id : crypto.randomUUID(),
+    filePath: typeof r.filePath === 'string' ? r.filePath : '',
+    requestIndex: typeof r.requestIndex === 'number' ? r.requestIndex : 0,
+    varName,
     aliasLocked,
-    label: raw.label ?? '',
-    continueOnFailure: raw.continueOnFailure ?? false,
-    overrides: parseOverrides(raw.overrides),
+    label: typeof r.label === 'string' ? r.label : '',
+    continueOnFailure: r.continueOnFailure === true,
+    overrides: parseOverrides(r.overrides),
   };
 }
 
@@ -122,9 +131,9 @@ export interface DiscoveredFlow {
 /** Scan the flows/ directory for .pb-flow.json files. */
 export async function scanForFlowFiles(dir: string, rootDir: string): Promise<DiscoveredFlow[]> {
   const flowsDir = await join(rootDir, FLOWS_DIR);
-  let entries: { name: string; isDirectory: boolean }[];
+  let entries: DirEntry[];
   try {
-    entries = (await readDir(flowsDir)) as any[];
+    entries = await readDir(flowsDir);
   } catch {
     return []; // .flows/ directory doesn't exist yet
   }
@@ -257,10 +266,10 @@ export async function saveFlowRunRecord(
 /** Delete the oldest run records if the count exceeds MAX_HISTORY_PER_FLOW. */
 async function pruneFlowHistory(resultsDir: string): Promise<void> {
   try {
-    const files = (await readDir(resultsDir)) as any[];
+    const files = await readDir(resultsDir);
     const jsonFiles = files
-      .filter((f: any) => !f.isDirectory && f.name.endsWith('.json'))
-      .sort((a: any, b: any) => b.name.localeCompare(a.name));
+      .filter((f) => !f.isDirectory && f.name.endsWith('.json'))
+      .sort((a, b) => b.name.localeCompare(a.name));
 
     if (jsonFiles.length <= MAX_HISTORY_PER_FLOW) return;
 
@@ -294,9 +303,9 @@ export async function loadFlowHistory(rootDir: string): Promise<FlowRunRecord[]>
   const resultsRoot = await join(rootDir, RESULTS_DIR);
   const records: FlowRunRecord[] = [];
 
-  let flowDirs: { name: string; isDirectory: boolean }[];
+  let flowDirs: DirEntry[];
   try {
-    flowDirs = (await readDir(resultsRoot)) as any[];
+    flowDirs = await readDir(resultsRoot);
   } catch {
     return []; // No results directory yet
   }
@@ -305,9 +314,9 @@ export async function loadFlowHistory(rootDir: string): Promise<FlowRunRecord[]>
     if (!flowDir.isDirectory) continue;
 
     const flowDirPath = await join(resultsRoot, flowDir.name);
-    let files: { name: string; isDirectory: boolean }[];
+    let files: DirEntry[];
     try {
-      files = (await readDir(flowDirPath)) as any[];
+      files = await readDir(flowDirPath);
     } catch {
       continue;
     }

--- a/src/lib/flowRunner.test.ts
+++ b/src/lib/flowRunner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { FileNode, TreeNode } from './types';
-import { getAllFileNodes, createFileNode } from './parser';
+import { createFileNode } from './parser';
+import { getAllFileNodes } from './tree';
 
 // ─── getAllFileNodes (used by flow runner to resolve step targets) ───────────
 

--- a/src/lib/flowRunner.ts
+++ b/src/lib/flowRunner.ts
@@ -1,4 +1,5 @@
 import { getAllFileNodes } from './tree';
+import { errorMessage } from './errors';
 import type { SubstitutionContext } from './parser';
 import { executeHttpRequest } from './requestExec';
 import type {
@@ -211,7 +212,7 @@ async function executeStep(
       durationMs: Math.round(performance.now() - startTime),
       error: null,
     };
-  } catch (e: any) {
+  } catch (e) {
     return {
       stepId,
       status: 'failed',
@@ -219,7 +220,7 @@ async function executeStep(
       sentRequest: null,
       assertionResults: [],
       durationMs: Math.round(performance.now() - startTime),
-      error: typeof e === 'string' ? e : e.message || 'Request failed',
+      error: errorMessage(e) || 'Request failed',
     };
   }
 }

--- a/src/lib/flowRunner.ts
+++ b/src/lib/flowRunner.ts
@@ -1,4 +1,4 @@
-import { getAllFileNodes } from './parser';
+import { getAllFileNodes } from './tree';
 import type { SubstitutionContext } from './parser';
 import { executeHttpRequest } from './requestExec';
 import type {

--- a/src/lib/importShared.test.ts
+++ b/src/lib/importShared.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeMethod, sanitizeFilename, sanitizeVarName, newImportId } from './importShared';
+
+describe('normalizeMethod', () => {
+  it('uppercases known methods', () => {
+    expect(normalizeMethod('get')).toBe('GET');
+    expect(normalizeMethod('Delete')).toBe('DELETE');
+    expect(normalizeMethod('CONNECT')).toBe('CONNECT');
+  });
+
+  it('falls back to GET for unknown methods', () => {
+    expect(normalizeMethod('FETCH')).toBe('GET');
+    expect(normalizeMethod('')).toBe('GET');
+  });
+});
+
+describe('sanitizeFilename', () => {
+  it('replaces invalid filename characters', () => {
+    expect(sanitizeFilename('a/b\\c:d*e?f"g<h>i|j')).toBe('a_b_c_d_e_f_g_h_i_j');
+  });
+
+  it('falls back to unnamed for empty input', () => {
+    expect(sanitizeFilename('')).toBe('unnamed');
+    expect(sanitizeFilename('   ')).toBe('unnamed');
+  });
+});
+
+describe('sanitizeVarName', () => {
+  it('replaces non-identifier characters and trims underscores', () => {
+    expect(sanitizeVarName('base url!')).toBe('base_url');
+    expect(sanitizeVarName('-token-')).toBe('token');
+  });
+
+  it('falls back to unnamed for empty input', () => {
+    expect(sanitizeVarName('')).toBe('unnamed');
+    expect(sanitizeVarName('---')).toBe('unnamed');
+  });
+});
+
+describe('newImportId', () => {
+  it('produces unique import-prefixed ids', () => {
+    const a = newImportId();
+    const b = newImportId();
+    expect(a).toMatch(/^import_\d+_[a-z0-9]+$/);
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/lib/importShared.ts
+++ b/src/lib/importShared.ts
@@ -1,0 +1,38 @@
+// Helpers shared by the collection importers (postman.ts, insomnia.ts, openapi.ts).
+
+import type { HttpMethod } from './types';
+
+// ─── Valid HTTP methods ──────────────────────────────────────────────────────
+
+export const VALID_METHODS = new Set<string>([
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+  'TRACE',
+  'CONNECT',
+]);
+
+/** Uppercase a method name, falling back to GET for anything unrecognized. */
+export function normalizeMethod(method: string): HttpMethod {
+  const upper = method.toUpperCase();
+  return VALID_METHODS.has(upper) ? (upper as HttpMethod) : 'GET';
+}
+
+/** Strip characters that are invalid in filenames. */
+export function sanitizeFilename(name: string): string {
+  return name.replace(/[<>:"/\\|?*]/g, '_').trim() || 'unnamed';
+}
+
+/** Reduce a name to a valid `{{variable}}` identifier. */
+export function sanitizeVarName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_]/g, '_').replace(/^_+|_+$/g, '') || 'unnamed';
+}
+
+/** Unique id for a request created by an importer. */
+export function newImportId(): string {
+  return `import_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/src/lib/insomnia.ts
+++ b/src/lib/insomnia.ts
@@ -1,6 +1,5 @@
 import * as yaml from 'js-yaml';
 import type {
-  HttpMethod,
   HttpHeader,
   HttpRequest,
   Variable,
@@ -9,6 +8,7 @@ import type {
   EnvironmentFile,
 } from './types';
 import { serializeHttpFile, extractVariableRefs } from './parser';
+import { normalizeMethod, sanitizeFilename, sanitizeVarName, newImportId } from './importShared';
 
 // ─── Shared Types ──────────────────────────────────────────────────────────
 
@@ -103,20 +103,6 @@ interface V4Resource {
   authentication?: InsomniaAuth;
   data?: Record<string, unknown>;
 }
-
-// ─── Valid HTTP methods ────────────────────────────────────────────────────
-
-const VALID_METHODS = new Set<string>([
-  'GET',
-  'POST',
-  'PUT',
-  'PATCH',
-  'DELETE',
-  'HEAD',
-  'OPTIONS',
-  'TRACE',
-  'CONNECT',
-]);
 
 // ─── Public API ────────────────────────────────────────────────────────────
 
@@ -277,7 +263,7 @@ function convertV5Request(item: V5Item, nameById: Map<string, string>): HttpRequ
   const body = convertTemplateVars(rawBody, nameById);
 
   return {
-    id: `import_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    id: newImportId(),
     name: item.name || `${method} ${url}`,
     varName: null,
     method,
@@ -394,7 +380,7 @@ function convertV4Request(resource: V4Resource, nameById: Map<string, string>): 
   const body = convertTemplateVars(rawBody, nameById);
 
   return {
-    id: `import_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    id: newImportId(),
     name: resource.name || `${method} ${url}`,
     varName: null,
     method,
@@ -417,11 +403,6 @@ function extractV4EnvVars(resources: V4Resource[], workspaceId: string | null): 
 }
 
 // ─── Shared Request Conversion Helpers ─────────────────────────────────────
-
-function normalizeMethod(method: string): HttpMethod {
-  const upper = method.toUpperCase();
-  return VALID_METHODS.has(upper) ? (upper as HttpMethod) : 'GET';
-}
 
 function appendQueryParams(url: string, parameters?: InsomniaParam[]): string {
   const enabled = (parameters ?? []).filter((p) => !p.disabled);
@@ -561,14 +542,4 @@ function convertTemplateVars(text: string, nameById: Map<string, string>): strin
   result = result.replace(/\{\{(\w[\w.]*)\s+\}\}/g, '{{$1}}');
 
   return result;
-}
-
-// ─── Utilities ─────────────────────────────────────────────────────────────
-
-function sanitizeFilename(name: string): string {
-  return name.replace(/[<>:"/\\|?*]/g, '_').trim() || 'unnamed';
-}
-
-function sanitizeVarName(name: string): string {
-  return name.replace(/[^a-zA-Z0-9_]/g, '_').replace(/^_+|_+$/g, '') || 'unnamed';
 }

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -1,13 +1,7 @@
 import * as yaml from 'js-yaml';
-import type {
-  HttpMethod,
-  HttpHeader,
-  HttpRequest,
-  ConvertedFile,
-  ImportResult,
-  Variable,
-} from './types';
+import type { HttpHeader, HttpRequest, ConvertedFile, ImportResult, Variable } from './types';
 import { serializeHttpFile, extractVariableRefs } from './parser';
+import { normalizeMethod, sanitizeFilename, sanitizeVarName, newImportId } from './importShared';
 
 // ─── OpenAPI Types (subset needed for import) ────────────────────────────────
 
@@ -94,18 +88,6 @@ interface SecurityScheme {
 }
 
 // ─── Constants ───────────────────────────────────────────────────────────────
-
-const VALID_METHODS = new Set<string>([
-  'GET',
-  'POST',
-  'PUT',
-  'PATCH',
-  'DELETE',
-  'HEAD',
-  'OPTIONS',
-  'TRACE',
-  'CONNECT',
-]);
 
 const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'] as const;
 
@@ -246,9 +228,7 @@ function buildRequest(
   security: SecurityRequirement[],
 ): HttpRequest {
   const upperMethod = method.toUpperCase();
-  const normalizedMethod: HttpMethod = VALID_METHODS.has(upperMethod)
-    ? (upperMethod as HttpMethod)
-    : 'GET';
+  const normalizedMethod = normalizeMethod(method);
 
   // Build URL: {{baseUrl}} + path with {param} -> {{param}}
   let url = `{{baseUrl}}${path.replace(/\{(\w+)\}/g, '{{$1}}')}`;
@@ -329,7 +309,7 @@ function buildRequest(
   const name = operation.summary || operation.operationId || `${upperMethod} ${path}`;
 
   return {
-    id: `import_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    id: newImportId(),
     name,
     varName: operation.operationId ?? null,
     method: normalizedMethod,
@@ -641,12 +621,4 @@ function deriveTagFromPath(path: string): string {
 
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
-}
-
-function sanitizeFilename(name: string): string {
-  return name.replace(/[<>:"/\\|?*]/g, '_').trim() || 'unnamed';
-}
-
-function sanitizeVarName(name: string): string {
-  return name.replace(/[^a-zA-Z0-9_]/g, '_').replace(/^_+|_+$/g, '') || 'unnamed';
 }

--- a/src/lib/parser-extended.test.ts
+++ b/src/lib/parser-extended.test.ts
@@ -15,9 +15,9 @@ import {
   extractVariableRefs,
   createEmptyRequest,
   buildWorkspaceTree,
-  getAllFileNodes,
   createEmptyFileNode,
 } from './parser';
+import { getAllFileNodes } from './tree';
 import type { SubstitutionContext, RequestMutations } from './parser';
 import type { HttpResponse, NamedRequestResult, PbDirective } from './types';
 

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1453,18 +1453,6 @@ export function buildWorkspaceTree(
 }
 
 /**
- * Collect all FileNodes from a tree (flat list).
- */
-export function getAllFileNodes(nodes: TreeNode[]): FileNode[] {
-  const result: FileNode[] = [];
-  for (const node of nodes) {
-    if (node.type === 'file') result.push(node);
-    if (node.type === 'folder') result.push(...getAllFileNodes(node.children));
-  }
-  return result;
-}
-
-/**
  * Create a new empty .http file node for adding to the tree.
  */
 export function createEmptyFileNode(absolutePath: string, fileName: string): FileNode {

--- a/src/lib/postman.ts
+++ b/src/lib/postman.ts
@@ -1,5 +1,6 @@
-import type { HttpMethod, HttpHeader, HttpRequest, ConvertedFile, ImportResult } from './types';
+import type { HttpHeader, HttpRequest, ConvertedFile, ImportResult } from './types';
 import { serializeHttpFile, extractVariableRefs } from './parser';
+import { normalizeMethod, sanitizeFilename, newImportId } from './importShared';
 
 // ─── Postman Collection v2.1 Types ─────────────────────────────────────────
 
@@ -73,20 +74,6 @@ interface PostmanVariable {
   key: string;
   value: string;
 }
-
-// ─── Valid HTTP methods ────────────────────────────────────────────────────
-
-const VALID_METHODS = new Set<string>([
-  'GET',
-  'POST',
-  'PUT',
-  'PATCH',
-  'DELETE',
-  'HEAD',
-  'OPTIONS',
-  'TRACE',
-  'CONNECT',
-]);
 
 // ─── Public API ────────────────────────────────────────────────────────────
 
@@ -186,7 +173,7 @@ function convertRequest(item: PostmanItem, collectionAuth?: PostmanAuth): HttpRe
   const body = buildBody(req.body);
 
   return {
-    id: `import_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    id: newImportId(),
     name: item.name || `${method} ${url}`,
     varName: null,
     method,
@@ -195,11 +182,6 @@ function convertRequest(item: PostmanItem, collectionAuth?: PostmanAuth): HttpRe
     body,
     directives: [],
   };
-}
-
-function normalizeMethod(method: string): HttpMethod {
-  const upper = method.toUpperCase();
-  return VALID_METHODS.has(upper) ? (upper as HttpMethod) : 'GET';
 }
 
 function buildUrl(url: PostmanUrl | string | undefined): string {
@@ -357,8 +339,4 @@ function buildBody(body?: PostmanBody): string {
     default:
       return '';
   }
-}
-
-function sanitizeFilename(name: string): string {
-  return name.replace(/[<>:"/\\|?*]/g, '_').trim() || 'unnamed';
 }

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -26,6 +26,7 @@ import {
   getEnvironmentNames,
   serializeHttpFile,
 } from './parser';
+import { findFile, findFolder, collectFilePaths, removeNodeByPath } from './tree';
 
 // ─── Workspace ──────────────────────────────────────────────────────────────
 
@@ -204,22 +205,10 @@ export function setTabResponseTab(loc: RequestLocation, responseTab: ResponseTab
 
 // ─── Derived: Active File & Request ─────────────────────────────────────────
 
-/** Find a FileNode by path in the workspace tree. */
-function findFileNode(nodes: TreeNode[], filePath: string): FileNode | null {
-  for (const node of nodes) {
-    if (node.type === 'file' && node.path === filePath) return node;
-    if (node.type === 'folder') {
-      const found = findFileNode(node.children, filePath);
-      if (found) return found;
-    }
-  }
-  return null;
-}
-
 /** The currently active file node. */
 export const activeFile = derived([workspace, selectedLocation], ([$ws, $loc]) => {
   if (!$loc) return null;
-  return findFileNode($ws.tree, $loc.filePath);
+  return findFile($ws.tree, $loc.filePath);
 });
 
 /** The currently selected request. */
@@ -296,7 +285,7 @@ export function deleteRequestFromFile(filePath: string, requestIndex: number) {
   // Fix selection
   const loc = get(selectedLocation);
   if (loc && loc.filePath === filePath) {
-    const file = findFileNode(get(workspace).tree, filePath);
+    const file = findFile(get(workspace).tree, filePath);
     if (file) {
       const maxIdx = file.requests.length - 1;
       if (loc.requestIndex > maxIdx) {
@@ -308,55 +297,22 @@ export function deleteRequestFromFile(filePath: string, requestIndex: number) {
 
 /** Remove a file from the workspace tree and close its tabs. */
 export function removeFileFromTree(filePath: string) {
-  function filterTree(nodes: TreeNode[]): TreeNode[] {
-    return nodes
-      .filter((n) => !(n.type === 'file' && n.path === filePath))
-      .map((n) => (n.type === 'folder' ? { ...n, children: filterTree(n.children) } : n));
-  }
-
-  const file = findFileNode(get(workspace).tree, filePath);
+  const file = findFile(get(workspace).tree, filePath);
   if (file) {
     for (let i = file.requests.length - 1; i >= 0; i--) {
       closeTab({ filePath, requestIndex: i });
     }
   }
 
-  workspace.update((ws) => ({ ...ws, tree: filterTree(ws.tree) }));
+  workspace.update((ws) => ({ ...ws, tree: removeNodeByPath(ws.tree, filePath) }));
 }
 
 /** Remove a folder and all its contents from the workspace tree, closing all affected tabs. */
 export function removeFolderFromTree(folderPath: string) {
-  function collectFilePaths(nodes: TreeNode[]): string[] {
-    const paths: string[] = [];
-    for (const n of nodes) {
-      if (n.type === 'file') paths.push(n.path);
-      if (n.type === 'folder') paths.push(...collectFilePaths(n.children));
-    }
-    return paths;
-  }
-
-  function findFolder(nodes: TreeNode[]): FolderNode | null {
-    for (const n of nodes) {
-      if (n.type === 'folder' && n.path === folderPath) return n as FolderNode;
-      if (n.type === 'folder') {
-        const found = findFolder(n.children);
-        if (found) return found;
-      }
-    }
-    return null;
-  }
-
-  function filterTree(nodes: TreeNode[]): TreeNode[] {
-    return nodes
-      .filter((n) => !(n.type === 'folder' && n.path === folderPath))
-      .map((n) => (n.type === 'folder' ? { ...n, children: filterTree(n.children) } : n));
-  }
-
-  const folder = findFolder(get(workspace).tree);
+  const folder = findFolder(get(workspace).tree, folderPath);
   if (folder) {
-    const filePaths = collectFilePaths(folder.children);
-    for (const fp of filePaths) {
-      const file = findFileNode(get(workspace).tree, fp);
+    for (const fp of collectFilePaths(folder.children)) {
+      const file = findFile(get(workspace).tree, fp);
       if (file) {
         for (let i = file.requests.length - 1; i >= 0; i--) {
           closeTab({ filePath: fp, requestIndex: i });
@@ -365,7 +321,7 @@ export function removeFolderFromTree(folderPath: string) {
     }
   }
 
-  workspace.update((ws) => ({ ...ws, tree: filterTree(ws.tree) }));
+  workspace.update((ws) => ({ ...ws, tree: removeNodeByPath(ws.tree, folderPath) }));
 }
 
 /** Mark a file as saved (not dirty). */

--- a/src/lib/tree.test.ts
+++ b/src/lib/tree.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import type { TreeNode, FileNode, FolderNode, HttpRequest } from './types';
+import {
+  visitNodes,
+  findFile,
+  findFolder,
+  getAllFileNodes,
+  collectFilePaths,
+  removeNodeByPath,
+  filterTreeByQuery,
+} from './tree';
+
+function req(partial: Partial<HttpRequest> = {}): HttpRequest {
+  return {
+    id: partial.id ?? 'r1',
+    name: partial.name ?? 'Request',
+    varName: partial.varName ?? null,
+    method: partial.method ?? 'GET',
+    url: partial.url ?? 'https://example.com',
+    headers: [],
+    body: '',
+    directives: [],
+    ...partial,
+  };
+}
+
+function file(path: string, requests: HttpRequest[] = []): FileNode {
+  const name = path.split('/').pop() ?? path;
+  return {
+    type: 'file',
+    name,
+    path,
+    requests,
+    variables: [],
+    dirty: false,
+    savedContent: '',
+  };
+}
+
+function folder(path: string, children: TreeNode[]): FolderNode {
+  const name = path.split('/').pop() ?? path;
+  return { type: 'folder', name, path, children, expanded: false };
+}
+
+const tree: TreeNode[] = [
+  file('/ws/auth.http', [req({ name: 'Login', url: 'https://api.test/login', varName: 'login' })]),
+  folder('/ws/users', [
+    file('/ws/users/crud.http', [req({ name: 'Get user', method: 'GET' })]),
+    folder('/ws/users/admin', [file('/ws/users/admin/roles.http')]),
+  ]),
+];
+
+describe('visitNodes', () => {
+  it('visits every node depth-first', () => {
+    const paths: string[] = [];
+    visitNodes(tree, (n) => paths.push(n.path));
+    expect(paths).toEqual([
+      '/ws/auth.http',
+      '/ws/users',
+      '/ws/users/crud.http',
+      '/ws/users/admin',
+      '/ws/users/admin/roles.http',
+    ]);
+  });
+
+  it('handles an empty tree', () => {
+    const visited: string[] = [];
+    visitNodes([], (n) => visited.push(n.path));
+    expect(visited).toEqual([]);
+  });
+});
+
+describe('findFile', () => {
+  it('finds a file at the top level', () => {
+    expect(findFile(tree, '/ws/auth.http')?.name).toBe('auth.http');
+  });
+
+  it('finds a nested file', () => {
+    expect(findFile(tree, '/ws/users/admin/roles.http')?.name).toBe('roles.http');
+  });
+
+  it('returns null for a missing path', () => {
+    expect(findFile(tree, '/ws/nope.http')).toBeNull();
+  });
+
+  it('does not match a folder with the given path', () => {
+    expect(findFile(tree, '/ws/users')).toBeNull();
+  });
+});
+
+describe('findFolder', () => {
+  it('finds a top-level folder', () => {
+    expect(findFolder(tree, '/ws/users')?.name).toBe('users');
+  });
+
+  it('finds a nested folder', () => {
+    expect(findFolder(tree, '/ws/users/admin')?.name).toBe('admin');
+  });
+
+  it('returns null for a missing path', () => {
+    expect(findFolder(tree, '/ws/missing')).toBeNull();
+  });
+
+  it('does not match a file with the given path', () => {
+    expect(findFolder(tree, '/ws/auth.http')).toBeNull();
+  });
+});
+
+describe('getAllFileNodes', () => {
+  it('collects all files depth-first', () => {
+    expect(getAllFileNodes(tree).map((f) => f.path)).toEqual([
+      '/ws/auth.http',
+      '/ws/users/crud.http',
+      '/ws/users/admin/roles.http',
+    ]);
+  });
+
+  it('returns an empty array for an empty tree', () => {
+    expect(getAllFileNodes([])).toEqual([]);
+  });
+});
+
+describe('collectFilePaths', () => {
+  it('collects all file paths', () => {
+    expect(collectFilePaths(tree)).toEqual([
+      '/ws/auth.http',
+      '/ws/users/crud.http',
+      '/ws/users/admin/roles.http',
+    ]);
+  });
+});
+
+describe('removeNodeByPath', () => {
+  it('removes a top-level file', () => {
+    const result = removeNodeByPath(tree, '/ws/auth.http');
+    expect(collectFilePaths(result)).toEqual(['/ws/users/crud.http', '/ws/users/admin/roles.http']);
+  });
+
+  it('removes a nested folder and its subtree', () => {
+    const result = removeNodeByPath(tree, '/ws/users/admin');
+    expect(collectFilePaths(result)).toEqual(['/ws/auth.http', '/ws/users/crud.http']);
+    expect(findFolder(result, '/ws/users/admin')).toBeNull();
+  });
+
+  it('returns a new tree without mutating the original', () => {
+    const result = removeNodeByPath(tree, '/ws/users/crud.http');
+    expect(result).not.toBe(tree);
+    expect(findFile(tree, '/ws/users/crud.http')).not.toBeNull();
+  });
+
+  it('leaves the tree unchanged for a missing path', () => {
+    expect(collectFilePaths(removeNodeByPath(tree, '/ws/nope'))).toEqual(collectFilePaths(tree));
+  });
+});
+
+describe('filterTreeByQuery', () => {
+  it('matches on file name', () => {
+    const result = filterTreeByQuery(tree, 'auth');
+    expect(collectFilePaths(result)).toEqual(['/ws/auth.http']);
+  });
+
+  it('matches on request name case-insensitively', () => {
+    const result = filterTreeByQuery(tree, 'GET USER');
+    expect(collectFilePaths(result)).toEqual(['/ws/users/crud.http']);
+  });
+
+  it('matches on request url and varName', () => {
+    expect(collectFilePaths(filterTreeByQuery(tree, 'api.test'))).toEqual(['/ws/auth.http']);
+    expect(collectFilePaths(filterTreeByQuery(tree, 'login'))).toEqual(['/ws/auth.http']);
+  });
+
+  it('expands folders that contain matches', () => {
+    const result = filterTreeByQuery(tree, 'roles');
+    const users = result[0] as FolderNode;
+    expect(users.type).toBe('folder');
+    expect(users.expanded).toBe(true);
+    const admin = users.children[0] as FolderNode;
+    expect(admin.expanded).toBe(true);
+  });
+
+  it('drops folders with no matches', () => {
+    const result = filterTreeByQuery(tree, 'no-such-thing');
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -1,0 +1,85 @@
+// Workspace tree utilities: typed walkers and lookups over TreeNode[].
+
+import type { TreeNode, FileNode, FolderNode } from './types';
+
+/** Depth-first visit of every node in the tree. */
+export function visitNodes(nodes: TreeNode[], visit: (node: TreeNode) => void): void {
+  for (const node of nodes) {
+    visit(node);
+    if (node.type === 'folder') visitNodes(node.children, visit);
+  }
+}
+
+/** Find a FileNode by absolute path. */
+export function findFile(nodes: TreeNode[], filePath: string): FileNode | null {
+  for (const node of nodes) {
+    if (node.type === 'file' && node.path === filePath) return node;
+    if (node.type === 'folder') {
+      const found = findFile(node.children, filePath);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/** Find a FolderNode by absolute path. */
+export function findFolder(nodes: TreeNode[], folderPath: string): FolderNode | null {
+  for (const node of nodes) {
+    if (node.type === 'folder') {
+      if (node.path === folderPath) return node;
+      const found = findFolder(node.children, folderPath);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/** All FileNodes in the tree, depth-first. */
+export function getAllFileNodes(nodes: TreeNode[]): FileNode[] {
+  const result: FileNode[] = [];
+  visitNodes(nodes, (node) => {
+    if (node.type === 'file') result.push(node);
+  });
+  return result;
+}
+
+/** Absolute paths of every file in the tree, depth-first. */
+export function collectFilePaths(nodes: TreeNode[]): string[] {
+  return getAllFileNodes(nodes).map((f) => f.path);
+}
+
+/** Remove the node with the given path (and its subtree). Returns a new tree. */
+export function removeNodeByPath(nodes: TreeNode[], path: string): TreeNode[] {
+  return nodes
+    .filter((n) => n.path !== path)
+    .map((n) => (n.type === 'folder' ? { ...n, children: removeNodeByPath(n.children, path) } : n));
+}
+
+/**
+ * Filter the tree to files whose name or requests match the query
+ * (request name, url, method or `# @name`). Folders that contain a match
+ * are kept and expanded.
+ */
+export function filterTreeByQuery(nodes: TreeNode[], query: string): TreeNode[] {
+  const q = query.toLowerCase();
+  const result: TreeNode[] = [];
+  for (const node of nodes) {
+    if (node.type === 'file') {
+      const fileMatch = node.name.toLowerCase().includes(q);
+      const reqMatch = node.requests.some(
+        (r) =>
+          r.name.toLowerCase().includes(q) ||
+          r.url.toLowerCase().includes(q) ||
+          r.method.toLowerCase().includes(q) ||
+          (r.varName && r.varName.toLowerCase().includes(q)),
+      );
+      if (fileMatch || reqMatch) result.push(node);
+    } else {
+      const filteredChildren = filterTreeByQuery(node.children, query);
+      if (filteredChildren.length > 0) {
+        result.push({ ...node, children: filteredChildren, expanded: true });
+      }
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Phase 3 (items 16 and 17) of docs/plans/review-remediation.md.

## Item 16: shared import helpers and tree utilities

- New src/lib/importShared.ts: VALID_METHODS, normalizeMethod, sanitizeFilename, sanitizeVarName, newImportId - replaces the three copies in postman.ts, insomnia.ts and openapi.ts
- New src/lib/tree.ts: visitNodes, findFile, findFolder, getAllFileNodes, collectFilePaths, removeNodeByPath, filterTreeByQuery - replaces findFileNode (stores.ts), the any-returning findFileInTree plus collectNames/collectSiblings (App.svelte), filterTree (TreeSidebar.svelte) and getAllFileNodes (parser.ts)
- Unit tests for both modules

## Item 17: kill any at boundaries

- New src/lib/errors.ts with errorMessage(e: unknown); every catch (e: any) removed
- flowIO.ts: parseFlowFile/parseOverrides/parseFlowStep take unknown with narrowing guards; readDir results typed as DirEntry instead of as any[]

## Verification

- pnpm check: 0 errors
- pnpm test: 282 passed
- pnpm lint: 0 errors (warnings down from 94 to 71)
- pnpm format:check: clean
- cargo fmt --check and cargo clippy -D warnings: clean