### PR TITLE
refactor: decompose App.svelte into lib modules

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -74,9 +74,10 @@
   import { errorMessage } from './lib/errors';
   import type { HttpRequest, RequestLocation, EnvironmentFile, KeyVaultState } from './lib/types';
   import type { BottomTab, ResponseTab } from './lib/stores';
-  import { saveFlowRunRecord, clearFlowRunHistory, FLOWS_DIR } from './lib/flowIO';
-  import { openFolderByPath, safeJoinPath } from './lib/workspaceIO';
+  import { saveFlowRunRecord, clearFlowRunHistory } from './lib/flowIO';
+  import { openFolderByPath } from './lib/workspaceIO';
   import { importCollectionContent, applyImportedVariables } from './lib/importIO';
+  import { createFlow, duplicateFlow, saveFlow, deleteFlow } from './lib/flowOps';
   import {
     createFile,
     createFolder,
@@ -738,33 +739,6 @@
     openFlowTab(path, flow.name);
   }
 
-  async function handleCreateFlow(e: CustomEvent<string>) {
-    const name = e.detail;
-    const rootPath = $workspace.rootPath;
-    if (!rootPath) return;
-
-    const { createEmptyFlow, writeFlowFile } = await import('./lib/flowIO');
-    const flow = createEmptyFlow(name);
-    const safeName =
-      name
-        .toLowerCase()
-        .replace(/[^a-z0-9_-]+/g, '-')
-        .replace(/-+/g, '-')
-        .replace(/^-|-$/g, '') || 'unnamed';
-    const flowsDir = await join(rootPath, FLOWS_DIR);
-    try {
-      await (await import('@tauri-apps/plugin-fs')).mkdir(flowsDir, { recursive: true });
-    } catch {
-      /* exists */
-    }
-    const absolutePath = await join(flowsDir, `${safeName}.pb-flow.json`);
-    const relativePath = `${FLOWS_DIR}/${safeName}.pb-flow.json`;
-
-    await writeFlowFile(absolutePath, flow);
-    flows.update((f) => ({ ...f, [relativePath]: flow }));
-    openFlowTab(relativePath, flow.name);
-  }
-
   let flowAbortController: AbortController | null = null;
   let lastFlowRunRecords: Record<string, FlowRunRecord> = {};
   let runningFlowPath: string | null = null;
@@ -863,78 +837,9 @@
     flowAbortController?.abort();
   }
 
-  async function handleSaveFlow(
-    e: CustomEvent<{ flowPath: string; flow: import('./lib/types').FlowDefinition }>,
-  ) {
-    const { flowPath, flow } = e.detail;
-    const rootPath = $workspace.rootPath;
-    if (!rootPath) return;
-
-    const { writeFlowFile } = await import('./lib/flowIO');
-    const absolutePath = await safeJoinPath(rootPath, flowPath);
-    await writeFlowFile(absolutePath, flow);
-    flows.update((f) => ({ ...f, [flowPath]: flow }));
-
-    // Update tab label if the name changed
-    flowTabs.update((ts) =>
-      ts.map((t) => (t.flowPath === flowPath ? { ...t, label: flow.name } : t)),
-    );
-  }
-
-  async function handleDuplicateFlow(e: CustomEvent<string>) {
-    const sourcePath = e.detail;
-    const sourceFlow = $flows[sourcePath];
-    if (!sourceFlow) return;
-    const rootPath = $workspace.rootPath;
-    if (!rootPath) return;
-
-    const { writeFlowFile } = await import('./lib/flowIO');
-    const newName = `${sourceFlow.name} (copy)`;
-    const newFlow = {
-      ...sourceFlow,
-      name: newName,
-      steps: sourceFlow.steps.map((s) => ({ ...s, id: crypto.randomUUID() })),
-    };
-    const safeName =
-      newName
-        .toLowerCase()
-        .replace(/[^a-z0-9_-]+/g, '-')
-        .replace(/-+/g, '-')
-        .replace(/^-|-$/g, '') || 'unnamed';
-    const flowsDir = await join(rootPath, FLOWS_DIR);
-    try {
-      await (await import('@tauri-apps/plugin-fs')).mkdir(flowsDir, { recursive: true });
-    } catch {
-      /* exists */
-    }
-    const absolutePath = await join(flowsDir, `${safeName}.pb-flow.json`);
-    const relativePath = `${FLOWS_DIR}/${safeName}.pb-flow.json`;
-
-    await writeFlowFile(absolutePath, newFlow);
-    flows.update((f) => ({ ...f, [relativePath]: newFlow }));
-    openFlowTab(relativePath, newFlow.name);
-  }
-
   async function handleDeleteFlow(e: CustomEvent<string>) {
-    const path = e.detail;
-    const rootPath = $workspace.rootPath;
-    if (!rootPath) return;
-
-    try {
-      const { remove } = await import('@tauri-apps/plugin-fs');
-      const absolutePath = await safeJoinPath(rootPath, path);
-      await remove(absolutePath);
-    } catch {
-      // Silently ignore - flow file may not exist on disk
-    }
-
-    flows.update((f) => {
-      const updated = { ...f };
-      delete updated[path];
-      return updated;
-    });
-    delete flowUIState[path];
-    closeFlowTab(path);
+    delete flowUIState[e.detail];
+    await deleteFlow(e.detail);
   }
 </script>
 
@@ -1053,8 +958,8 @@
         on:openSettings={() => (showSettings = true)}
         on:nameRequest={handleNameRequest}
         on:openFlow={handleOpenFlow}
-        on:createFlow={handleCreateFlow}
-        on:duplicateFlow={handleDuplicateFlow}
+        on:createFlow={(e) => createFlow(e.detail)}
+        on:duplicateFlow={(e) => duplicateFlow(e.detail)}
         on:deleteFlow={handleDeleteFlow}
       />
     </div>
@@ -1119,7 +1024,7 @@
               flowUIState[$activeFlowTabPath] = e.detail;
               flowUIState = flowUIState;
             }}
-            on:save={handleSaveFlow}
+            on:save={(e) => saveFlow(e.detail.flowPath, e.detail.flow)}
             on:run={handleRunFlow}
             on:abort={handleAbortFlow}
             on:clearHistory={() => {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -82,7 +82,6 @@
     buildWorkspaceTree,
     createFileNode,
     createEmptyFileNode,
-    resolveEnvironmentVariables,
   } from './lib/parser';
   import type { SubstitutionContext } from './lib/parser';
   import { getAllFileNodes, findFile, findFolder, collectFilePaths } from './lib/tree';
@@ -104,20 +103,19 @@
     loadFlowHistory,
     saveFlowRunRecord,
     clearFlowRunHistory,
-    parseFlowFile,
     FLOWS_DIR,
     migrateFlowsDirectory,
   } from './lib/flowIO';
   import { generateFolderName } from './lib/folderCreate';
   import { runFlow } from './lib/flowRunner';
   import { executeHttpRequest } from './lib/requestExec';
+  import { startMcpBridge } from './lib/mcpBridge';
   import type { PbVarEffects } from './lib/requestExec';
   import type { FlowStepResult, FlowRunRecord } from './lib/types';
 
   import { open } from '@tauri-apps/plugin-dialog';
   import { readTextFile, writeTextFile, readDir, rename } from '@tauri-apps/plugin-fs';
   import { invoke } from '@tauri-apps/api/core';
-  import { listen, emit } from '@tauri-apps/api/event';
   import { join, basename, dirname } from '@tauri-apps/api/path';
   import { onDestroy } from 'svelte';
   import { get } from 'svelte/store';
@@ -359,266 +357,10 @@
   });
 
   // ─── MCP Bridge ───
-  // The embedded MCP server (Rust) reaches live app state through Tauri events:
-  // it emits `mcp:request` with { id, kind, params }; we do the work for `kind`
-  // and emit `mcp:response` with { id, ok, data?, error? }, matched by `id`.
-  // New MCP tools that need frontend state add a `kind` branch here.
+  // Bridge logic lives in src/lib/mcpBridge.ts; App.svelte only owns the
+  // listener's lifecycle (started here, torn down in onDestroy).
 
-  interface BridgeRequest {
-    id: string;
-    kind: string;
-    params: unknown;
-  }
-
-  function respondBridge(
-    id: string,
-    payload: { ok: true; data: unknown } | { ok: false; error: string },
-  ) {
-    emit('mcp:response', { id, ...payload }).catch(() => {});
-  }
-
-  /** Gather every request across all .http files in the open workspace. */
-  function collectWorkspaceRequests() {
-    const ws = get(workspace);
-    if (!ws.rootPath) return [];
-    return getAllFileNodes(ws.tree).flatMap((file) => {
-      const filePath = file.path.substring(ws.rootPath!.length + 1).replaceAll('\\', '/');
-      return file.requests.map((req, requestIndex) => ({
-        filePath,
-        requestIndex,
-        name: req.name,
-        method: req.method,
-        url: req.url,
-      }));
-    });
-  }
-
-  interface ExecuteRequestParams {
-    filePath: string;
-    requestIndex: number;
-    environment?: string | null;
-  }
-
-  /**
-   * Run a single request for the MCP `execute_request` tool and return the
-   * structured result. This is the silent twin of `sendRequest`: it must never
-   * touch UI stores (`currentResponse`, `currentSentRequest`, `pbAssertionResults`,
-   * tabs, `namedResults`, `pbGlobals`, `pbFileOverrides`). All runtime state from
-   * pb directives is kept in locals and discarded after the call.
-   */
-  async function executeRequestSilently(params: ExecuteRequestParams) {
-    const ws = get(workspace);
-    if (!ws.rootPath) throw new Error('No workspace folder is open');
-
-    const normalized = params.filePath.replaceAll('\\', '/');
-    const file = getAllFileNodes(ws.tree).find(
-      (f) => f.path.substring(ws.rootPath!.length + 1).replaceAll('\\', '/') === normalized,
-    );
-    if (!file) throw new Error(`File not found in workspace: ${params.filePath}`);
-
-    const request = file.requests[params.requestIndex];
-    if (!request) {
-      throw new Error(`No request at index ${params.requestIndex} in ${params.filePath}`);
-    }
-
-    // Resolve environment variables for the requested environment, falling back to
-    // the active one. For the active environment, reuse the fully-resolved store so
-    // Key Vault secrets, globals, and pb.set overrides are included exactly as the
-    // UI sees them; for any other environment, resolve it fresh from the env files.
-    const active = get(activeEnvironment);
-    const effectiveEnv = params.environment ?? active;
-    let environmentVariables: Record<string, string>;
-    if (effectiveEnv && effectiveEnv === active) {
-      environmentVariables = { ...get(resolvedEnvVars) };
-    } else if (effectiveEnv) {
-      environmentVariables = {
-        ...resolveEnvironmentVariables(effectiveEnv, get(envFile), get(userEnvFile)),
-        ...get(pbGlobals),
-        ...(get(pbFileOverrides)[file.path] ?? {}),
-      };
-    } else {
-      environmentVariables = { ...get(pbGlobals) };
-    }
-
-    const ctx: SubstitutionContext = {
-      fileVariables: file.variables,
-      environmentVariables,
-      // Read-only copy: chaining can resolve existing named results, but the
-      // silent run must not mutate the shared store.
-      namedResults: { ...get(namedResults) },
-      dotenvVariables: get(dotenvVariables),
-    };
-
-    // All pb effects (set/global vars, named result) stay in the returned
-    // locals and are discarded - a silent run never reaches the stores.
-    const result = await executeHttpRequest(request, ctx, { alias: request.varName });
-
-    return {
-      status: result.response.status,
-      statusText: result.response.statusText,
-      headers: result.response.headers,
-      body: result.response.body,
-      time: result.response.time,
-      assertions: result.assertionResults.map((a) => ({ label: a.label, passed: a.passed })),
-    };
-  }
-
-  interface ExecuteFlowParams {
-    flowFilePath: string;
-    environment?: string | null;
-  }
-
-  /**
-   * Run a whole flow for the MCP `execute_flow` tool and return the structured
-   * run record. This is the silent twin of `handleRunFlow`: it loads and runs the
-   * flow but must never touch UI stores (`flowRunState`, `flowRunHistory`,
-   * `lastFlowRunRecords`, tabs) and must not persist a results file. `runFlow`
-   * keeps all run state in isolated locals, which are discarded after mapping.
-   */
-  async function executeFlowSilently(params: ExecuteFlowParams) {
-    const ws = get(workspace);
-    if (!ws.rootPath) throw new Error('No workspace folder is open');
-
-    const relPath = params.flowFilePath.replaceAll('\\', '/');
-    if (!relPath.endsWith('.pb-flow.json')) {
-      throw new Error(`Not a flow file (expected .pb-flow.json): ${params.flowFilePath}`);
-    }
-    const absolutePath = await join(ws.rootPath, relPath);
-
-    let content: string;
-    try {
-      content = await readTextFile(absolutePath);
-    } catch {
-      throw new Error(`Flow file not found: ${params.flowFilePath}`);
-    }
-
-    let raw: unknown;
-    try {
-      raw = JSON.parse(content);
-    } catch {
-      throw new Error(`Flow file is not valid JSON: ${params.flowFilePath}`);
-    }
-    if (
-      typeof raw !== 'object' ||
-      raw === null ||
-      !Array.isArray((raw as { steps?: unknown }).steps)
-    ) {
-      throw new Error(`Not a valid flow file: ${params.flowFilePath}`);
-    }
-    const flow = parseFlowFile(content);
-
-    // Resolve environment variables for the requested environment, falling back to
-    // the active one. Mirror executeRequestSilently: reuse the resolved store for
-    // the active env (so Key Vault secrets, globals, and pb.set overrides are
-    // included as the UI sees them); resolve any other env fresh from the files.
-    const active = get(activeEnvironment);
-    const effectiveEnv = params.environment ?? active;
-    let environmentVariables: Record<string, string>;
-    if (effectiveEnv && effectiveEnv === active) {
-      environmentVariables = { ...get(resolvedEnvVars) };
-    } else if (effectiveEnv) {
-      environmentVariables = {
-        ...resolveEnvironmentVariables(effectiveEnv, get(envFile), get(userEnvFile)),
-        ...get(pbGlobals),
-      };
-    } else {
-      environmentVariables = { ...get(pbGlobals) };
-    }
-
-    // No-op callbacks: a silent run reports nothing to the UI. runFlow returns a
-    // fully isolated record; we never write it to stores or to disk.
-    const record = await runFlow(
-      flow,
-      ws.rootPath,
-      ws.tree,
-      environmentVariables,
-      get(dotenvVariables),
-      effectiveEnv,
-      { onStepStart() {}, onStepComplete() {} },
-    );
-
-    // Map the internal record onto the tool's output shape. The flow runner stores
-    // both network errors and assertion/HTTP failures as `failed`; split them back
-    // out so a network-level failure (non-null `error`) surfaces as `error`.
-    const stepById = new Map(flow.steps.map((s) => [s.id, s]));
-    const steps = record.stepResults.map((r) => {
-      const status: 'passed' | 'failed' | 'skipped' | 'error' =
-        r.status === 'failed' && r.error != null
-          ? 'error'
-          : r.status === 'passed'
-            ? 'passed'
-            : r.status === 'skipped'
-              ? 'skipped'
-              : 'failed';
-      return {
-        id: r.stepId,
-        label: stepById.get(r.stepId)?.label ?? '',
-        status,
-        durationMs: r.durationMs,
-        assertions: r.assertionResults.map((a) => ({ label: a.label, passed: a.passed })),
-        error: r.error,
-      };
-    });
-
-    const overall: 'passed' | 'failed' | 'error' = steps.some((s) => s.status === 'error')
-      ? 'error'
-      : steps.some((s) => s.status === 'failed')
-        ? 'failed'
-        : 'passed';
-
-    return { status: overall, summary: record.summary, steps };
-  }
-
-  /**
-   * Snapshot the user's most recent manual request result for the MCP
-   * `get_last_result` tool. Reads the live UI stores without mutating them and
-   * returns the `execute_request` shape, or `null` if no request has run yet.
-   */
-  function snapshotLastResult() {
-    const response = get(currentResponse);
-    if (!response) return null;
-    return {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-      body: response.body,
-      time: response.time,
-      assertions: get(pbAssertionResults).map((a) => ({ label: a.label, passed: a.passed })),
-    };
-  }
-
-  async function handleBridgeRequest(req: BridgeRequest) {
-    try {
-      switch (req.kind) {
-        case 'list_requests':
-          respondBridge(req.id, { ok: true, data: collectWorkspaceRequests() });
-          break;
-        case 'execute_request':
-          respondBridge(req.id, {
-            ok: true,
-            data: await executeRequestSilently(req.params as ExecuteRequestParams),
-          });
-          break;
-        case 'execute_flow':
-          respondBridge(req.id, {
-            ok: true,
-            data: await executeFlowSilently(req.params as ExecuteFlowParams),
-          });
-          break;
-        case 'get_last_result':
-          respondBridge(req.id, { ok: true, data: snapshotLastResult() });
-          break;
-        default:
-          respondBridge(req.id, { ok: false, error: `Unknown MCP bridge request: ${req.kind}` });
-      }
-    } catch (e) {
-      respondBridge(req.id, { ok: false, error: e instanceof Error ? e.message : String(e) });
-    }
-  }
-
-  const mcpBridgeUnlisten = listen<BridgeRequest>('mcp:request', (event) => {
-    void handleBridgeRequest(event.payload);
-  });
+  const mcpBridgeUnlisten = startMcpBridge();
 
   void refreshMcpStatus();
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -40,12 +40,6 @@
     updateRequestInTree,
     addRequestToFile,
     deleteRequestFromFile,
-    removeFileFromTree,
-    removeFolderFromTree,
-    addFileToTree,
-    addFolderToTree,
-    renameFolderInTree,
-    renameFileInTree,
     editingFilePath,
     editingFolderPath,
     toggleFolder,
@@ -79,11 +73,9 @@
     substituteAll,
     ensureSharedEnvironment,
     buildWorkspaceTree,
-    createFileNode,
-    createEmptyFileNode,
   } from './lib/parser';
   import type { SubstitutionContext } from './lib/parser';
-  import { getAllFileNodes, findFile, findFolder, collectFilePaths } from './lib/tree';
+  import { getAllFileNodes, findFile } from './lib/tree';
   import { errorMessage } from './lib/errors';
   import { importPostmanCollection } from './lib/postman';
   import { importInsomniaExport } from './lib/insomnia';
@@ -98,7 +90,16 @@
   import type { BottomTab, ResponseTab } from './lib/stores';
   import { saveFlowRunRecord, clearFlowRunHistory, FLOWS_DIR } from './lib/flowIO';
   import { openFolderByPath, scanForHttpFiles, safeJoinPath } from './lib/workspaceIO';
-  import { generateFolderName } from './lib/folderCreate';
+  import {
+    createFile,
+    createFolder,
+    renameFile,
+    renameFolder,
+    duplicateFile,
+    deleteFile,
+    deleteFolder,
+    cancelRename,
+  } from './lib/fileOps';
   import { runFlow } from './lib/flowRunner';
   import { executeHttpRequest } from './lib/requestExec';
   import { startMcpBridge } from './lib/mcpBridge';
@@ -106,7 +107,7 @@
   import type { FlowStepResult, FlowRunRecord } from './lib/types';
 
   import { open } from '@tauri-apps/plugin-dialog';
-  import { readTextFile, writeTextFile, rename } from '@tauri-apps/plugin-fs';
+  import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
   import { invoke } from '@tauri-apps/api/core';
   import { join, basename, dirname } from '@tauri-apps/api/path';
   import { onDestroy } from 'svelte';
@@ -806,202 +807,6 @@
     deleteRequestFromFile(e.detail.filePath, e.detail.requestIndex);
   }
 
-  async function handleDeleteFile(e: CustomEvent<string>) {
-    const filePath = e.detail;
-
-    try {
-      const { remove } = await import('@tauri-apps/plugin-fs');
-      await remove(filePath);
-    } catch (err) {
-      addToast(`Failed to delete file: ${errorMessage(err)}`, 'error');
-      return;
-    }
-
-    removeFileFromTree(filePath);
-  }
-
-  async function handleDeleteFolder(e: CustomEvent<string>) {
-    const folderPath = e.detail;
-
-    try {
-      const { remove } = await import('@tauri-apps/plugin-fs');
-      await remove(folderPath, { recursive: true });
-    } catch (err) {
-      addToast(`Failed to delete folder: ${errorMessage(err)}`, 'error');
-      return;
-    }
-
-    removeFolderFromTree(folderPath);
-  }
-
-  async function handleCreateFile(e: CustomEvent<string | null>) {
-    const rootPath = $workspace.rootPath;
-    if (!rootPath) return;
-
-    const folderPath = e.detail || rootPath;
-
-    // Generate unique filename
-    const stem = 'new-request';
-    let fileName = stem + '.http';
-    let filePath = await join(folderPath, fileName);
-    let counter = 2;
-
-    // Check for collisions in the tree
-    const existingNames = new Set(collectFilePaths($workspace.tree));
-
-    while (existingNames.has(filePath)) {
-      fileName = `${stem}-${counter}.http`;
-      filePath = await join(folderPath, fileName);
-      counter++;
-    }
-
-    const fileNode = createEmptyFileNode(filePath, fileName);
-    const content = serializeHttpFile(fileNode.requests, fileNode.variables);
-
-    try {
-      await writeTextFile(filePath, content);
-    } catch (err) {
-      addToast(`Failed to create file: ${errorMessage(err)}`, 'error');
-      return;
-    }
-
-    fileNode.dirty = false;
-    fileNode.savedContent = content;
-    addFileToTree(folderPath === rootPath ? null : folderPath, fileNode);
-    editingFilePath.set(filePath);
-  }
-
-  async function handleCreateFolder(e: CustomEvent<string | null>) {
-    const rootPath = $workspace.rootPath;
-    if (!rootPath) return;
-
-    const parentDir = e.detail || rootPath;
-
-    // Collect sibling names in the target parent
-    const siblings = new Set<string>();
-    if (parentDir === rootPath) {
-      for (const n of $workspace.tree) siblings.add(n.name);
-    } else {
-      const parent = findFolder($workspace.tree, parentDir);
-      for (const c of parent?.children ?? []) siblings.add(c.name);
-    }
-
-    const folderName = generateFolderName(siblings);
-    const folderPath = await join(parentDir, folderName);
-
-    try {
-      const { mkdir } = await import('@tauri-apps/plugin-fs');
-      await mkdir(folderPath, { recursive: true });
-    } catch (err) {
-      addToast(`Failed to create folder: ${errorMessage(err)}`, 'error');
-      return;
-    }
-
-    addFolderToTree(parentDir === rootPath ? null : parentDir, {
-      type: 'folder',
-      name: folderName,
-      path: folderPath,
-      children: [],
-      expanded: true,
-    });
-    editingFolderPath.set(folderPath);
-  }
-
-  async function handleRenameFolder(e: CustomEvent<{ oldPath: string; newName: string }>) {
-    const { oldPath, newName } = e.detail;
-    const dir = await dirname(oldPath);
-    const newPath = await join(dir, newName);
-
-    try {
-      await rename(oldPath, newPath);
-    } catch (err) {
-      addToast(`Failed to rename folder: ${errorMessage(err)}`, 'error');
-      return;
-    }
-
-    renameFolderInTree(oldPath, newPath, newName);
-    editingFolderPath.set(null);
-  }
-
-  async function handleRenameFile(e: CustomEvent<{ oldPath: string; newName: string }>) {
-    const { oldPath, newName } = e.detail;
-
-    // If file is dirty, save first
-    const file = findFile($workspace.tree, oldPath);
-    if (file && file.dirty) {
-      try {
-        const content = serializeHttpFile(file.requests, file.variables);
-        await writeTextFile(oldPath, content);
-        markFileSaved(oldPath);
-      } catch (err) {
-        addToast(`Failed to save file before rename: ${errorMessage(err)}`, 'error');
-        return;
-      }
-    }
-
-    const dir = await dirname(oldPath);
-    const newPath = await join(dir, newName);
-
-    try {
-      await rename(oldPath, newPath);
-    } catch (err) {
-      addToast(`Failed to rename file: ${errorMessage(err)}`, 'error');
-      return;
-    }
-
-    renameFileInTree(oldPath, newPath, newName);
-    editingFilePath.set(null);
-  }
-
-  async function handleDuplicateFile(e: CustomEvent<string>) {
-    const sourcePath = e.detail;
-
-    let content: string;
-    try {
-      content = await readTextFile(sourcePath);
-    } catch (err) {
-      addToast(`Failed to read file: ${errorMessage(err)}`, 'error');
-      return;
-    }
-
-    const dir = await dirname(sourcePath);
-    const sourceBase = await basename(sourcePath);
-    const sourceStem = sourceBase.replace(/\.(http|rest)$/, '');
-
-    // Generate unique copy name
-    let copyStem = `${sourceStem} (copy)`;
-    let copyName = copyStem + '.http';
-    let copyPath = await join(dir, copyName);
-    let counter = 2;
-
-    const existingNames = new Set(collectFilePaths($workspace.tree));
-
-    while (existingNames.has(copyPath)) {
-      copyStem = `${sourceStem} (copy ${counter})`;
-      copyName = copyStem + '.http';
-      copyPath = await join(dir, copyName);
-      counter++;
-    }
-
-    try {
-      await writeTextFile(copyPath, content);
-    } catch (err) {
-      addToast(`Failed to duplicate file: ${errorMessage(err)}`, 'error');
-      return;
-    }
-
-    const fileNode = createFileNode(copyPath, copyName, content);
-    const rootPath = $workspace.rootPath;
-    const parentPath = dir === rootPath ? null : dir;
-    addFileToTree(parentPath, fileNode);
-    editingFilePath.set(copyPath);
-  }
-
-  function handleCancelRename() {
-    editingFilePath.set(null);
-    editingFolderPath.set(null);
-  }
-
   function handleToggleFolder(e: CustomEvent<string>) {
     toggleFolder(e.detail);
   }
@@ -1390,14 +1195,14 @@
         on:toggleFolder={handleToggleFolder}
         on:addRequest={handleAddRequest}
         on:deleteRequest={handleDeleteRequest}
-        on:deleteFile={handleDeleteFile}
-        on:deleteFolder={handleDeleteFolder}
-        on:createFile={handleCreateFile}
-        on:createFolder={handleCreateFolder}
-        on:renameFile={handleRenameFile}
-        on:renameFolder={handleRenameFolder}
-        on:duplicateFile={handleDuplicateFile}
-        on:cancelRename={handleCancelRename}
+        on:deleteFile={(e) => deleteFile(e.detail)}
+        on:deleteFolder={(e) => deleteFolder(e.detail)}
+        on:createFile={(e) => createFile(e.detail)}
+        on:createFolder={(e) => createFolder(e.detail)}
+        on:renameFile={(e) => renameFile(e.detail.oldPath, e.detail.newName)}
+        on:renameFolder={(e) => renameFolder(e.detail.oldPath, e.detail.newName)}
+        on:duplicateFile={(e) => duplicateFile(e.detail)}
+        on:cancelRename={cancelRename}
         on:changeEnv={(e) => activeEnvironment.set(e.detail)}
         on:editEnv={() => (showEnvEditor = true)}
         on:openVarInspector={() => (showVarInspector = true)}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -74,7 +74,6 @@
   } from './lib/keyvaultCache';
   import { serializeHttpFile, substituteAll } from './lib/parser';
   import type { SubstitutionContext } from './lib/parser';
-  import { getAllFileNodes, findFile } from './lib/tree';
   import { errorMessage } from './lib/errors';
   import type { HttpRequest, RequestLocation, EnvironmentFile } from './lib/types';
   import type { BottomTab, ResponseTab } from './lib/stores';
@@ -82,6 +81,7 @@
   import { openFolderByPath } from './lib/workspaceIO';
   import { importCollectionContent, applyImportedVariables } from './lib/importIO';
   import { createFlow, duplicateFlow, saveFlow, deleteFlow } from './lib/flowOps';
+  import { runAllRequests, nameRequest } from './lib/requestOps';
   import {
     createFile,
     createFolder,
@@ -593,81 +593,6 @@
     toggleFolder(e.detail);
   }
 
-  /** Resolve the full dependency chain in topological order, then run each unsent request. */
-  async function handleRunAll(e: CustomEvent<string[]>) {
-    const allFiles = getAllFileNodes($workspace.tree);
-    const depRe = /\{\{(\w+)\.(?:request|response)\./g;
-
-    // Build a lookup: varName -> HttpRequest
-    const requestByName = new Map<string, HttpRequest>();
-    for (const file of allFiles) {
-      for (const req of file.requests) {
-        if (req.varName) requestByName.set(req.varName, req);
-      }
-    }
-
-    // Collect transitive dependencies in execution order (deepest first)
-    const ordered: string[] = [];
-    const visited = new Set<string>();
-
-    function resolve(name: string) {
-      if (visited.has(name)) return;
-      visited.add(name);
-      const req = requestByName.get(name);
-      if (!req) return;
-      // Find this request's own dependencies
-      const text = `${req.url} ${req.headers.map((h) => h.value).join(' ')} ${req.body}`;
-      let match;
-      const re = new RegExp(depRe.source, 'g');
-      while ((match = re.exec(text)) !== null) {
-        resolve(match[1]);
-      }
-      ordered.push(name);
-    }
-
-    for (const name of e.detail) {
-      resolve(name);
-    }
-
-    // Execute in order, skipping already-sent requests
-    for (const name of ordered) {
-      if ($namedResults[name]) continue;
-      const req = requestByName.get(name);
-      if (req) await sendRequest(req);
-    }
-  }
-
-  function handleNameRequest(
-    e: CustomEvent<{ filePath: string; requestIndex: number; varName: string }>,
-  ) {
-    const { filePath, requestIndex, varName } = e.detail;
-    const file = findFile($workspace.tree, filePath);
-    if (!file) return;
-    const req = file.requests[requestIndex];
-    if (!req) return;
-    // Block duplicate names
-    if (varName) {
-      const duplicate = getAllFileNodes($workspace.tree).some((f) =>
-        f.requests.some(
-          (r, ri) => r.varName === varName && !(f.path === filePath && ri === requestIndex),
-        ),
-      );
-      if (duplicate) {
-        addToast(`Name "${varName}" is already in use`);
-        return;
-      }
-    }
-    // Remove old name from namedResults if it changed or was cleared
-    if (req.varName && req.varName !== varName) {
-      namedResults.update((nr) => {
-        const updated = { ...nr };
-        delete updated[req.varName!];
-        return updated;
-      });
-    }
-    updateRequestInTree(filePath, requestIndex, { ...req, varName: varName || null });
-  }
-
   // ─── Flow Handlers ───
 
   function handleOpenFlow(e: CustomEvent<string>) {
@@ -894,7 +819,8 @@
         on:openVarInspector={() => (showVarInspector = true)}
         on:openHelp={() => (showHelp = true)}
         on:openSettings={() => (showSettings = true)}
-        on:nameRequest={handleNameRequest}
+        on:nameRequest={(e) =>
+          nameRequest(e.detail.filePath, e.detail.requestIndex, e.detail.varName)}
         on:openFlow={handleOpenFlow}
         on:createFlow={(e) => createFlow(e.detail)}
         on:duplicateFlow={(e) => duplicateFlow(e.detail)}
@@ -982,7 +908,7 @@
               on:update={handleUpdateRequest}
               on:send={(e) => sendRequest(e.detail)}
               on:save={saveActiveFile}
-              on:runAll={handleRunAll}
+              on:runAll={(e) => runAllRequests(e.detail, sendRequest)}
               on:bottomTabChange={handleBottomTabChange}
             />
           </div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -67,12 +67,16 @@
     activeFlow,
     favorites,
   } from './lib/stores';
-  import { extractKeyVaultConfig, fetchKeyVaultSecrets, kvCacheKey } from './lib/keyvault';
+  import {
+    refreshKeyVaultSecrets,
+    resetKeyVaultCache,
+    refreshKeyVaultForEnv,
+  } from './lib/keyvaultCache';
   import { serializeHttpFile, substituteAll } from './lib/parser';
   import type { SubstitutionContext } from './lib/parser';
   import { getAllFileNodes, findFile } from './lib/tree';
   import { errorMessage } from './lib/errors';
-  import type { HttpRequest, RequestLocation, EnvironmentFile, KeyVaultState } from './lib/types';
+  import type { HttpRequest, RequestLocation, EnvironmentFile } from './lib/types';
   import type { BottomTab, ResponseTab } from './lib/stores';
   import { saveFlowRunRecord, clearFlowRunHistory } from './lib/flowIO';
   import { openFolderByPath } from './lib/workspaceIO';
@@ -229,72 +233,8 @@
   }
 
   // ─── Key Vault ───
-
-  let lastKvEnv: string | null = null;
-  let kvFetchSeq = 0;
-  /** Per-environment KV cache - persists across env switches, cleared on folder change. */
-  let kvCache: Record<string, KeyVaultState> = {};
-  const idleKv: KeyVaultState = { status: 'idle', variables: {}, error: null, cacheKey: null };
-
-  async function refreshKeyVaultSecrets(forEnv?: string) {
-    const env = forEnv ?? $activeEnvironment;
-    if (!env) {
-      keyVaultState.set(idleKv);
-      return;
-    }
-
-    const config = extractKeyVaultConfig(env, $envFile, $userEnvFile);
-    if (!config) {
-      // No KV config for this env - restore idle but keep cache for other envs
-      keyVaultState.set(idleKv);
-      return;
-    }
-
-    const newCacheKey = kvCacheKey(env, config);
-
-    // Check per-env cache first
-    const cached = kvCache[newCacheKey];
-    if (cached && cached.status === 'loaded') {
-      keyVaultState.set(cached);
-      return;
-    }
-
-    // Only clear conflict preferences when switching environments
-    if (lastKvEnv !== env) {
-      varSourcePrefs.set({});
-    }
-    lastKvEnv = env;
-
-    const seq = ++kvFetchSeq;
-    keyVaultState.set({ status: 'loading', variables: {}, error: null, cacheKey: newCacheKey });
-
-    try {
-      const vars = await fetchKeyVaultSecrets(config);
-      if (kvFetchSeq === seq) {
-        const state: KeyVaultState = {
-          status: 'loaded',
-          variables: vars,
-          error: null,
-          cacheKey: newCacheKey,
-        };
-        kvCache[newCacheKey] = state;
-        kvCache = kvCache;
-        keyVaultState.set(state);
-      }
-    } catch (err: unknown) {
-      if (kvFetchSeq === seq) {
-        const msg = err instanceof Error ? err.message : String(err);
-        const state: KeyVaultState = {
-          status: 'error',
-          variables: {},
-          error: msg,
-          cacheKey: newCacheKey,
-        };
-        keyVaultState.set(state);
-        addToast(`Key Vault error: ${msg}`, 'error');
-      }
-    }
-  }
+  // Cache and fetch live in src/lib/keyvaultCache.ts; App.svelte only owns
+  // the environment-change subscription.
 
   const unsubKv = activeEnvironment.subscribe(() => {
     refreshKeyVaultSecrets();
@@ -387,14 +327,12 @@
   })();
 
   // ─── Open Folder (scan for .http files) ───
-  // Scanning and opening live in src/lib/workspaceIO.ts; App.svelte supplies
-  // the Key Vault hooks because the per-environment KV cache is UI state here.
+  // Scanning and opening live in src/lib/workspaceIO.ts; the Key Vault hooks
+  // reset and refill the per-environment secret cache in lib/keyvaultCache.ts.
 
   function openWorkspaceFolder(rootPath: string) {
     return openFolderByPath(rootPath, {
-      resetCache: () => {
-        kvCache = {};
-      },
+      resetCache: resetKeyVaultCache,
       refresh: () => {
         refreshKeyVaultSecrets();
       },
@@ -999,15 +937,7 @@
               on:sourcePref={(e) => {
                 varSourcePrefs.update((p) => ({ ...p, [e.detail.key]: e.detail.source }));
               }}
-              on:refreshKv={(e) => {
-                // Invalidate cache for this env so fresh secrets are fetched
-                for (const key of Object.keys(kvCache)) {
-                  if (key.startsWith(e.detail + '::')) delete kvCache[key];
-                }
-                kvCache = kvCache;
-                keyVaultState.update((s) => ({ ...s, cacheKey: null }));
-                refreshKeyVaultSecrets(e.detail);
-              }}
+              on:refreshKv={(e) => refreshKeyVaultForEnv(e.detail)}
             />
           </div>
         {:else if $activeFlowTabPath && $activeFlow}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -68,28 +68,15 @@
     favorites,
   } from './lib/stores';
   import { extractKeyVaultConfig, fetchKeyVaultSecrets, kvCacheKey } from './lib/keyvault';
-  import {
-    serializeHttpFile,
-    substituteAll,
-    ensureSharedEnvironment,
-    buildWorkspaceTree,
-  } from './lib/parser';
+  import { serializeHttpFile, substituteAll } from './lib/parser';
   import type { SubstitutionContext } from './lib/parser';
   import { getAllFileNodes, findFile } from './lib/tree';
   import { errorMessage } from './lib/errors';
-  import { importPostmanCollection } from './lib/postman';
-  import { importInsomniaExport } from './lib/insomnia';
-  import { importOpenApiSpec } from './lib/openapi';
-  import type {
-    HttpRequest,
-    RequestLocation,
-    EnvironmentFile,
-    ImportResult,
-    KeyVaultState,
-  } from './lib/types';
+  import type { HttpRequest, RequestLocation, EnvironmentFile, KeyVaultState } from './lib/types';
   import type { BottomTab, ResponseTab } from './lib/stores';
   import { saveFlowRunRecord, clearFlowRunHistory, FLOWS_DIR } from './lib/flowIO';
-  import { openFolderByPath, scanForHttpFiles, safeJoinPath } from './lib/workspaceIO';
+  import { openFolderByPath, safeJoinPath } from './lib/workspaceIO';
+  import { importCollectionContent, applyImportedVariables } from './lib/importIO';
   import {
     createFile,
     createFolder,
@@ -107,9 +94,9 @@
   import type { FlowStepResult, FlowRunRecord } from './lib/types';
 
   import { open } from '@tauri-apps/plugin-dialog';
-  import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
+  import { writeTextFile } from '@tauri-apps/plugin-fs';
   import { invoke } from '@tauri-apps/api/core';
-  import { join, basename, dirname } from '@tauri-apps/api/path';
+  import { join } from '@tauri-apps/api/path';
   import { onDestroy } from 'svelte';
   import { get } from 'svelte/store';
 
@@ -149,44 +136,7 @@
 
   async function handleImportEnvConfirm(e: CustomEvent<{ target: string }>) {
     showImportEnvModal = false;
-    const envName = e.detail.target;
-    const rootPath = $workspace.rootPath;
-    if (!rootPath || pendingImportVars.length === 0) return;
-
-    try {
-      // Load or create the env file
-      const currentEnv: EnvironmentFile = ensureSharedEnvironment($envFile ?? {});
-
-      // Ensure the target environment exists
-      if (!currentEnv[envName]) {
-        currentEnv[envName] = {};
-      }
-
-      // Add discovered variables with their values (only if not already present)
-      for (const v of pendingImportVars) {
-        if (!(v.key in currentEnv[envName])) {
-          (currentEnv[envName] as Record<string, string>)[v.key] = v.value;
-        }
-      }
-
-      // Write the env file
-      const envPath = await join(rootPath, 'http-client.env.json');
-      await writeTextFile(envPath, JSON.stringify(currentEnv, null, 2));
-
-      // Update stores
-      envFile.set(currentEnv);
-      if (!$activeEnvironment) {
-        activeEnvironment.set(envName);
-      }
-
-      addToast(
-        `Added ${pendingImportVars.length} variable${pendingImportVars.length !== 1 ? 's' : ''} to "${envName}" environment.`,
-        'info',
-      );
-    } catch (e) {
-      addToast(`Failed to update environment file: ${errorMessage(e)}`, 'error');
-    }
-
+    await applyImportedVariables(e.detail.target, pendingImportVars);
     pendingImportVars = [];
   }
 
@@ -537,131 +487,24 @@
   }
 
   // ─── Import Collections ───
+  // Writing and env-merge live in src/lib/importIO.ts; App.svelte only owns
+  // the modal state and shows the env-target modal for returned variables.
 
-  async function writeImportedFiles(result: ImportResult): Promise<number> {
-    const rootPath = $workspace.rootPath!;
-    const { mkdir } = await import('@tauri-apps/plugin-fs');
-    let written = 0;
-    for (const file of result.files) {
-      const outPath = await safeJoinPath(rootPath, file.relativePath);
-      const parentDir = await dirname(outPath);
-      try {
-        await mkdir(parentDir, { recursive: true });
-      } catch {
-        /* already exists */
-      }
-      await writeTextFile(outPath, file.content);
-      written++;
-    }
-
-    // Refresh workspace tree
-    const { files: discovered, emptyFolders } = await scanForHttpFiles(rootPath);
-    const tree = buildWorkspaceTree(discovered, emptyFolders, rootPath);
-    const rootName = await basename(rootPath);
-    workspace.set({ rootPath, rootName, tree });
-
-    return written;
-  }
-
-  /** After writing files, write the env file directly if multi-env, or show the modal. */
-  async function showEnvModalIfNeeded(result: ImportResult) {
-    if (result.environmentFile && Object.keys(result.environmentFile).length > 0) {
-      await writeImportedEnvironmentFile(result.environmentFile);
-      return;
-    }
-    if (result.discoveredVariables.length > 0) {
-      pendingImportVars = result.discoveredVariables;
+  function showEnvModalIfNeeded(vars: import('./lib/types').Variable[]) {
+    if (vars.length > 0) {
+      pendingImportVars = vars;
       showImportEnvModal = true;
-    }
-  }
-
-  async function writeImportedEnvironmentFile(imported: EnvironmentFile) {
-    const rootPath = $workspace.rootPath;
-    if (!rootPath) return;
-    try {
-      const current: EnvironmentFile = ensureSharedEnvironment(
-        $envFile ? structuredClone($envFile) : {},
-      );
-
-      for (const [envName, vars] of Object.entries(imported)) {
-        if (!current[envName]) current[envName] = {};
-        for (const [key, value] of Object.entries(vars)) {
-          if (typeof value === 'string' && !(key in current[envName])) {
-            current[envName][key] = value;
-          }
-        }
-      }
-
-      const envPath = await join(rootPath, 'http-client.env.json');
-      await writeTextFile(envPath, JSON.stringify(current, null, 2));
-      envFile.set(current);
-
-      const envNames = Object.keys(imported).filter((n) => n !== '$shared');
-      if (!$activeEnvironment && envNames.length > 0) {
-        activeEnvironment.set(envNames[0]);
-      }
-
-      addToast(
-        `Imported ${envNames.length} environment${envNames.length !== 1 ? 's' : ''}: ${envNames.join(', ')}`,
-        'info',
-      );
-    } catch (e) {
-      addToast(`Failed to write environment file: ${errorMessage(e)}`, 'error');
     }
   }
 
   async function handleImportFile(e: CustomEvent<{ content: string; format: ImportFormat }>) {
     showImportCollectionModal = false;
-    const { content, format } = e.detail;
-
-    if (!$workspace.rootPath) {
-      addToast('Open a workspace folder first before importing.', 'error');
-      return;
-    }
-
-    try {
-      let result: ImportResult;
-      switch (format) {
-        case 'postman':
-          result = importPostmanCollection(content);
-          break;
-        case 'insomnia':
-          result = importInsomniaExport(content);
-          break;
-        case 'openapi':
-          result = importOpenApiSpec(content);
-          break;
-      }
-      const written = await writeImportedFiles(result);
-      addToast(
-        `Imported ${written} file${written !== 1 ? 's' : ''} from "${result.collectionName}".`,
-        'info',
-      );
-      await showEnvModalIfNeeded(result);
-    } catch (e) {
-      addToast(`Import failed: ${errorMessage(e)}`, 'error');
-    }
+    showEnvModalIfNeeded(await importCollectionContent(e.detail.content, e.detail.format));
   }
 
   async function handleImportUrl(e: CustomEvent<{ content: string }>) {
     showImportCollectionModal = false;
-
-    if (!$workspace.rootPath) {
-      addToast('Open a workspace folder first before importing.', 'error');
-      return;
-    }
-
-    try {
-      const result = importOpenApiSpec(e.detail.content);
-      const written = await writeImportedFiles(result);
-      addToast(
-        `Imported ${written} file${written !== 1 ? 's' : ''} from "${result.collectionName}".`,
-        'info',
-      );
-      await showEnvModalIfNeeded(result);
-    } catch (e) {
-      addToast(`Import failed: ${errorMessage(e)}`, 'error');
-    }
+    showEnvModalIfNeeded(await importCollectionContent(e.detail.content, 'openapi'));
   }
 
   // ─── Save File ───

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -77,7 +77,6 @@
   import {
     serializeHttpFile,
     substituteAll,
-    parseEnvironmentFile,
     ensureSharedEnvironment,
     buildWorkspaceTree,
     createFileNode,
@@ -97,15 +96,8 @@
     KeyVaultState,
   } from './lib/types';
   import type { BottomTab, ResponseTab } from './lib/stores';
-  import type { DiscoveredFile, DiscoveredFolder } from './lib/parser';
-  import {
-    scanForFlowFiles,
-    loadFlowHistory,
-    saveFlowRunRecord,
-    clearFlowRunHistory,
-    FLOWS_DIR,
-    migrateFlowsDirectory,
-  } from './lib/flowIO';
+  import { saveFlowRunRecord, clearFlowRunHistory, FLOWS_DIR } from './lib/flowIO';
+  import { openFolderByPath, scanForHttpFiles, safeJoinPath } from './lib/workspaceIO';
   import { generateFolderName } from './lib/folderCreate';
   import { runFlow } from './lib/flowRunner';
   import { executeHttpRequest } from './lib/requestExec';
@@ -114,7 +106,7 @@
   import type { FlowStepResult, FlowRunRecord } from './lib/types';
 
   import { open } from '@tauri-apps/plugin-dialog';
-  import { readTextFile, writeTextFile, readDir, rename } from '@tauri-apps/plugin-fs';
+  import { readTextFile, writeTextFile, rename } from '@tauri-apps/plugin-fs';
   import { invoke } from '@tauri-apps/api/core';
   import { join, basename, dirname } from '@tauri-apps/api/path';
   import { onDestroy } from 'svelte';
@@ -443,65 +435,25 @@
   })();
 
   // ─── Open Folder (scan for .http files) ───
+  // Scanning and opening live in src/lib/workspaceIO.ts; App.svelte supplies
+  // the Key Vault hooks because the per-environment KV cache is UI state here.
 
-  async function openFolderByPath(rootPath: string) {
-    const { files: discovered, emptyFolders } = await scanForHttpFiles(rootPath);
-    const tree = buildWorkspaceTree(discovered, emptyFolders, rootPath);
-    const rootName = await basename(rootPath);
-
-    workspace.set({ rootPath, rootName, tree });
-    selectedLocation.set(null);
-    currentResponse.set(null);
-    namedResults.set({});
-    tabs.set([]);
-    currentSentRequest.set(null);
-
-    // Reset environment state before loading new env files
-    envFile.set(null);
-    userEnvFile.set(null);
-    kvCache = {};
-    activeEnvironment.set(null);
-
-    // Auto-discover env files from workspace root
-    await tryLoadEnvFiles(rootPath);
-
-    // Migrate legacy flows/ to .flows/ if needed
-    try {
-      const migrated = await migrateFlowsDirectory(rootPath);
-      if (migrated) addToast("Workspace updated: renamed 'flows' to '.flows'", 'info');
-    } catch {
-      /* best effort */
-    }
-
-    // Discover test flows and load run history
-    try {
-      const discoveredFlows = await scanForFlowFiles(rootPath, rootPath);
-      const flowMap: Record<string, import('./lib/types').FlowDefinition> = {};
-      for (const df of discoveredFlows) {
-        flowMap[df.relativePath] = df.flow;
-      }
-      flows.set(flowMap);
-    } catch {
-      /* no flows yet */
-    }
-
-    try {
-      const history = await loadFlowHistory(rootPath);
-      flowRunHistory.set(history);
-    } catch {
-      /* no history yet */
-    }
-
-    // Reset flow tabs
-    flowTabs.set([]);
-    activeFlowTabPath.set(null);
+  function openWorkspaceFolder(rootPath: string) {
+    return openFolderByPath(rootPath, {
+      resetCache: () => {
+        kvCache = {};
+      },
+      refresh: () => {
+        refreshKeyVaultSecrets();
+      },
+    });
   }
 
   async function openFolder() {
     try {
       const rootPath = await open({ directory: true, title: 'Select workspace folder' });
       if (!rootPath) return;
-      await openFolderByPath(rootPath as string);
+      await openWorkspaceFolder(rootPath as string);
     } catch (e) {
       addToast(`Failed to open folder: ${errorMessage(e)}`, 'error');
     }
@@ -568,7 +520,7 @@
   /** Open a favorited folder, surfacing an error toast if it can no longer be read. */
   async function openFavorite(path: string) {
     try {
-      await openFolderByPath(path);
+      await openWorkspaceFolder(path);
     } catch (e) {
       addToast(`Could not open favorite "${path}": ${errorMessage(e)}`, 'error');
     }
@@ -577,115 +529,13 @@
   async function openGettingStarted() {
     try {
       const path = await invoke<string>('extract_getting_started');
-      await openFolderByPath(path);
+      await openWorkspaceFolder(path);
     } catch (e) {
       addToast(`Failed to open getting-started folder: ${errorMessage(e)}`, 'error');
     }
   }
 
-  // ── Recursively scan a directory for .http/.rest files ──
-
-  async function scanDir(
-    dir: string,
-    rootDir: string,
-    emptyFolderSink: DiscoveredFolder[],
-  ): Promise<DiscoveredFile[]> {
-    const entries = await readDir(dir);
-    const results: DiscoveredFile[] = [];
-    let hasHttpDescendant = false;
-
-    for (const entry of entries) {
-      if (entry.name.startsWith('.')) continue;
-      const fullPath = await join(dir, entry.name);
-      if (entry.isDirectory) {
-        const subFiles = await scanDir(fullPath, rootDir, emptyFolderSink);
-        results.push(...subFiles);
-        if (subFiles.length > 0) hasHttpDescendant = true;
-      } else if (entry.name.endsWith('.http') || entry.name.endsWith('.rest')) {
-        const content = await readTextFile(fullPath);
-        const relativePath = fullPath.substring(rootDir.length + 1).replaceAll('\\', '/');
-        results.push({ absolutePath: fullPath, relativePath, content });
-        hasHttpDescendant = true;
-      }
-    }
-
-    if (!hasHttpDescendant) {
-      const relDir = dir.substring(rootDir.length + 1).replaceAll('\\', '/');
-      emptyFolderSink.push({ relativePath: relDir });
-    }
-
-    return results;
-  }
-
-  async function scanForHttpFiles(
-    rootDir: string,
-  ): Promise<{ files: DiscoveredFile[]; emptyFolders: DiscoveredFolder[] }> {
-    const emptyFolders: DiscoveredFolder[] = [];
-    const entries = await readDir(rootDir);
-    const files: DiscoveredFile[] = [];
-
-    for (const entry of entries) {
-      if (entry.name.startsWith('.')) continue;
-      const fullPath = await join(rootDir, entry.name);
-      if (entry.isDirectory) {
-        const subFiles = await scanDir(fullPath, rootDir, emptyFolders);
-        files.push(...subFiles);
-      } else if (entry.name.endsWith('.http') || entry.name.endsWith('.rest')) {
-        const content = await readTextFile(fullPath);
-        const relativePath = fullPath.substring(rootDir.length + 1).replaceAll('\\', '/');
-        files.push({ absolutePath: fullPath, relativePath, content });
-      }
-    }
-
-    return { files, emptyFolders };
-  }
-
-  // ── Auto-discover env files from workspace root ──
-
-  async function tryLoadEnvFiles(rootDir: string) {
-    try {
-      const envPath = await join(rootDir, 'http-client.env.json');
-      const content = await readTextFile(envPath);
-      const parsed = parseEnvironmentFile(content);
-      if (parsed) {
-        envFile.set(parsed);
-        const names = Object.keys(parsed).filter((k) => k !== '$shared');
-        if (names.length > 0 && !$activeEnvironment) activeEnvironment.set(names[0]);
-      }
-    } catch {
-      /* file doesn't exist */
-    }
-
-    try {
-      const userPath = await join(rootDir, 'http-client.env.json.user');
-      const content = await readTextFile(userPath);
-      const parsed = parseEnvironmentFile(content);
-      if (parsed) userEnvFile.set(parsed);
-    } catch {
-      /* file doesn't exist */
-    }
-
-    refreshKeyVaultSecrets();
-  }
-
   // ─── Import Collections ───
-
-  /** Validate and join a relative path onto a root, preventing directory traversal. */
-  async function safeJoinPath(rootPath: string, relativePath: string): Promise<string> {
-    for (const seg of relativePath.split('/')) {
-      if (
-        !seg ||
-        seg === '..' ||
-        seg === '.' ||
-        seg.includes('\0') ||
-        seg.includes('\\') ||
-        seg.includes('/')
-      ) {
-        throw new Error(`Invalid path segment: "${seg}"`);
-      }
-    }
-    return join(rootPath, relativePath);
-  }
 
   async function writeImportedFiles(result: ImportResult): Promise<number> {
     const rootPath = $workspace.rootPath!;

--- a/src/lib/fileOps.ts
+++ b/src/lib/fileOps.ts
@@ -1,0 +1,213 @@
+// ─── File and folder CRUD ────────────────────────────────────────────────────
+// Create/rename/delete/duplicate operations for .http files and folders in
+// the open workspace. Each operation performs the disk change first and only
+// updates the tree stores when it succeeds; failures surface as error toasts.
+
+import { get } from 'svelte/store';
+import { readTextFile, writeTextFile, rename, remove, mkdir } from '@tauri-apps/plugin-fs';
+import { join, basename, dirname } from '@tauri-apps/api/path';
+import {
+  workspace,
+  addToast,
+  removeFileFromTree,
+  removeFolderFromTree,
+  addFileToTree,
+  addFolderToTree,
+  renameFileInTree,
+  renameFolderInTree,
+  markFileSaved,
+  editingFilePath,
+  editingFolderPath,
+} from './stores';
+import { serializeHttpFile, createFileNode, createEmptyFileNode } from './parser';
+import { findFile, findFolder, collectFilePaths } from './tree';
+import { errorMessage } from './errors';
+import { generateFolderName } from './folderCreate';
+
+export async function deleteFile(filePath: string) {
+  try {
+    await remove(filePath);
+  } catch (err) {
+    addToast(`Failed to delete file: ${errorMessage(err)}`, 'error');
+    return;
+  }
+
+  removeFileFromTree(filePath);
+}
+
+export async function deleteFolder(folderPath: string) {
+  try {
+    await remove(folderPath, { recursive: true });
+  } catch (err) {
+    addToast(`Failed to delete folder: ${errorMessage(err)}`, 'error');
+    return;
+  }
+
+  removeFolderFromTree(folderPath);
+}
+
+/** Create a new empty .http file in the given folder (workspace root when null). */
+export async function createFile(parentFolder: string | null) {
+  const ws = get(workspace);
+  const rootPath = ws.rootPath;
+  if (!rootPath) return;
+
+  const folderPath = parentFolder || rootPath;
+
+  // Generate unique filename
+  const stem = 'new-request';
+  let fileName = stem + '.http';
+  let filePath = await join(folderPath, fileName);
+  let counter = 2;
+
+  // Check for collisions in the tree
+  const existingNames = new Set(collectFilePaths(ws.tree));
+
+  while (existingNames.has(filePath)) {
+    fileName = `${stem}-${counter}.http`;
+    filePath = await join(folderPath, fileName);
+    counter++;
+  }
+
+  const fileNode = createEmptyFileNode(filePath, fileName);
+  const content = serializeHttpFile(fileNode.requests, fileNode.variables);
+
+  try {
+    await writeTextFile(filePath, content);
+  } catch (err) {
+    addToast(`Failed to create file: ${errorMessage(err)}`, 'error');
+    return;
+  }
+
+  fileNode.dirty = false;
+  fileNode.savedContent = content;
+  addFileToTree(folderPath === rootPath ? null : folderPath, fileNode);
+  editingFilePath.set(filePath);
+}
+
+/** Create a new folder in the given parent (workspace root when null). */
+export async function createFolder(parentFolder: string | null) {
+  const ws = get(workspace);
+  const rootPath = ws.rootPath;
+  if (!rootPath) return;
+
+  const parentDir = parentFolder || rootPath;
+
+  // Collect sibling names in the target parent
+  const siblings = new Set<string>();
+  if (parentDir === rootPath) {
+    for (const n of ws.tree) siblings.add(n.name);
+  } else {
+    const parent = findFolder(ws.tree, parentDir);
+    for (const c of parent?.children ?? []) siblings.add(c.name);
+  }
+
+  const folderName = generateFolderName(siblings);
+  const folderPath = await join(parentDir, folderName);
+
+  try {
+    await mkdir(folderPath, { recursive: true });
+  } catch (err) {
+    addToast(`Failed to create folder: ${errorMessage(err)}`, 'error');
+    return;
+  }
+
+  addFolderToTree(parentDir === rootPath ? null : parentDir, {
+    type: 'folder',
+    name: folderName,
+    path: folderPath,
+    children: [],
+    expanded: true,
+  });
+  editingFolderPath.set(folderPath);
+}
+
+export async function renameFolder(oldPath: string, newName: string) {
+  const dir = await dirname(oldPath);
+  const newPath = await join(dir, newName);
+
+  try {
+    await rename(oldPath, newPath);
+  } catch (err) {
+    addToast(`Failed to rename folder: ${errorMessage(err)}`, 'error');
+    return;
+  }
+
+  renameFolderInTree(oldPath, newPath, newName);
+  editingFolderPath.set(null);
+}
+
+export async function renameFile(oldPath: string, newName: string) {
+  // If file is dirty, save first
+  const file = findFile(get(workspace).tree, oldPath);
+  if (file && file.dirty) {
+    try {
+      const content = serializeHttpFile(file.requests, file.variables);
+      await writeTextFile(oldPath, content);
+      markFileSaved(oldPath);
+    } catch (err) {
+      addToast(`Failed to save file before rename: ${errorMessage(err)}`, 'error');
+      return;
+    }
+  }
+
+  const dir = await dirname(oldPath);
+  const newPath = await join(dir, newName);
+
+  try {
+    await rename(oldPath, newPath);
+  } catch (err) {
+    addToast(`Failed to rename file: ${errorMessage(err)}`, 'error');
+    return;
+  }
+
+  renameFileInTree(oldPath, newPath, newName);
+  editingFilePath.set(null);
+}
+
+export async function duplicateFile(sourcePath: string) {
+  let content: string;
+  try {
+    content = await readTextFile(sourcePath);
+  } catch (err) {
+    addToast(`Failed to read file: ${errorMessage(err)}`, 'error');
+    return;
+  }
+
+  const dir = await dirname(sourcePath);
+  const sourceBase = await basename(sourcePath);
+  const sourceStem = sourceBase.replace(/\.(http|rest)$/, '');
+
+  // Generate unique copy name
+  let copyStem = `${sourceStem} (copy)`;
+  let copyName = copyStem + '.http';
+  let copyPath = await join(dir, copyName);
+  let counter = 2;
+
+  const ws = get(workspace);
+  const existingNames = new Set(collectFilePaths(ws.tree));
+
+  while (existingNames.has(copyPath)) {
+    copyStem = `${sourceStem} (copy ${counter})`;
+    copyName = copyStem + '.http';
+    copyPath = await join(dir, copyName);
+    counter++;
+  }
+
+  try {
+    await writeTextFile(copyPath, content);
+  } catch (err) {
+    addToast(`Failed to duplicate file: ${errorMessage(err)}`, 'error');
+    return;
+  }
+
+  const fileNode = createFileNode(copyPath, copyName, content);
+  const parentPath = dir === ws.rootPath ? null : dir;
+  addFileToTree(parentPath, fileNode);
+  editingFilePath.set(copyPath);
+}
+
+export function cancelRename() {
+  editingFilePath.set(null);
+  editingFolderPath.set(null);
+}

--- a/src/lib/flowOps.ts
+++ b/src/lib/flowOps.ts
@@ -1,0 +1,98 @@
+// ─── Flow file operations ────────────────────────────────────────────────────
+// Create/save/duplicate/delete operations for .pb-flow.json files in the open
+// workspace. Disk writes go through lib/flowIO.ts; on success the flows store
+// and flow tabs are updated. Editor-local UI state (flowUIState) stays in
+// App.svelte and is cleaned up by the caller.
+
+import { get } from 'svelte/store';
+import { mkdir, remove } from '@tauri-apps/plugin-fs';
+import { join } from '@tauri-apps/api/path';
+import { workspace, flows, flowTabs, openFlowTab, closeFlowTab } from './stores';
+import { createEmptyFlow, writeFlowFile, FLOWS_DIR } from './flowIO';
+import { safeJoinPath } from './workspaceIO';
+import type { FlowDefinition } from './types';
+
+/** Slug used for a flow's file name, derived from its display name. */
+function safeFlowFileName(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || 'unnamed'
+  );
+}
+
+/** Write a flow into the flows directory, register it and open its tab. */
+async function writeNewFlow(rootPath: string, flow: FlowDefinition) {
+  const safeName = safeFlowFileName(flow.name);
+  const flowsDir = await join(rootPath, FLOWS_DIR);
+  try {
+    await mkdir(flowsDir, { recursive: true });
+  } catch {
+    /* exists */
+  }
+  const absolutePath = await join(flowsDir, `${safeName}.pb-flow.json`);
+  const relativePath = `${FLOWS_DIR}/${safeName}.pb-flow.json`;
+
+  await writeFlowFile(absolutePath, flow);
+  flows.update((f) => ({ ...f, [relativePath]: flow }));
+  openFlowTab(relativePath, flow.name);
+}
+
+/** Create a new empty flow with the given name and open it. */
+export async function createFlow(name: string) {
+  const rootPath = get(workspace).rootPath;
+  if (!rootPath) return;
+
+  await writeNewFlow(rootPath, createEmptyFlow(name));
+}
+
+/** Duplicate an existing flow under "<name> (copy)" with fresh step ids. */
+export async function duplicateFlow(sourcePath: string) {
+  const sourceFlow = get(flows)[sourcePath];
+  if (!sourceFlow) return;
+  const rootPath = get(workspace).rootPath;
+  if (!rootPath) return;
+
+  const newFlow = {
+    ...sourceFlow,
+    name: `${sourceFlow.name} (copy)`,
+    steps: sourceFlow.steps.map((s) => ({ ...s, id: crypto.randomUUID() })),
+  };
+
+  await writeNewFlow(rootPath, newFlow);
+}
+
+/** Persist a flow definition and sync its tab label. */
+export async function saveFlow(flowPath: string, flow: FlowDefinition) {
+  const rootPath = get(workspace).rootPath;
+  if (!rootPath) return;
+
+  const absolutePath = await safeJoinPath(rootPath, flowPath);
+  await writeFlowFile(absolutePath, flow);
+  flows.update((f) => ({ ...f, [flowPath]: flow }));
+
+  // Update tab label if the name changed
+  flowTabs.update((ts) => ts.map((t) => (t.flowPath === flowPath ? { ...t, label: flow.name } : t)));
+}
+
+/** Delete a flow file (best effort) and drop it from the stores and tabs. */
+export async function deleteFlow(path: string) {
+  const rootPath = get(workspace).rootPath;
+  if (!rootPath) return;
+
+  try {
+    const absolutePath = await safeJoinPath(rootPath, path);
+    await remove(absolutePath);
+  } catch {
+    // Silently ignore - flow file may not exist on disk
+  }
+
+  flows.update((f) => {
+    const updated = { ...f };
+    delete updated[path];
+    return updated;
+  });
+  closeFlowTab(path);
+}

--- a/src/lib/flowOps.ts
+++ b/src/lib/flowOps.ts
@@ -74,7 +74,9 @@ export async function saveFlow(flowPath: string, flow: FlowDefinition) {
   flows.update((f) => ({ ...f, [flowPath]: flow }));
 
   // Update tab label if the name changed
-  flowTabs.update((ts) => ts.map((t) => (t.flowPath === flowPath ? { ...t, label: flow.name } : t)));
+  flowTabs.update((ts) =>
+    ts.map((t) => (t.flowPath === flowPath ? { ...t, label: flow.name } : t)),
+  );
 }
 
 /** Delete a flow file (best effort) and drop it from the stores and tabs. */

--- a/src/lib/importIO.ts
+++ b/src/lib/importIO.ts
@@ -1,0 +1,165 @@
+// ─── Import IO ───────────────────────────────────────────────────────────────
+// Writing imported collections into the workspace and merging imported
+// environments into http-client.env.json. Modal visibility stays in
+// App.svelte; importCollectionContent returns the discovered variables that
+// still need the target-environment modal (empty when nothing is pending).
+
+import { get } from 'svelte/store';
+import { writeTextFile, mkdir } from '@tauri-apps/plugin-fs';
+import { join, basename, dirname } from '@tauri-apps/api/path';
+import { workspace, envFile, activeEnvironment, addToast } from './stores';
+import { errorMessage } from './errors';
+import { buildWorkspaceTree, ensureSharedEnvironment } from './parser';
+import { scanForHttpFiles, safeJoinPath } from './workspaceIO';
+import { importPostmanCollection } from './postman';
+import { importInsomniaExport } from './insomnia';
+import { importOpenApiSpec } from './openapi';
+import type { ImportFormat } from './detect';
+import type { ImportResult, EnvironmentFile, Variable } from './types';
+
+export async function writeImportedFiles(result: ImportResult): Promise<number> {
+  const rootPath = get(workspace).rootPath!;
+  let written = 0;
+  for (const file of result.files) {
+    const outPath = await safeJoinPath(rootPath, file.relativePath);
+    const parentDir = await dirname(outPath);
+    try {
+      await mkdir(parentDir, { recursive: true });
+    } catch {
+      /* already exists */
+    }
+    await writeTextFile(outPath, file.content);
+    written++;
+  }
+
+  // Refresh workspace tree
+  const { files: discovered, emptyFolders } = await scanForHttpFiles(rootPath);
+  const tree = buildWorkspaceTree(discovered, emptyFolders, rootPath);
+  const rootName = await basename(rootPath);
+  workspace.set({ rootPath, rootName, tree });
+
+  return written;
+}
+
+/** Merge a fully-formed imported environment file into http-client.env.json. */
+export async function writeImportedEnvironmentFile(imported: EnvironmentFile) {
+  const rootPath = get(workspace).rootPath;
+  if (!rootPath) return;
+  try {
+    const existing = get(envFile);
+    const current: EnvironmentFile = ensureSharedEnvironment(
+      existing ? structuredClone(existing) : {},
+    );
+
+    for (const [envName, vars] of Object.entries(imported)) {
+      if (!current[envName]) current[envName] = {};
+      for (const [key, value] of Object.entries(vars)) {
+        if (typeof value === 'string' && !(key in current[envName])) {
+          current[envName][key] = value;
+        }
+      }
+    }
+
+    const envPath = await join(rootPath, 'http-client.env.json');
+    await writeTextFile(envPath, JSON.stringify(current, null, 2));
+    envFile.set(current);
+
+    const envNames = Object.keys(imported).filter((n) => n !== '$shared');
+    if (!get(activeEnvironment) && envNames.length > 0) {
+      activeEnvironment.set(envNames[0]);
+    }
+
+    addToast(
+      `Imported ${envNames.length} environment${envNames.length !== 1 ? 's' : ''}: ${envNames.join(', ')}`,
+      'info',
+    );
+  } catch (e) {
+    addToast(`Failed to write environment file: ${errorMessage(e)}`, 'error');
+  }
+}
+
+/** Add discovered variables to the chosen environment (only keys not already present). */
+export async function applyImportedVariables(envName: string, vars: Variable[]) {
+  const rootPath = get(workspace).rootPath;
+  if (!rootPath || vars.length === 0) return;
+
+  try {
+    // Load or create the env file
+    const currentEnv: EnvironmentFile = ensureSharedEnvironment(get(envFile) ?? {});
+
+    // Ensure the target environment exists
+    if (!currentEnv[envName]) {
+      currentEnv[envName] = {};
+    }
+
+    // Add discovered variables with their values (only if not already present)
+    for (const v of vars) {
+      if (!(v.key in currentEnv[envName])) {
+        (currentEnv[envName] as Record<string, string>)[v.key] = v.value;
+      }
+    }
+
+    // Write the env file
+    const envPath = await join(rootPath, 'http-client.env.json');
+    await writeTextFile(envPath, JSON.stringify(currentEnv, null, 2));
+
+    // Update stores
+    envFile.set(currentEnv);
+    if (!get(activeEnvironment)) {
+      activeEnvironment.set(envName);
+    }
+
+    addToast(
+      `Added ${vars.length} variable${vars.length !== 1 ? 's' : ''} to "${envName}" environment.`,
+      'info',
+    );
+  } catch (e) {
+    addToast(`Failed to update environment file: ${errorMessage(e)}`, 'error');
+  }
+}
+
+/**
+ * Import a collection payload: convert to .http files, write them into the
+ * workspace, and merge any imported environment file. Returns the discovered
+ * variables that still need an environment target (the caller shows the
+ * import-environment modal for them), or [] when nothing is pending.
+ */
+export async function importCollectionContent(
+  content: string,
+  format: ImportFormat,
+): Promise<Variable[]> {
+  if (!get(workspace).rootPath) {
+    addToast('Open a workspace folder first before importing.', 'error');
+    return [];
+  }
+
+  try {
+    let result: ImportResult;
+    switch (format) {
+      case 'postman':
+        result = importPostmanCollection(content);
+        break;
+      case 'insomnia':
+        result = importInsomniaExport(content);
+        break;
+      case 'openapi':
+        result = importOpenApiSpec(content);
+        break;
+    }
+    const written = await writeImportedFiles(result);
+    addToast(
+      `Imported ${written} file${written !== 1 ? 's' : ''} from "${result.collectionName}".`,
+      'info',
+    );
+    // Write the env file directly if multi-env; otherwise hand back the
+    // discovered variables so the caller can show the target modal.
+    if (result.environmentFile && Object.keys(result.environmentFile).length > 0) {
+      await writeImportedEnvironmentFile(result.environmentFile);
+      return [];
+    }
+    return result.discoveredVariables;
+  } catch (e) {
+    addToast(`Import failed: ${errorMessage(e)}`, 'error');
+    return [];
+  }
+}

--- a/src/lib/keyvaultCache.ts
+++ b/src/lib/keyvaultCache.ts
@@ -1,0 +1,96 @@
+// ─── Key Vault cache ─────────────────────────────────────────────────────────
+// Fetching and per-environment caching of Azure Key Vault secrets. The cache
+// persists across environment switches within a workspace and is cleared when
+// a new folder opens. Fetch results land in the keyVaultState store; stale
+// responses are dropped via a fetch sequence counter.
+
+import { get } from 'svelte/store';
+import {
+  activeEnvironment,
+  envFile,
+  userEnvFile,
+  keyVaultState,
+  varSourcePrefs,
+  addToast,
+} from './stores';
+import { extractKeyVaultConfig, fetchKeyVaultSecrets, kvCacheKey } from './keyvault';
+import type { KeyVaultState } from './types';
+
+let lastKvEnv: string | null = null;
+let kvFetchSeq = 0;
+/** Per-environment KV cache - persists across env switches, cleared on folder change. */
+let kvCache: Record<string, KeyVaultState> = {};
+const idleKv: KeyVaultState = { status: 'idle', variables: {}, error: null, cacheKey: null };
+
+export async function refreshKeyVaultSecrets(forEnv?: string) {
+  const env = forEnv ?? get(activeEnvironment);
+  if (!env) {
+    keyVaultState.set(idleKv);
+    return;
+  }
+
+  const config = extractKeyVaultConfig(env, get(envFile), get(userEnvFile));
+  if (!config) {
+    // No KV config for this env - restore idle but keep cache for other envs
+    keyVaultState.set(idleKv);
+    return;
+  }
+
+  const newCacheKey = kvCacheKey(env, config);
+
+  // Check per-env cache first
+  const cached = kvCache[newCacheKey];
+  if (cached && cached.status === 'loaded') {
+    keyVaultState.set(cached);
+    return;
+  }
+
+  // Only clear conflict preferences when switching environments
+  if (lastKvEnv !== env) {
+    varSourcePrefs.set({});
+  }
+  lastKvEnv = env;
+
+  const seq = ++kvFetchSeq;
+  keyVaultState.set({ status: 'loading', variables: {}, error: null, cacheKey: newCacheKey });
+
+  try {
+    const vars = await fetchKeyVaultSecrets(config);
+    if (kvFetchSeq === seq) {
+      const state: KeyVaultState = {
+        status: 'loaded',
+        variables: vars,
+        error: null,
+        cacheKey: newCacheKey,
+      };
+      kvCache[newCacheKey] = state;
+      keyVaultState.set(state);
+    }
+  } catch (err: unknown) {
+    if (kvFetchSeq === seq) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const state: KeyVaultState = {
+        status: 'error',
+        variables: {},
+        error: msg,
+        cacheKey: newCacheKey,
+      };
+      keyVaultState.set(state);
+      addToast(`Key Vault error: ${msg}`, 'error');
+    }
+  }
+}
+
+/** Clear the whole cache (a new workspace folder was opened). */
+export function resetKeyVaultCache() {
+  kvCache = {};
+}
+
+/** Invalidate one environment's cache entries and fetch fresh secrets for it. */
+export function refreshKeyVaultForEnv(env: string) {
+  for (const key of Object.keys(kvCache)) {
+    if (key.startsWith(env + '::')) delete kvCache[key];
+  }
+  keyVaultState.update((s) => ({ ...s, cacheKey: null }));
+  void refreshKeyVaultSecrets(env);
+}

--- a/src/lib/mcpBridge.test.ts
+++ b/src/lib/mcpBridge.test.ts
@@ -1,0 +1,570 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+
+vi.mock('@tauri-apps/api/event', () => ({
+  emit: vi.fn(async () => {}),
+  listen: vi.fn(async () => () => {}),
+}));
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+  readDir: vi.fn(),
+  mkdir: vi.fn(),
+  remove: vi.fn(),
+  rename: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/path', () => ({
+  join: vi.fn(async (...parts: string[]) => parts.join('/')),
+  basename: vi.fn(async (p: string) => p.split('/').pop() ?? p),
+  dirname: vi.fn(async (p: string) => p.split('/').slice(0, -1).join('/')),
+}));
+
+vi.mock('./requestExec', () => ({
+  executeHttpRequest: vi.fn(),
+}));
+
+vi.mock('./flowRunner', () => ({
+  runFlow: vi.fn(),
+}));
+
+import { emit, listen } from '@tauri-apps/api/event';
+import { readTextFile } from '@tauri-apps/plugin-fs';
+import { executeHttpRequest } from './requestExec';
+import { runFlow } from './flowRunner';
+import {
+  collectWorkspaceRequests,
+  executeRequestSilently,
+  executeFlowSilently,
+  snapshotLastResult,
+  handleBridgeRequest,
+  startMcpBridge,
+} from './mcpBridge';
+import {
+  workspace,
+  activeEnvironment,
+  envFile,
+  userEnvFile,
+  pbGlobals,
+  pbFileOverrides,
+  namedResults,
+  dotenvVariables,
+  currentResponse,
+  pbAssertionResults,
+  varSourcePrefs,
+} from './stores';
+import type { ExecutedRequest } from './requestExec';
+import type { FileNode, HttpRequest, HttpResponse, FlowRunRecord } from './types';
+
+const mockedEmit = vi.mocked(emit);
+const mockedListen = vi.mocked(listen);
+const mockedReadTextFile = vi.mocked(readTextFile);
+const mockedExecute = vi.mocked(executeHttpRequest);
+const mockedRunFlow = vi.mocked(runFlow);
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeRequest(overrides: Partial<HttpRequest> = {}): HttpRequest {
+  return {
+    id: 'req-1',
+    name: 'Get user',
+    varName: null,
+    method: 'GET',
+    url: 'https://api.example.com/users/1',
+    headers: [],
+    body: '',
+    directives: [],
+    ...overrides,
+  };
+}
+
+function makeFileNode(overrides: Partial<FileNode> = {}): FileNode {
+  return {
+    type: 'file',
+    name: 'users.http',
+    path: '/ws/users.http',
+    requests: [makeRequest()],
+    variables: [],
+    dirty: false,
+    savedContent: '',
+    ...overrides,
+  };
+}
+
+function makeResponse(overrides: Partial<HttpResponse> = {}): HttpResponse {
+  return {
+    status: 200,
+    statusText: 'OK',
+    headers: { 'content-type': 'application/json' },
+    body: '{"id":1}',
+    time: 42,
+    size: 8,
+    ...overrides,
+  };
+}
+
+function makeExecuted(overrides: Partial<ExecutedRequest> = {}): ExecutedRequest {
+  return {
+    sentRequest: { method: 'GET', url: 'https://api.example.com/users/1', headers: {}, body: '' },
+    response: makeResponse(),
+    assertionResults: [{ label: 'Should return 200', passed: true }],
+    beforeSend: { setVars: {}, globalVars: {} },
+    afterReceive: { setVars: {}, globalVars: {} },
+    namedResult: null,
+    ...overrides,
+  };
+}
+
+function makeRunRecord(overrides: Partial<FlowRunRecord> = {}): FlowRunRecord {
+  return {
+    id: 'run-1',
+    flowName: 'Smoke',
+    flowFilePath: '.flows/smoke.pb-flow.json',
+    environment: null,
+    startedAt: '2026-07-08T00:00:00Z',
+    completedAt: '2026-07-08T00:00:01Z',
+    status: 'completed',
+    stepResults: [],
+    summary: { total: 0, passed: 0, failed: 0, skipped: 0 },
+    ...overrides,
+  };
+}
+
+const flowJson = JSON.stringify({
+  version: 1,
+  name: 'Smoke',
+  description: '',
+  steps: [
+    {
+      id: 's1',
+      filePath: 'users.http',
+      requestIndex: 0,
+      varName: null,
+      aliasLocked: false,
+      label: 'GET /users/1',
+      continueOnFailure: false,
+    },
+  ],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  workspace.set({ rootPath: null, rootName: '', tree: [] });
+  activeEnvironment.set(null);
+  envFile.set(null);
+  userEnvFile.set(null);
+  pbGlobals.set({});
+  pbFileOverrides.set({});
+  namedResults.set({});
+  dotenvVariables.set({});
+  currentResponse.set(null);
+  pbAssertionResults.set([]);
+  varSourcePrefs.set({});
+});
+
+// ─── collectWorkspaceRequests ────────────────────────────────────────────────
+
+describe('collectWorkspaceRequests', () => {
+  it('returns [] when no workspace is open', () => {
+    expect(collectWorkspaceRequests()).toEqual([]);
+  });
+
+  it('lists every request with workspace-relative paths', () => {
+    const file = makeFileNode({
+      path: '/ws/api/users.http',
+      requests: [makeRequest(), makeRequest({ id: 'req-2', name: 'Create user', method: 'POST' })],
+    });
+    workspace.set({
+      rootPath: '/ws',
+      rootName: 'ws',
+      tree: [{ type: 'folder', name: 'api', path: '/ws/api', children: [file], expanded: true }],
+    });
+
+    expect(collectWorkspaceRequests()).toEqual([
+      {
+        filePath: 'api/users.http',
+        requestIndex: 0,
+        name: 'Get user',
+        method: 'GET',
+        url: 'https://api.example.com/users/1',
+      },
+      {
+        filePath: 'api/users.http',
+        requestIndex: 1,
+        name: 'Create user',
+        method: 'POST',
+        url: 'https://api.example.com/users/1',
+      },
+    ]);
+  });
+});
+
+// ─── executeRequestSilently ──────────────────────────────────────────────────
+
+describe('executeRequestSilently', () => {
+  it('throws when no workspace folder is open', async () => {
+    await expect(
+      executeRequestSilently({ filePath: 'users.http', requestIndex: 0 }),
+    ).rejects.toThrow('No workspace folder is open');
+  });
+
+  it('throws when the file is not in the workspace', async () => {
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [makeFileNode()] });
+    await expect(
+      executeRequestSilently({ filePath: 'missing.http', requestIndex: 0 }),
+    ).rejects.toThrow('File not found in workspace: missing.http');
+  });
+
+  it('throws when the request index is out of range', async () => {
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [makeFileNode()] });
+    await expect(
+      executeRequestSilently({ filePath: 'users.http', requestIndex: 5 }),
+    ).rejects.toThrow('No request at index 5 in users.http');
+  });
+
+  it('executes the request and maps the result shape', async () => {
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [makeFileNode()] });
+    mockedExecute.mockResolvedValue(makeExecuted());
+
+    const result = await executeRequestSilently({ filePath: 'users.http', requestIndex: 0 });
+
+    expect(result).toEqual({
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json' },
+      body: '{"id":1}',
+      time: 42,
+      assertions: [{ label: 'Should return 200', passed: true }],
+    });
+  });
+
+  it('uses the fully-resolved store variables for the active environment', async () => {
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [makeFileNode()] });
+    envFile.set({ $shared: { shared: 'a' }, dev: { host: 'dev.example.com' } });
+    activeEnvironment.set('dev');
+    pbGlobals.set({ token: 'g-123' });
+    mockedExecute.mockResolvedValue(makeExecuted());
+
+    await executeRequestSilently({ filePath: 'users.http', requestIndex: 0 });
+
+    const ctx = mockedExecute.mock.calls[0][1];
+    expect(ctx.environmentVariables).toMatchObject({
+      shared: 'a',
+      host: 'dev.example.com',
+      token: 'g-123',
+    });
+  });
+
+  it('resolves a non-active environment fresh from the env files', async () => {
+    const file = makeFileNode();
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [file] });
+    envFile.set({
+      $shared: { shared: 'a' },
+      dev: { host: 'dev.example.com' },
+      prod: { host: 'prod.example.com' },
+    });
+    activeEnvironment.set('dev');
+    pbGlobals.set({ token: 'g-123' });
+    pbFileOverrides.set({ [file.path]: { userId: '42' } });
+    mockedExecute.mockResolvedValue(makeExecuted());
+
+    await executeRequestSilently({
+      filePath: 'users.http',
+      requestIndex: 0,
+      environment: 'prod',
+    });
+
+    const ctx = mockedExecute.mock.calls[0][1];
+    expect(ctx.environmentVariables).toEqual({
+      shared: 'a',
+      host: 'prod.example.com',
+      token: 'g-123',
+      userId: '42',
+    });
+  });
+
+  it('falls back to pb globals only when no environment exists', async () => {
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [makeFileNode()] });
+    pbGlobals.set({ token: 'g-123' });
+    mockedExecute.mockResolvedValue(makeExecuted());
+
+    await executeRequestSilently({ filePath: 'users.http', requestIndex: 0 });
+
+    const ctx = mockedExecute.mock.calls[0][1];
+    expect(ctx.environmentVariables).toEqual({ token: 'g-123' });
+  });
+
+  it('never commits pb effects or named results to the stores', async () => {
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [makeFileNode()] });
+    mockedExecute.mockResolvedValue(
+      makeExecuted({
+        afterReceive: { setVars: { a: '1' }, globalVars: { b: '2' } },
+        namedResult: {
+          name: 'login',
+          result: {
+            request: { url: 'u', method: 'GET', headers: {}, body: '' },
+            response: makeResponse(),
+          },
+        },
+      }),
+    );
+
+    await executeRequestSilently({ filePath: 'users.http', requestIndex: 0 });
+
+    expect(get(namedResults)).toEqual({});
+    expect(get(pbGlobals)).toEqual({});
+    expect(get(pbFileOverrides)).toEqual({});
+    expect(get(currentResponse)).toBeNull();
+  });
+});
+
+// ─── executeFlowSilently ─────────────────────────────────────────────────────
+
+describe('executeFlowSilently', () => {
+  beforeEach(() => {
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [makeFileNode()] });
+  });
+
+  it('throws when no workspace folder is open', async () => {
+    workspace.set({ rootPath: null, rootName: '', tree: [] });
+    await expect(
+      executeFlowSilently({ flowFilePath: '.flows/smoke.pb-flow.json' }),
+    ).rejects.toThrow('No workspace folder is open');
+  });
+
+  it('rejects paths that are not .pb-flow.json files', async () => {
+    await expect(executeFlowSilently({ flowFilePath: 'users.http' })).rejects.toThrow(
+      'Not a flow file (expected .pb-flow.json): users.http',
+    );
+  });
+
+  it('throws when the flow file cannot be read', async () => {
+    mockedReadTextFile.mockRejectedValue(new Error('ENOENT'));
+    await expect(
+      executeFlowSilently({ flowFilePath: '.flows/smoke.pb-flow.json' }),
+    ).rejects.toThrow('Flow file not found: .flows/smoke.pb-flow.json');
+  });
+
+  it('throws when the flow file is not valid JSON', async () => {
+    mockedReadTextFile.mockResolvedValue('nonsense{');
+    await expect(
+      executeFlowSilently({ flowFilePath: '.flows/smoke.pb-flow.json' }),
+    ).rejects.toThrow('Flow file is not valid JSON: .flows/smoke.pb-flow.json');
+  });
+
+  it('throws when the JSON is not a flow definition', async () => {
+    mockedReadTextFile.mockResolvedValue('{"name":"x"}');
+    await expect(
+      executeFlowSilently({ flowFilePath: '.flows/smoke.pb-flow.json' }),
+    ).rejects.toThrow('Not a valid flow file: .flows/smoke.pb-flow.json');
+  });
+
+  it('maps step results, splitting network errors out of failed', async () => {
+    mockedReadTextFile.mockResolvedValue(flowJson);
+    mockedRunFlow.mockResolvedValue(
+      makeRunRecord({
+        stepResults: [
+          {
+            stepId: 's1',
+            status: 'failed',
+            response: null,
+            sentRequest: null,
+            assertionResults: [],
+            durationMs: 10,
+            error: 'connection refused',
+          },
+        ],
+        summary: { total: 1, passed: 0, failed: 1, skipped: 0 },
+      }),
+    );
+
+    const result = await executeFlowSilently({ flowFilePath: '.flows/smoke.pb-flow.json' });
+
+    expect(result.status).toBe('error');
+    expect(result.steps).toEqual([
+      {
+        id: 's1',
+        label: 'GET /users/1',
+        status: 'error',
+        durationMs: 10,
+        assertions: [],
+        error: 'connection refused',
+      },
+    ]);
+    expect(result.summary).toEqual({ total: 1, passed: 0, failed: 1, skipped: 0 });
+  });
+
+  it('reports failed when an assertion fails without a network error', async () => {
+    mockedReadTextFile.mockResolvedValue(flowJson);
+    mockedRunFlow.mockResolvedValue(
+      makeRunRecord({
+        stepResults: [
+          {
+            stepId: 's1',
+            status: 'failed',
+            response: makeResponse({ status: 500 }),
+            sentRequest: null,
+            assertionResults: [{ label: 'Should return 200', passed: false }],
+            durationMs: 12,
+            error: null,
+          },
+        ],
+        summary: { total: 1, passed: 0, failed: 1, skipped: 0 },
+      }),
+    );
+
+    const result = await executeFlowSilently({ flowFilePath: '.flows/smoke.pb-flow.json' });
+
+    expect(result.status).toBe('failed');
+    expect(result.steps[0].status).toBe('failed');
+    expect(result.steps[0].assertions).toEqual([{ label: 'Should return 200', passed: false }]);
+  });
+
+  it('reports passed when all steps pass', async () => {
+    mockedReadTextFile.mockResolvedValue(flowJson);
+    mockedRunFlow.mockResolvedValue(
+      makeRunRecord({
+        stepResults: [
+          {
+            stepId: 's1',
+            status: 'passed',
+            response: makeResponse(),
+            sentRequest: null,
+            assertionResults: [],
+            durationMs: 5,
+            error: null,
+          },
+        ],
+        summary: { total: 1, passed: 1, failed: 0, skipped: 0 },
+      }),
+    );
+
+    const result = await executeFlowSilently({ flowFilePath: '.flows/smoke.pb-flow.json' });
+    expect(result.status).toBe('passed');
+  });
+
+  it('passes the requested environment variables to runFlow', async () => {
+    envFile.set({ $shared: {}, dev: { host: 'dev' }, prod: { host: 'prod' } });
+    activeEnvironment.set('dev');
+    pbGlobals.set({ token: 'g' });
+    mockedReadTextFile.mockResolvedValue(flowJson);
+    mockedRunFlow.mockResolvedValue(makeRunRecord());
+
+    await executeFlowSilently({
+      flowFilePath: '.flows/smoke.pb-flow.json',
+      environment: 'prod',
+    });
+
+    const envVars = mockedRunFlow.mock.calls[0][3];
+    expect(envVars).toEqual({ host: 'prod', token: 'g' });
+    expect(mockedRunFlow.mock.calls[0][5]).toBe('prod');
+  });
+});
+
+// ─── snapshotLastResult ──────────────────────────────────────────────────────
+
+describe('snapshotLastResult', () => {
+  it('returns null when no request has run yet', () => {
+    expect(snapshotLastResult()).toBeNull();
+  });
+
+  it('returns the last response with assertion results', () => {
+    currentResponse.set(makeResponse());
+    pbAssertionResults.set([{ label: 'ok', passed: true }]);
+
+    expect(snapshotLastResult()).toEqual({
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json' },
+      body: '{"id":1}',
+      time: 42,
+      assertions: [{ label: 'ok', passed: true }],
+    });
+  });
+});
+
+// ─── handleBridgeRequest ─────────────────────────────────────────────────────
+
+describe('handleBridgeRequest', () => {
+  it('responds ok with data for list_requests', async () => {
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [makeFileNode()] });
+
+    await handleBridgeRequest({ id: 'r1', kind: 'list_requests', params: null });
+
+    expect(mockedEmit).toHaveBeenCalledWith('mcp:response', {
+      id: 'r1',
+      ok: true,
+      data: [
+        {
+          filePath: 'users.http',
+          requestIndex: 0,
+          name: 'Get user',
+          method: 'GET',
+          url: 'https://api.example.com/users/1',
+        },
+      ],
+    });
+  });
+
+  it('responds with an error for unknown kinds', async () => {
+    await handleBridgeRequest({ id: 'r2', kind: 'bogus', params: null });
+
+    expect(mockedEmit).toHaveBeenCalledWith('mcp:response', {
+      id: 'r2',
+      ok: false,
+      error: 'Unknown MCP bridge request: bogus',
+    });
+  });
+
+  it('responds with the thrown error message when execution fails', async () => {
+    await handleBridgeRequest({
+      id: 'r3',
+      kind: 'execute_request',
+      params: { filePath: 'users.http', requestIndex: 0 },
+    });
+
+    expect(mockedEmit).toHaveBeenCalledWith('mcp:response', {
+      id: 'r3',
+      ok: false,
+      error: 'No workspace folder is open',
+    });
+  });
+
+  it('responds ok for get_last_result', async () => {
+    currentResponse.set(makeResponse());
+
+    await handleBridgeRequest({ id: 'r4', kind: 'get_last_result', params: null });
+
+    const call = mockedEmit.mock.calls.find(
+      (c) => (c[1] as { id: string }).id === 'r4',
+    ) as unknown as [string, { ok: boolean; data: { status: number } }];
+    expect(call[1].ok).toBe(true);
+    expect(call[1].data.status).toBe(200);
+  });
+});
+
+// ─── startMcpBridge ──────────────────────────────────────────────────────────
+
+describe('startMcpBridge', () => {
+  it('subscribes to mcp:request and dispatches payloads', async () => {
+    const unlistenFn = () => {};
+    mockedListen.mockResolvedValue(unlistenFn);
+
+    const unlisten = await startMcpBridge();
+
+    expect(mockedListen).toHaveBeenCalledWith('mcp:request', expect.any(Function));
+    expect(unlisten).toBe(unlistenFn);
+
+    // Drive the captured handler and verify it routes to handleBridgeRequest
+    const handler = mockedListen.mock.calls[0][1] as (event: { payload: unknown }) => void;
+    handler({ payload: { id: 'x1', kind: 'bogus', params: null } });
+    await vi.waitFor(() => {
+      expect(mockedEmit).toHaveBeenCalledWith('mcp:response', {
+        id: 'x1',
+        ok: false,
+        error: 'Unknown MCP bridge request: bogus',
+      });
+    });
+  });
+});

--- a/src/lib/mcpBridge.ts
+++ b/src/lib/mcpBridge.ts
@@ -1,0 +1,297 @@
+// ─── MCP Bridge ──────────────────────────────────────────────────────────────
+// The embedded MCP server (Rust) reaches live app state through Tauri events:
+// it emits `mcp:request` with { id, kind, params }; we do the work for `kind`
+// and emit `mcp:response` with { id, ok, data?, error? }, matched by `id`.
+// New MCP tools that need frontend state add a `kind` branch here.
+//
+// Everything in this module is store-driven via `get()` and UI-free: silent
+// executions must never touch UI stores (`currentResponse`, `currentSentRequest`,
+// `pbAssertionResults`, tabs, `namedResults`, `pbGlobals`, `pbFileOverrides`,
+// `flowRunState`, `flowRunHistory`).
+
+import { get } from 'svelte/store';
+import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { readTextFile } from '@tauri-apps/plugin-fs';
+import { join } from '@tauri-apps/api/path';
+import {
+  workspace,
+  activeEnvironment,
+  resolvedEnvVars,
+  envFile,
+  userEnvFile,
+  pbGlobals,
+  pbFileOverrides,
+  namedResults,
+  dotenvVariables,
+  currentResponse,
+  pbAssertionResults,
+} from './stores';
+import { resolveEnvironmentVariables } from './parser';
+import type { SubstitutionContext } from './parser';
+import { getAllFileNodes } from './tree';
+import { executeHttpRequest } from './requestExec';
+import { runFlow } from './flowRunner';
+import { parseFlowFile } from './flowIO';
+
+export interface BridgeRequest {
+  id: string;
+  kind: string;
+  params: unknown;
+}
+
+function respondBridge(
+  id: string,
+  payload: { ok: true; data: unknown } | { ok: false; error: string },
+) {
+  emit('mcp:response', { id, ...payload }).catch(() => {});
+}
+
+/** Gather every request across all .http files in the open workspace. */
+export function collectWorkspaceRequests() {
+  const ws = get(workspace);
+  if (!ws.rootPath) return [];
+  return getAllFileNodes(ws.tree).flatMap((file) => {
+    const filePath = file.path.substring(ws.rootPath!.length + 1).replaceAll('\\', '/');
+    return file.requests.map((req, requestIndex) => ({
+      filePath,
+      requestIndex,
+      name: req.name,
+      method: req.method,
+      url: req.url,
+    }));
+  });
+}
+
+export interface ExecuteRequestParams {
+  filePath: string;
+  requestIndex: number;
+  environment?: string | null;
+}
+
+/**
+ * Run a single request for the MCP `execute_request` tool and return the
+ * structured result. This is the silent twin of `sendRequest`: it must never
+ * touch UI stores (`currentResponse`, `currentSentRequest`, `pbAssertionResults`,
+ * tabs, `namedResults`, `pbGlobals`, `pbFileOverrides`). All runtime state from
+ * pb directives is kept in locals and discarded after the call.
+ */
+export async function executeRequestSilently(params: ExecuteRequestParams) {
+  const ws = get(workspace);
+  if (!ws.rootPath) throw new Error('No workspace folder is open');
+
+  const normalized = params.filePath.replaceAll('\\', '/');
+  const file = getAllFileNodes(ws.tree).find(
+    (f) => f.path.substring(ws.rootPath!.length + 1).replaceAll('\\', '/') === normalized,
+  );
+  if (!file) throw new Error(`File not found in workspace: ${params.filePath}`);
+
+  const request = file.requests[params.requestIndex];
+  if (!request) {
+    throw new Error(`No request at index ${params.requestIndex} in ${params.filePath}`);
+  }
+
+  // Resolve environment variables for the requested environment, falling back to
+  // the active one. For the active environment, reuse the fully-resolved store so
+  // Key Vault secrets, globals, and pb.set overrides are included exactly as the
+  // UI sees them; for any other environment, resolve it fresh from the env files.
+  const active = get(activeEnvironment);
+  const effectiveEnv = params.environment ?? active;
+  let environmentVariables: Record<string, string>;
+  if (effectiveEnv && effectiveEnv === active) {
+    environmentVariables = { ...get(resolvedEnvVars) };
+  } else if (effectiveEnv) {
+    environmentVariables = {
+      ...resolveEnvironmentVariables(effectiveEnv, get(envFile), get(userEnvFile)),
+      ...get(pbGlobals),
+      ...(get(pbFileOverrides)[file.path] ?? {}),
+    };
+  } else {
+    environmentVariables = { ...get(pbGlobals) };
+  }
+
+  const ctx: SubstitutionContext = {
+    fileVariables: file.variables,
+    environmentVariables,
+    // Read-only copy: chaining can resolve existing named results, but the
+    // silent run must not mutate the shared store.
+    namedResults: { ...get(namedResults) },
+    dotenvVariables: get(dotenvVariables),
+  };
+
+  // All pb effects (set/global vars, named result) stay in the returned
+  // locals and are discarded - a silent run never reaches the stores.
+  const result = await executeHttpRequest(request, ctx, { alias: request.varName });
+
+  return {
+    status: result.response.status,
+    statusText: result.response.statusText,
+    headers: result.response.headers,
+    body: result.response.body,
+    time: result.response.time,
+    assertions: result.assertionResults.map((a) => ({ label: a.label, passed: a.passed })),
+  };
+}
+
+export interface ExecuteFlowParams {
+  flowFilePath: string;
+  environment?: string | null;
+}
+
+/**
+ * Run a whole flow for the MCP `execute_flow` tool and return the structured
+ * run record. This is the silent twin of `handleRunFlow`: it loads and runs the
+ * flow but must never touch UI stores (`flowRunState`, `flowRunHistory`,
+ * `lastFlowRunRecords`, tabs) and must not persist a results file. `runFlow`
+ * keeps all run state in isolated locals, which are discarded after mapping.
+ */
+export async function executeFlowSilently(params: ExecuteFlowParams) {
+  const ws = get(workspace);
+  if (!ws.rootPath) throw new Error('No workspace folder is open');
+
+  const relPath = params.flowFilePath.replaceAll('\\', '/');
+  if (!relPath.endsWith('.pb-flow.json')) {
+    throw new Error(`Not a flow file (expected .pb-flow.json): ${params.flowFilePath}`);
+  }
+  const absolutePath = await join(ws.rootPath, relPath);
+
+  let content: string;
+  try {
+    content = await readTextFile(absolutePath);
+  } catch {
+    throw new Error(`Flow file not found: ${params.flowFilePath}`);
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(content);
+  } catch {
+    throw new Error(`Flow file is not valid JSON: ${params.flowFilePath}`);
+  }
+  if (
+    typeof raw !== 'object' ||
+    raw === null ||
+    !Array.isArray((raw as { steps?: unknown }).steps)
+  ) {
+    throw new Error(`Not a valid flow file: ${params.flowFilePath}`);
+  }
+  const flow = parseFlowFile(content);
+
+  // Resolve environment variables for the requested environment, falling back to
+  // the active one. Mirror executeRequestSilently: reuse the resolved store for
+  // the active env (so Key Vault secrets, globals, and pb.set overrides are
+  // included as the UI sees them); resolve any other env fresh from the files.
+  const active = get(activeEnvironment);
+  const effectiveEnv = params.environment ?? active;
+  let environmentVariables: Record<string, string>;
+  if (effectiveEnv && effectiveEnv === active) {
+    environmentVariables = { ...get(resolvedEnvVars) };
+  } else if (effectiveEnv) {
+    environmentVariables = {
+      ...resolveEnvironmentVariables(effectiveEnv, get(envFile), get(userEnvFile)),
+      ...get(pbGlobals),
+    };
+  } else {
+    environmentVariables = { ...get(pbGlobals) };
+  }
+
+  // No-op callbacks: a silent run reports nothing to the UI. runFlow returns a
+  // fully isolated record; we never write it to stores or to disk.
+  const record = await runFlow(
+    flow,
+    ws.rootPath,
+    ws.tree,
+    environmentVariables,
+    get(dotenvVariables),
+    effectiveEnv,
+    { onStepStart() {}, onStepComplete() {} },
+  );
+
+  // Map the internal record onto the tool's output shape. The flow runner stores
+  // both network errors and assertion/HTTP failures as `failed`; split them back
+  // out so a network-level failure (non-null `error`) surfaces as `error`.
+  const stepById = new Map(flow.steps.map((s) => [s.id, s]));
+  const steps = record.stepResults.map((r) => {
+    const status: 'passed' | 'failed' | 'skipped' | 'error' =
+      r.status === 'failed' && r.error != null
+        ? 'error'
+        : r.status === 'passed'
+          ? 'passed'
+          : r.status === 'skipped'
+            ? 'skipped'
+            : 'failed';
+    return {
+      id: r.stepId,
+      label: stepById.get(r.stepId)?.label ?? '',
+      status,
+      durationMs: r.durationMs,
+      assertions: r.assertionResults.map((a) => ({ label: a.label, passed: a.passed })),
+      error: r.error,
+    };
+  });
+
+  const overall: 'passed' | 'failed' | 'error' = steps.some((s) => s.status === 'error')
+    ? 'error'
+    : steps.some((s) => s.status === 'failed')
+      ? 'failed'
+      : 'passed';
+
+  return { status: overall, summary: record.summary, steps };
+}
+
+/**
+ * Snapshot the user's most recent manual request result for the MCP
+ * `get_last_result` tool. Reads the live UI stores without mutating them and
+ * returns the `execute_request` shape, or `null` if no request has run yet.
+ */
+export function snapshotLastResult() {
+  const response = get(currentResponse);
+  if (!response) return null;
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+    body: response.body,
+    time: response.time,
+    assertions: get(pbAssertionResults).map((a) => ({ label: a.label, passed: a.passed })),
+  };
+}
+
+export async function handleBridgeRequest(req: BridgeRequest) {
+  try {
+    switch (req.kind) {
+      case 'list_requests':
+        respondBridge(req.id, { ok: true, data: collectWorkspaceRequests() });
+        break;
+      case 'execute_request':
+        respondBridge(req.id, {
+          ok: true,
+          data: await executeRequestSilently(req.params as ExecuteRequestParams),
+        });
+        break;
+      case 'execute_flow':
+        respondBridge(req.id, {
+          ok: true,
+          data: await executeFlowSilently(req.params as ExecuteFlowParams),
+        });
+        break;
+      case 'get_last_result':
+        respondBridge(req.id, { ok: true, data: snapshotLastResult() });
+        break;
+      default:
+        respondBridge(req.id, { ok: false, error: `Unknown MCP bridge request: ${req.kind}` });
+    }
+  } catch (e) {
+    respondBridge(req.id, { ok: false, error: e instanceof Error ? e.message : String(e) });
+  }
+}
+
+/**
+ * Subscribe to `mcp:request` events from the embedded MCP server. Returns a
+ * promise resolving to the unlisten function; the caller (App.svelte) must
+ * call it on teardown.
+ */
+export function startMcpBridge(): Promise<UnlistenFn> {
+  return listen<BridgeRequest>('mcp:request', (event) => {
+    void handleBridgeRequest(event.payload);
+  });
+}

--- a/src/lib/requestOps.ts
+++ b/src/lib/requestOps.ts
@@ -1,0 +1,87 @@
+// ─── Request operations ──────────────────────────────────────────────────────
+// Store-driven orchestration for named requests: running a dependency chain
+// in topological order and assigning/clearing `# @name` aliases. The actual
+// send is injected by the caller (App.svelte's manual sendRequest), which
+// owns the UI stores the send updates.
+
+import { get } from 'svelte/store';
+import { workspace, namedResults, updateRequestInTree, addToast } from './stores';
+import { getAllFileNodes, findFile } from './tree';
+import type { HttpRequest } from './types';
+
+/** Resolve the full dependency chain in topological order, then run each unsent request. */
+export async function runAllRequests(
+  names: string[],
+  send: (request: HttpRequest) => Promise<void>,
+) {
+  const allFiles = getAllFileNodes(get(workspace).tree);
+  const depRe = /\{\{(\w+)\.(?:request|response)\./g;
+
+  // Build a lookup: varName -> HttpRequest
+  const requestByName = new Map<string, HttpRequest>();
+  for (const file of allFiles) {
+    for (const req of file.requests) {
+      if (req.varName) requestByName.set(req.varName, req);
+    }
+  }
+
+  // Collect transitive dependencies in execution order (deepest first)
+  const ordered: string[] = [];
+  const visited = new Set<string>();
+
+  function resolve(name: string) {
+    if (visited.has(name)) return;
+    visited.add(name);
+    const req = requestByName.get(name);
+    if (!req) return;
+    // Find this request's own dependencies
+    const text = `${req.url} ${req.headers.map((h) => h.value).join(' ')} ${req.body}`;
+    let match;
+    const re = new RegExp(depRe.source, 'g');
+    while ((match = re.exec(text)) !== null) {
+      resolve(match[1]);
+    }
+    ordered.push(name);
+  }
+
+  for (const name of names) {
+    resolve(name);
+  }
+
+  // Execute in order, skipping already-sent requests
+  for (const name of ordered) {
+    if (get(namedResults)[name]) continue;
+    const req = requestByName.get(name);
+    if (req) await send(req);
+  }
+}
+
+/** Set or clear a request's `# @name` alias, rejecting duplicates. */
+export function nameRequest(filePath: string, requestIndex: number, varName: string) {
+  const tree = get(workspace).tree;
+  const file = findFile(tree, filePath);
+  if (!file) return;
+  const req = file.requests[requestIndex];
+  if (!req) return;
+  // Block duplicate names
+  if (varName) {
+    const duplicate = getAllFileNodes(tree).some((f) =>
+      f.requests.some(
+        (r, ri) => r.varName === varName && !(f.path === filePath && ri === requestIndex),
+      ),
+    );
+    if (duplicate) {
+      addToast(`Name "${varName}" is already in use`);
+      return;
+    }
+  }
+  // Remove old name from namedResults if it changed or was cleared
+  if (req.varName && req.varName !== varName) {
+    namedResults.update((nr) => {
+      const updated = { ...nr };
+      delete updated[req.varName!];
+      return updated;
+    });
+  }
+  updateRequestInTree(filePath, requestIndex, { ...req, varName: varName || null });
+}

--- a/src/lib/workspaceIO.ts
+++ b/src/lib/workspaceIO.ts
@@ -1,0 +1,195 @@
+// ─── Workspace IO ────────────────────────────────────────────────────────────
+// Scanning and opening workspace folders: discover .http/.rest files, build
+// the workspace tree, auto-load environment files, and discover flows. All
+// state lands in the shared stores; UI-owned state (the per-environment Key
+// Vault cache in App.svelte) is reached through the KeyVaultHooks callbacks.
+
+import { get } from 'svelte/store';
+import { readTextFile, readDir } from '@tauri-apps/plugin-fs';
+import { join, basename } from '@tauri-apps/api/path';
+import {
+  workspace,
+  selectedLocation,
+  currentResponse,
+  currentSentRequest,
+  namedResults,
+  tabs,
+  envFile,
+  userEnvFile,
+  activeEnvironment,
+  flows,
+  flowRunHistory,
+  flowTabs,
+  activeFlowTabPath,
+  addToast,
+} from './stores';
+import { buildWorkspaceTree, parseEnvironmentFile } from './parser';
+import type { DiscoveredFile, DiscoveredFolder } from './parser';
+import { scanForFlowFiles, loadFlowHistory, migrateFlowsDirectory } from './flowIO';
+import type { FlowDefinition } from './types';
+
+/** Callbacks into UI-owned Key Vault state (cache and fetch live in App.svelte). */
+export interface KeyVaultHooks {
+  /** Clear the per-environment Key Vault cache (called when a folder opens). */
+  resetCache(): void;
+  /** Kick off a Key Vault secret fetch for the active environment. */
+  refresh(): void;
+}
+
+// ── Recursively scan a directory for .http/.rest files ──
+
+async function scanDir(
+  dir: string,
+  rootDir: string,
+  emptyFolderSink: DiscoveredFolder[],
+): Promise<DiscoveredFile[]> {
+  const entries = await readDir(dir);
+  const results: DiscoveredFile[] = [];
+  let hasHttpDescendant = false;
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const fullPath = await join(dir, entry.name);
+    if (entry.isDirectory) {
+      const subFiles = await scanDir(fullPath, rootDir, emptyFolderSink);
+      results.push(...subFiles);
+      if (subFiles.length > 0) hasHttpDescendant = true;
+    } else if (entry.name.endsWith('.http') || entry.name.endsWith('.rest')) {
+      const content = await readTextFile(fullPath);
+      const relativePath = fullPath.substring(rootDir.length + 1).replaceAll('\\', '/');
+      results.push({ absolutePath: fullPath, relativePath, content });
+      hasHttpDescendant = true;
+    }
+  }
+
+  if (!hasHttpDescendant) {
+    const relDir = dir.substring(rootDir.length + 1).replaceAll('\\', '/');
+    emptyFolderSink.push({ relativePath: relDir });
+  }
+
+  return results;
+}
+
+export async function scanForHttpFiles(
+  rootDir: string,
+): Promise<{ files: DiscoveredFile[]; emptyFolders: DiscoveredFolder[] }> {
+  const emptyFolders: DiscoveredFolder[] = [];
+  const entries = await readDir(rootDir);
+  const files: DiscoveredFile[] = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const fullPath = await join(rootDir, entry.name);
+    if (entry.isDirectory) {
+      const subFiles = await scanDir(fullPath, rootDir, emptyFolders);
+      files.push(...subFiles);
+    } else if (entry.name.endsWith('.http') || entry.name.endsWith('.rest')) {
+      const content = await readTextFile(fullPath);
+      const relativePath = fullPath.substring(rootDir.length + 1).replaceAll('\\', '/');
+      files.push({ absolutePath: fullPath, relativePath, content });
+    }
+  }
+
+  return { files, emptyFolders };
+}
+
+// ── Auto-discover env files from workspace root ──
+
+export async function tryLoadEnvFiles(rootDir: string) {
+  try {
+    const envPath = await join(rootDir, 'http-client.env.json');
+    const content = await readTextFile(envPath);
+    const parsed = parseEnvironmentFile(content);
+    if (parsed) {
+      envFile.set(parsed);
+      const names = Object.keys(parsed).filter((k) => k !== '$shared');
+      if (names.length > 0 && !get(activeEnvironment)) activeEnvironment.set(names[0]);
+    }
+  } catch {
+    /* file doesn't exist */
+  }
+
+  try {
+    const userPath = await join(rootDir, 'http-client.env.json.user');
+    const content = await readTextFile(userPath);
+    const parsed = parseEnvironmentFile(content);
+    if (parsed) userEnvFile.set(parsed);
+  } catch {
+    /* file doesn't exist */
+  }
+}
+
+// ── Open a workspace folder ──
+
+export async function openFolderByPath(rootPath: string, keyVault: KeyVaultHooks) {
+  const { files: discovered, emptyFolders } = await scanForHttpFiles(rootPath);
+  const tree = buildWorkspaceTree(discovered, emptyFolders, rootPath);
+  const rootName = await basename(rootPath);
+
+  workspace.set({ rootPath, rootName, tree });
+  selectedLocation.set(null);
+  currentResponse.set(null);
+  namedResults.set({});
+  tabs.set([]);
+  currentSentRequest.set(null);
+
+  // Reset environment state before loading new env files
+  envFile.set(null);
+  userEnvFile.set(null);
+  keyVault.resetCache();
+  activeEnvironment.set(null);
+
+  // Auto-discover env files from workspace root
+  await tryLoadEnvFiles(rootPath);
+  keyVault.refresh();
+
+  // Migrate legacy flows/ to .flows/ if needed
+  try {
+    const migrated = await migrateFlowsDirectory(rootPath);
+    if (migrated) addToast("Workspace updated: renamed 'flows' to '.flows'", 'info');
+  } catch {
+    /* best effort */
+  }
+
+  // Discover test flows and load run history
+  try {
+    const discoveredFlows = await scanForFlowFiles(rootPath, rootPath);
+    const flowMap: Record<string, FlowDefinition> = {};
+    for (const df of discoveredFlows) {
+      flowMap[df.relativePath] = df.flow;
+    }
+    flows.set(flowMap);
+  } catch {
+    /* no flows yet */
+  }
+
+  try {
+    const history = await loadFlowHistory(rootPath);
+    flowRunHistory.set(history);
+  } catch {
+    /* no history yet */
+  }
+
+  // Reset flow tabs
+  flowTabs.set([]);
+  activeFlowTabPath.set(null);
+}
+
+// ── Path safety ──
+
+/** Validate and join a relative path onto a root, preventing directory traversal. */
+export async function safeJoinPath(rootPath: string, relativePath: string): Promise<string> {
+  for (const seg of relativePath.split('/')) {
+    if (
+      !seg ||
+      seg === '..' ||
+      seg === '.' ||
+      seg.includes('\0') ||
+      seg.includes('\\') ||
+      seg.includes('/')
+    ) {
+      throw new Error(`Invalid path segment: "${seg}"`);
+    }
+  }
+  return join(rootPath, relativePath);
+}


### PR DESCRIPTION
## Summary

Item 7 of the review remediation plan: decompose App.svelte with no behavior change. App.svelte goes from 2082 to 1083 lines. One commit per extraction; each commit passed pnpm check and pnpm test.

### Extractions

1. **src/lib/mcpBridge.ts** (297 lines) - MCP bridge and silent executors (collectWorkspaceRequests, executeRequestSilently, executeFlowSilently, snapshotLastResult, handleBridgeRequest). Store-driven via get() and UI-free; App.svelte only owns the listener lifecycle via startMcpBridge(). Includes **src/lib/mcpBridge.test.ts** (570 lines, 26 tests) covering request listing, environment resolution paths, error handling, store isolation and bridge dispatch.
2. **src/lib/workspaceIO.ts** (195 lines) - workspace scanning/opening (scanDir, scanForHttpFiles, tryLoadEnvFiles, openFolderByPath) plus safeJoinPath. The UI-owned Key Vault cache is reached through KeyVaultHooks callbacks.
3. **src/lib/fileOps.ts** (213 lines) - file/folder create/rename/delete/duplicate, built on the typed tree helpers from lib/tree.ts (item 16).
4. **src/lib/importIO.ts** (165 lines) - import writing and env-merge (writeImportedFiles, writeImportedEnvironmentFile, applyImportedVariables, importCollectionContent). Modal state stays in App.svelte.

The plan's estimate assumed a ~1990-line file; the actual file was 2082 lines, so three further extractions in the same spirit were needed to reach the under-~1100 acceptance target:

5. **src/lib/flowOps.ts** (98 lines) - flow create/duplicate/save/delete, deduplicating the flow-name slug and write-register-open sequence.
6. **src/lib/keyvaultCache.ts** (97 lines) - Key Vault secret fetch, per-environment cache, stale-fetch guard and env-scoped invalidation.
7. **src/lib/requestOps.ts** (88 lines) - Run All dependency-chain ordering and duplicate-checked request naming; the send function is injected so the manual send stays in App.svelte.

### Notes

- App.svelte deliberately stays in Svelte legacy mode (its $: statements depend on it); the full runes migration is phase 4, after this lands.
- No parser.ts import changes, per the concurrent parser split on another branch.
- Test count: 282 -> 308 (26 new mcpBridge tests). pnpm check, pnpm test and pnpm lint (0 errors) green after every commit.

### Verification

- [x] pnpm check - 0 errors
- [x] pnpm test - 308 passed
- [x] pnpm lint - 0 errors (warning count down 71 -> 68)
- [ ] Manual smoke test: open folder, send request, import collection (please verify before merge)
