### PR TITLE
test: core logic coverage for stores, env var model, and flow validation (item 14)

### DIFF
--- a/src/components/EnvironmentEditor.svelte
+++ b/src/components/EnvironmentEditor.svelte
@@ -7,7 +7,7 @@
     KeyVaultState,
     VarSource,
   } from '../lib/types';
-  import { isKeyVaultConfig } from '../lib/keyvault';
+  import { buildVarList, type EnvVar } from '../lib/envVarModel';
   import HelpTip from './HelpTip.svelte';
 
   export let envFile: EnvironmentFile;
@@ -30,21 +30,7 @@
   // Local editing state - independent from sidebar's active env
   let editingEnv = activeEnv;
 
-  // ─── Unified grouped variable model ────────────────────────────────────────
-
-  interface VarSourceEntry {
-    source: VarSource;
-    value: string;
-  }
-
-  interface EnvVar {
-    key: string;
-    enabled: boolean;
-    /** Which source is currently active (displayed in the main row). */
-    activeSource: VarSource;
-    /** All sources where this variable is defined, ordered: local, user-local, keyvault. */
-    sources: VarSourceEntry[];
-  }
+  // ─── Unified grouped variable model (see lib/envVarModel.ts) ───────────────
 
   /** Convenience: get the active value for a grouped variable. */
   function activeValue(v: EnvVar): string {
@@ -61,71 +47,6 @@
       case 'keyvault':
         return 'KV';
     }
-  }
-
-  /** Default priority: KV > user-local > local. */
-  function defaultActiveSource(sources: VarSourceEntry[]): VarSource {
-    const sourceSet = new Set(sources.map((s) => s.source));
-    if (sourceSet.has('keyvault')) return 'keyvault';
-    if (sourceSet.has('user-local')) return 'user-local';
-    return 'local';
-  }
-
-  /** Check if an environment has KV access (directly or via $shared). */
-  function envHasKv(ef: EnvironmentFile, env: string): boolean {
-    return isKeyVaultConfig(ef?.[env]?.$keyvault) || isKeyVaultConfig(ef?.['$shared']?.$keyvault);
-  }
-
-  function buildVarList(
-    ef: EnvironmentFile,
-    uef: EnvironmentFile | null,
-    env: string,
-    kv: KeyVaultState,
-  ): EnvVar[] {
-    const hasKv = kv.status === 'loaded' && envHasKv(ef, env);
-    const vars = ef?.[env];
-    const userVars = uef?.[env];
-
-    // Collect all sources per key, preserving insertion order
-    const keyMap = new Map<string, VarSourceEntry[]>();
-
-    function addEntry(key: string, source: VarSource, value: string) {
-      if (!keyMap.has(key)) keyMap.set(key, []);
-      keyMap.get(key)!.push({ source, value });
-    }
-
-    // Base file (local)
-    if (vars) {
-      for (const [key, value] of Object.entries(vars)) {
-        if (key === '$keyvault') continue;
-        const val = typeof value === 'string' ? value : JSON.stringify(value);
-        addEntry(key, 'local', val);
-      }
-    }
-
-    // User file (user-local)
-    if (userVars) {
-      for (const [key, value] of Object.entries(userVars)) {
-        if (key === '$keyvault') continue;
-        if (typeof value !== 'string') continue;
-        addEntry(key, 'user-local', value);
-      }
-    }
-
-    // Key Vault
-    if (hasKv) {
-      for (const [key, value] of Object.entries(kv.variables)) {
-        addEntry(key, 'keyvault', value);
-      }
-    }
-
-    // Build result
-    return [...keyMap.entries()].map(([key, sources]) => ({
-      key,
-      enabled: true,
-      activeSource: defaultActiveSource(sources),
-      sources,
-    }));
   }
 
   function envFileFingerprint(

--- a/src/components/FlowEditor.svelte
+++ b/src/components/FlowEditor.svelte
@@ -17,9 +17,14 @@
     Variable,
     NamedRequestResult,
   } from '../lib/types';
-  import { substituteAll } from '../lib/substitution';
   import { parseScriptText } from '../lib/pbScript';
   import { getAllFileNodes } from '../lib/tree';
+  import {
+    findFileForStep as findStepFile,
+    isStepBroken as stepIsBroken,
+    resolveStepUrls,
+    urlFromLabel as getUrl,
+  } from '../lib/flowValidation';
   import { applyAliasSync, autoAliasFor } from '../lib/flowAlias';
   import { baseEnvVars, dotenvVariables } from '../lib/stores';
   import { METHOD_COLORS } from '../lib/theme';
@@ -54,20 +59,12 @@
 
   /** Find the FileNode matching a step's filePath. */
   function findFileForStep(step: FlowStep): FileNode | undefined {
-    const normalized = step.filePath.replaceAll('\\', '/');
-    return allFiles.find((f) => {
-      const rel = f.path.substring(rootPath.length + 1).replaceAll('\\', '/');
-      return rel === normalized;
-    });
+    return findStepFile(step, allFiles, rootPath);
   }
 
   /** Check if a step's target file and request still exist in the workspace. */
   function isStepBroken(step: FlowStep): boolean {
-    const file = findFileForStep(step);
-    if (!file) return true;
-    if (step.requestIndex >= 0 && step.requestIndex < file.requests.length) return false;
-    if (step.varName && file.requests.some((r) => r.varName === step.varName)) return false;
-    return true;
+    return stepIsBroken(step, allFiles, rootPath);
   }
 
   $: brokenCount = flow.steps.filter(isStepBroken).length;
@@ -99,34 +96,14 @@
     return { ...v.setVars, ...v.globalVars };
   })();
 
-  $: resolvedStepUrls = (() => {
-    const env = $baseEnvVars;
-    const dotenv = $dotenvVariables;
-    const scope = flowScopeVars;
-    return flow.steps.map((step) => {
-      const file = findFileForStep(step);
-      const req =
-        file && step.requestIndex >= 0 && step.requestIndex < (file.requests?.length ?? 0)
-          ? file.requests[step.requestIndex]
-          : null;
-      // Prefer the step's override URL (what the user is actively editing) over the base.
-      const rawUrl = step.overrides?.url ?? (req ? req.url : getUrl(step.label));
-      if (!rawUrl || !rawUrl.includes('{{')) return '';
-      // Merge env with flow-scope vars (pb.set / pb.global captured on last run) so
-      // URLs that reference them (e.g. {{sessionId}}) resolve in the preview.
-      const nonEmptyEnv: Record<string, string> = {};
-      for (const [k, v] of Object.entries(env)) if (v) nonEmptyEnv[k] = v;
-      for (const [k, v] of Object.entries(scope))
-        if (v != null && v !== '') nonEmptyEnv[k] = String(v);
-      const resolved = substituteAll(rawUrl, {
-        fileVariables: [],
-        environmentVariables: nonEmptyEnv,
-        namedResults: {},
-        dotenvVariables: dotenv,
-      });
-      return resolved !== rawUrl ? resolved : '';
-    });
-  })();
+  $: resolvedStepUrls = resolveStepUrls(
+    flow.steps,
+    allFiles,
+    rootPath,
+    $baseEnvVars,
+    $dotenvVariables,
+    flowScopeVars,
+  );
 
   function getStepStatus(stepId: string): FlowStepResult | undefined {
     return runState?.stepResults.find((r) => r.stepId === stepId);
@@ -352,11 +329,6 @@
   function getMethod(label: string): string {
     const m = label.match(/^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT)\b/);
     return m ? m[1] : '';
-  }
-
-  function getUrl(label: string): string {
-    const m = label.match(/^(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT)\s+(.*)/);
-    return m ? m[1] : label;
   }
 
   /** Compute URL suffixes for requests in a file, stripping common prefix segments. */

--- a/src/lib/envVarModel.test.ts
+++ b/src/lib/envVarModel.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { buildVarList, defaultActiveSource, envHasKv } from './envVarModel';
+import type { EnvironmentFile, KeyVaultState } from './types';
+
+const idleKv: KeyVaultState = { status: 'idle', variables: {}, error: null, cacheKey: null };
+
+function loadedKv(variables: Record<string, string>): KeyVaultState {
+  return { status: 'loaded', variables, error: null, cacheKey: 'dev::https://vault.test' };
+}
+
+const kvConfig = {
+  provider: 'AzureKeyVault',
+  vaultUrl: 'https://vault.test',
+  secretName: 'secrets',
+} as const;
+
+describe('defaultActiveSource', () => {
+  it('prefers keyvault over everything', () => {
+    expect(
+      defaultActiveSource([
+        { source: 'local', value: 'a' },
+        { source: 'user-local', value: 'b' },
+        { source: 'keyvault', value: 'c' },
+      ]),
+    ).toBe('keyvault');
+  });
+
+  it('prefers user-local over local', () => {
+    expect(
+      defaultActiveSource([
+        { source: 'local', value: 'a' },
+        { source: 'user-local', value: 'b' },
+      ]),
+    ).toBe('user-local');
+  });
+
+  it('falls back to local', () => {
+    expect(defaultActiveSource([{ source: 'local', value: 'a' }])).toBe('local');
+  });
+});
+
+describe('envHasKv', () => {
+  it('detects a $keyvault config on the environment itself', () => {
+    const ef: EnvironmentFile = { $shared: {}, dev: { $keyvault: kvConfig } };
+    expect(envHasKv(ef, 'dev')).toBe(true);
+  });
+
+  it('detects a $keyvault config inherited from $shared', () => {
+    const ef: EnvironmentFile = { $shared: { $keyvault: kvConfig }, dev: {} };
+    expect(envHasKv(ef, 'dev')).toBe(true);
+  });
+
+  it('returns false when neither the env nor $shared has a config', () => {
+    const ef: EnvironmentFile = { $shared: {}, dev: {} };
+    expect(envHasKv(ef, 'dev')).toBe(false);
+  });
+});
+
+describe('buildVarList', () => {
+  it('groups values from base, user, and Key Vault under one key', () => {
+    const ef: EnvironmentFile = { $shared: {}, dev: { $keyvault: kvConfig, token: 'base' } };
+    const uef: EnvironmentFile = { dev: { token: 'user' } };
+    const list = buildVarList(ef, uef, 'dev', loadedKv({ token: 'kv' }));
+
+    expect(list).toHaveLength(1);
+    expect(list[0].key).toBe('token');
+    expect(list[0].sources).toEqual([
+      { source: 'local', value: 'base' },
+      { source: 'user-local', value: 'user' },
+      { source: 'keyvault', value: 'kv' },
+    ]);
+    expect(list[0].activeSource).toBe('keyvault');
+  });
+
+  it('marks user-local active when there is no Key Vault value', () => {
+    const ef: EnvironmentFile = { $shared: {}, dev: { token: 'base' } };
+    const uef: EnvironmentFile = { dev: { token: 'user' } };
+    const list = buildVarList(ef, uef, 'dev', idleKv);
+    expect(list[0].activeSource).toBe('user-local');
+  });
+
+  it('excludes the $keyvault config entry from the variable list', () => {
+    const ef: EnvironmentFile = { $shared: {}, dev: { $keyvault: kvConfig, a: '1' } };
+    const list = buildVarList(ef, null, 'dev', idleKv);
+    expect(list.map((v) => v.key)).toEqual(['a']);
+  });
+
+  it('ignores Key Vault variables when the environment has no $keyvault config', () => {
+    const ef: EnvironmentFile = { $shared: {}, dev: { a: '1' } };
+    const list = buildVarList(ef, null, 'dev', loadedKv({ secret: 'kv' }));
+    expect(list.map((v) => v.key)).toEqual(['a']);
+  });
+
+  it('ignores Key Vault variables when the fetch has not loaded', () => {
+    const ef: EnvironmentFile = { $shared: {}, dev: { $keyvault: kvConfig, a: '1' } };
+    const list = buildVarList(ef, null, 'dev', {
+      status: 'loading',
+      variables: { secret: 'kv' },
+      error: null,
+      cacheKey: null,
+    });
+    expect(list.map((v) => v.key)).toEqual(['a']);
+  });
+
+  it('serializes non-string base values and skips non-string user values', () => {
+    const ef = { $shared: {}, dev: { obj: { provider: 'AzureKeyVault' } } } as EnvironmentFile;
+    const uef = { dev: { obj: { provider: 'AzureKeyVault' } } } as EnvironmentFile;
+    const list = buildVarList(ef, uef, 'dev', idleKv);
+    expect(list).toHaveLength(1);
+    expect(list[0].sources).toEqual([{ source: 'local', value: '{"provider":"AzureKeyVault"}' }]);
+  });
+
+  it('preserves insertion order of keys', () => {
+    const ef: EnvironmentFile = { $shared: {}, dev: { b: '1', a: '2' } };
+    const uef: EnvironmentFile = { dev: { c: '3' } };
+    const list = buildVarList(ef, uef, 'dev', idleKv);
+    expect(list.map((v) => v.key)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('returns an empty list for an unknown environment', () => {
+    const ef: EnvironmentFile = { $shared: {}, dev: { a: '1' } };
+    expect(buildVarList(ef, null, 'prod', idleKv)).toEqual([]);
+  });
+});

--- a/src/lib/envVarModel.ts
+++ b/src/lib/envVarModel.ts
@@ -1,0 +1,89 @@
+// Grouped environment variable model for the environment editor: collects the
+// values a key has across the base env file, the .user file, and Key Vault,
+// and decides which source is active by default. Extracted from
+// EnvironmentEditor.svelte so it can be unit tested.
+
+import type { EnvironmentFile, KeyVaultState, VarSource } from './types';
+import { isKeyVaultConfig } from './keyvault';
+
+/** One value for a variable, tagged with the source it came from. */
+export interface VarSourceEntry {
+  source: VarSource;
+  value: string;
+}
+
+/** A variable grouped across all sources that define it. */
+export interface EnvVar {
+  key: string;
+  enabled: boolean;
+  /** Which source is currently active (displayed in the main row). */
+  activeSource: VarSource;
+  /** All sources where this variable is defined, ordered: local, user-local, keyvault. */
+  sources: VarSourceEntry[];
+}
+
+/** Default priority: KV > user-local > local. */
+export function defaultActiveSource(sources: VarSourceEntry[]): VarSource {
+  const sourceSet = new Set(sources.map((s) => s.source));
+  if (sourceSet.has('keyvault')) return 'keyvault';
+  if (sourceSet.has('user-local')) return 'user-local';
+  return 'local';
+}
+
+/** Check if an environment has KV access (directly or via $shared). */
+export function envHasKv(ef: EnvironmentFile, env: string): boolean {
+  return isKeyVaultConfig(ef?.[env]?.$keyvault) || isKeyVaultConfig(ef?.['$shared']?.$keyvault);
+}
+
+/** Build the grouped variable list for one environment tab. */
+export function buildVarList(
+  ef: EnvironmentFile,
+  uef: EnvironmentFile | null,
+  env: string,
+  kv: KeyVaultState,
+): EnvVar[] {
+  const hasKv = kv.status === 'loaded' && envHasKv(ef, env);
+  const vars = ef?.[env];
+  const userVars = uef?.[env];
+
+  // Collect all sources per key, preserving insertion order
+  const keyMap = new Map<string, VarSourceEntry[]>();
+
+  function addEntry(key: string, source: VarSource, value: string) {
+    if (!keyMap.has(key)) keyMap.set(key, []);
+    keyMap.get(key)!.push({ source, value });
+  }
+
+  // Base file (local)
+  if (vars) {
+    for (const [key, value] of Object.entries(vars)) {
+      if (key === '$keyvault') continue;
+      const val = typeof value === 'string' ? value : JSON.stringify(value);
+      addEntry(key, 'local', val);
+    }
+  }
+
+  // User file (user-local)
+  if (userVars) {
+    for (const [key, value] of Object.entries(userVars)) {
+      if (key === '$keyvault') continue;
+      if (typeof value !== 'string') continue;
+      addEntry(key, 'user-local', value);
+    }
+  }
+
+  // Key Vault
+  if (hasKv) {
+    for (const [key, value] of Object.entries(kv.variables)) {
+      addEntry(key, 'keyvault', value);
+    }
+  }
+
+  // Build result
+  return [...keyMap.entries()].map(([key, sources]) => ({
+    key,
+    enabled: true,
+    activeSource: defaultActiveSource(sources),
+    sources,
+  }));
+}

--- a/src/lib/flowValidation.test.ts
+++ b/src/lib/flowValidation.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { findFileForStep, isStepBroken, resolveStepUrls, urlFromLabel } from './flowValidation';
+import type { FileNode, FlowStep, HttpRequest } from './types';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const ROOT = 'C:\\ws';
+
+function makeRequest(overrides: Partial<HttpRequest> = {}): HttpRequest {
+  return {
+    id: 'req-1',
+    name: 'get user',
+    varName: null,
+    method: 'GET',
+    url: 'https://example.test/users/1',
+    headers: [],
+    body: '',
+    directives: [],
+    ...overrides,
+  };
+}
+
+function makeFile(relPath: string, requests: HttpRequest[]): FileNode {
+  return {
+    type: 'file',
+    name: relPath.split('/').pop() ?? relPath,
+    path: `${ROOT}\\${relPath.replaceAll('/', '\\')}`,
+    requests,
+    variables: [],
+    dirty: false,
+    savedContent: '',
+  };
+}
+
+function makeStep(overrides: Partial<FlowStep> = {}): FlowStep {
+  return {
+    id: 'step-1',
+    filePath: 'api/users.http',
+    requestIndex: 0,
+    varName: null,
+    aliasLocked: false,
+    label: 'GET https://example.test/users/1',
+    continueOnFailure: false,
+    ...overrides,
+  };
+}
+
+const files = [makeFile('api/users.http', [makeRequest(), makeRequest({ varName: 'login' })])];
+
+// ─── urlFromLabel ────────────────────────────────────────────────────────────
+
+describe('urlFromLabel', () => {
+  it('strips the leading method from a step label', () => {
+    expect(urlFromLabel('POST /api/login')).toBe('/api/login');
+  });
+
+  it('returns the label unchanged when it has no method prefix', () => {
+    expect(urlFromLabel('just-a-label')).toBe('just-a-label');
+  });
+});
+
+// ─── findFileForStep ─────────────────────────────────────────────────────────
+
+describe('findFileForStep', () => {
+  it('matches a step filePath against a backslash workspace path', () => {
+    expect(findFileForStep(makeStep(), files, ROOT)).toBe(files[0]);
+  });
+
+  it('matches when the step filePath uses backslashes', () => {
+    const step = makeStep({ filePath: 'api\\users.http' });
+    expect(findFileForStep(step, files, ROOT)).toBe(files[0]);
+  });
+
+  it('returns undefined for a file that is not in the workspace', () => {
+    const step = makeStep({ filePath: 'api/missing.http' });
+    expect(findFileForStep(step, files, ROOT)).toBeUndefined();
+  });
+});
+
+// ─── isStepBroken ────────────────────────────────────────────────────────────
+
+describe('isStepBroken', () => {
+  it('is not broken when the request index exists', () => {
+    expect(isStepBroken(makeStep({ requestIndex: 1 }), files, ROOT)).toBe(false);
+  });
+
+  it('is broken when the file is missing', () => {
+    expect(isStepBroken(makeStep({ filePath: 'gone.http' }), files, ROOT)).toBe(true);
+  });
+
+  it('is broken when the request index is out of range and no varName matches', () => {
+    expect(isStepBroken(makeStep({ requestIndex: 5 }), files, ROOT)).toBe(true);
+  });
+
+  it('falls back to varName lookup when the request index drifted', () => {
+    const step = makeStep({ requestIndex: 5, varName: 'login' });
+    expect(isStepBroken(step, files, ROOT)).toBe(false);
+  });
+
+  it('is broken when the varName no longer exists in the file', () => {
+    const step = makeStep({ requestIndex: 5, varName: 'logout' });
+    expect(isStepBroken(step, files, ROOT)).toBe(true);
+  });
+});
+
+// ─── resolveStepUrls ─────────────────────────────────────────────────────────
+
+describe('resolveStepUrls', () => {
+  const templatedFiles = [
+    makeFile('api/users.http', [makeRequest({ url: '{{baseUrl}}/users/{{userId}}' })]),
+  ];
+
+  it('resolves placeholders from environment variables', () => {
+    const urls = resolveStepUrls(
+      [makeStep()],
+      templatedFiles,
+      ROOT,
+      { baseUrl: 'https://dev.test', userId: '42' },
+      {},
+      {},
+    );
+    expect(urls).toEqual(['https://dev.test/users/42']);
+  });
+
+  it('returns "" for URLs without placeholders', () => {
+    const urls = resolveStepUrls(
+      [makeStep()],
+      files,
+      ROOT,
+      { baseUrl: 'https://dev.test' },
+      {},
+      {},
+    );
+    expect(urls).toEqual(['']);
+  });
+
+  it('returns "" when no placeholder can be resolved', () => {
+    const urls = resolveStepUrls([makeStep()], templatedFiles, ROOT, {}, {}, {});
+    expect(urls).toEqual(['']);
+  });
+
+  it('prefers the step override URL over the base request URL', () => {
+    const step = makeStep({
+      overrides: { url: '{{baseUrl}}/override' },
+    });
+    const urls = resolveStepUrls(
+      [step],
+      templatedFiles,
+      ROOT,
+      { baseUrl: 'https://dev.test' },
+      {},
+      {},
+    );
+    expect(urls).toEqual(['https://dev.test/override']);
+  });
+
+  it('resolves flow-scope variables captured from the last run', () => {
+    const scopedFiles = [makeFile('api/users.http', [makeRequest({ url: '{{sessionUrl}}' })])];
+    const urls = resolveStepUrls(
+      [makeStep()],
+      scopedFiles,
+      ROOT,
+      {},
+      {},
+      {
+        sessionUrl: 'https://dev.test/session/abc',
+      },
+    );
+    expect(urls).toEqual(['https://dev.test/session/abc']);
+  });
+
+  it('lets flow-scope variables override empty environment values', () => {
+    const urls = resolveStepUrls(
+      [makeStep()],
+      templatedFiles,
+      ROOT,
+      { baseUrl: '', userId: '42' },
+      {},
+      { baseUrl: 'https://scope.test' },
+    );
+    expect(urls).toEqual(['https://scope.test/users/42']);
+  });
+
+  it('falls back to the label URL for broken steps', () => {
+    const step = makeStep({
+      filePath: 'gone.http',
+      label: 'GET {{baseUrl}}/from-label',
+    });
+    const urls = resolveStepUrls([step], files, ROOT, { baseUrl: 'https://dev.test' }, {}, {});
+    expect(urls).toEqual(['https://dev.test/from-label']);
+  });
+
+  it('returns one entry per step in order', () => {
+    const steps = [makeStep(), makeStep({ id: 'step-2', filePath: 'gone.http', label: 'x' })];
+    const urls = resolveStepUrls(
+      steps,
+      templatedFiles,
+      ROOT,
+      { baseUrl: 'https://dev.test', userId: '1' },
+      {},
+      {},
+    );
+    expect(urls).toEqual(['https://dev.test/users/1', '']);
+  });
+});

--- a/src/lib/flowValidation.ts
+++ b/src/lib/flowValidation.ts
@@ -1,0 +1,75 @@
+// Flow step validation and URL preview resolution: maps flow steps back to
+// workspace files, detects broken references, and resolves {{variable}}
+// placeholders in step URLs. Extracted from FlowEditor.svelte so it can be
+// unit tested.
+
+import type { FileNode, FlowStep } from './types';
+import { substituteAll } from './substitution';
+
+/** Extract the URL portion from a step label like "POST /api/login". */
+export function urlFromLabel(label: string): string {
+  const m = label.match(/^(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT)\s+(.*)/);
+  return m ? m[1] : label;
+}
+
+/** Find the FileNode matching a step's workspace-relative filePath. */
+export function findFileForStep(
+  step: FlowStep,
+  allFiles: FileNode[],
+  rootPath: string,
+): FileNode | undefined {
+  const normalized = step.filePath.replaceAll('\\', '/');
+  return allFiles.find((f) => {
+    const rel = f.path.substring(rootPath.length + 1).replaceAll('\\', '/');
+    return rel === normalized;
+  });
+}
+
+/** Check if a step's target file and request still exist in the workspace. */
+export function isStepBroken(step: FlowStep, allFiles: FileNode[], rootPath: string): boolean {
+  const file = findFileForStep(step, allFiles, rootPath);
+  if (!file) return true;
+  if (step.requestIndex >= 0 && step.requestIndex < file.requests.length) return false;
+  if (step.varName && file.requests.some((r) => r.varName === step.varName)) return false;
+  return true;
+}
+
+/**
+ * Resolve a preview URL for every step. Returns '' for steps whose URL has no
+ * {{variable}} placeholders or whose placeholders cannot be resolved.
+ *
+ * `scopeVars` holds variables captured from the flow's most recent run
+ * (pb.set / pb.global) so URLs referencing them resolve in the preview.
+ */
+export function resolveStepUrls(
+  steps: FlowStep[],
+  allFiles: FileNode[],
+  rootPath: string,
+  env: Record<string, string>,
+  dotenv: Record<string, string>,
+  scopeVars: Record<string, string>,
+): string[] {
+  return steps.map((step) => {
+    const file = findFileForStep(step, allFiles, rootPath);
+    const req =
+      file && step.requestIndex >= 0 && step.requestIndex < (file.requests?.length ?? 0)
+        ? file.requests[step.requestIndex]
+        : null;
+    // Prefer the step's override URL (what the user is actively editing) over the base.
+    const rawUrl = step.overrides?.url ?? (req ? req.url : urlFromLabel(step.label));
+    if (!rawUrl || !rawUrl.includes('{{')) return '';
+    // Merge env with flow-scope vars (pb.set / pb.global captured on last run) so
+    // URLs that reference them (e.g. {{sessionId}}) resolve in the preview.
+    const nonEmptyEnv: Record<string, string> = {};
+    for (const [k, v] of Object.entries(env)) if (v) nonEmptyEnv[k] = v;
+    for (const [k, v] of Object.entries(scopeVars))
+      if (v != null && v !== '') nonEmptyEnv[k] = String(v);
+    const resolved = substituteAll(rawUrl, {
+      fileVariables: [],
+      environmentVariables: nonEmptyEnv,
+      namedResults: {},
+      dotenvVariables: dotenv,
+    });
+    return resolved !== rawUrl ? resolved : '';
+  });
+}

--- a/src/lib/stores.test.ts
+++ b/src/lib/stores.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  workspace,
+  selectedLocation,
+  tabs,
+  activeTabKey,
+  currentResponse,
+  currentSentRequest,
+  envFile,
+  userEnvFile,
+  activeEnvironment,
+  varSourcePrefs,
+  keyVaultState,
+  pbGlobals,
+  pbFileOverrides,
+  resolvedEnvVars,
+  baseEnvVarsWithSource,
+  pinTab,
+  activateTab,
+  closeTab,
+  renameFileInTree,
+} from './stores';
+import { substituteAll } from './substitution';
+import type { FileNode, HttpRequest, KeyVaultState } from './types';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeRequest(name: string): HttpRequest {
+  return {
+    id: `req-${name}`,
+    name,
+    varName: null,
+    method: 'GET',
+    url: 'https://example.test/' + name,
+    headers: [],
+    body: '',
+    directives: [],
+  };
+}
+
+function makeFile(path: string, name: string, requestCount = 1): FileNode {
+  const requests = Array.from({ length: requestCount }, (_, i) => makeRequest(`${name}-${i}`));
+  return {
+    type: 'file',
+    name,
+    path,
+    requests,
+    variables: [],
+    dirty: false,
+    savedContent: '',
+  };
+}
+
+const idleKv: KeyVaultState = { status: 'idle', variables: {}, error: null, cacheKey: null };
+
+function resetStores() {
+  workspace.set({ rootPath: null, rootName: 'No folder open', tree: [] });
+  selectedLocation.set(null);
+  tabs.set([]);
+  activeTabKey.set(null);
+  currentResponse.set(null);
+  currentSentRequest.set(null);
+  envFile.set(null);
+  userEnvFile.set(null);
+  activeEnvironment.set(null);
+  varSourcePrefs.set({});
+  keyVaultState.set(idleKv);
+  pbGlobals.set({});
+  pbFileOverrides.set({});
+}
+
+beforeEach(resetStores);
+
+// ─── resolvedEnvVars: priority chain ────────────────────────────────────────
+
+describe('resolvedEnvVars priority chain', () => {
+  it('resolves $shared as the lowest layer', () => {
+    envFile.set({ $shared: { baseUrl: 'https://shared.test' }, dev: {} });
+    activeEnvironment.set('dev');
+    expect(get(resolvedEnvVars).baseUrl).toBe('https://shared.test');
+  });
+
+  it('lets .user $shared override $shared', () => {
+    envFile.set({ $shared: { baseUrl: 'https://shared.test' }, dev: {} });
+    userEnvFile.set({ $shared: { baseUrl: 'https://user-shared.test' } });
+    activeEnvironment.set('dev');
+    expect(get(resolvedEnvVars).baseUrl).toBe('https://user-shared.test');
+  });
+
+  it('lets env-specific override .user $shared', () => {
+    envFile.set({
+      $shared: { baseUrl: 'https://shared.test' },
+      dev: { baseUrl: 'https://dev.test' },
+    });
+    userEnvFile.set({ $shared: { baseUrl: 'https://user-shared.test' } });
+    activeEnvironment.set('dev');
+    expect(get(resolvedEnvVars).baseUrl).toBe('https://dev.test');
+  });
+
+  it('lets .user env-specific override env-specific', () => {
+    envFile.set({
+      $shared: { baseUrl: 'https://shared.test' },
+      dev: { baseUrl: 'https://dev.test' },
+    });
+    userEnvFile.set({
+      $shared: { baseUrl: 'https://user-shared.test' },
+      dev: { baseUrl: 'https://user-dev.test' },
+    });
+    activeEnvironment.set('dev');
+    expect(get(resolvedEnvVars).baseUrl).toBe('https://user-dev.test');
+  });
+
+  it('lets file-level @variables override all environment layers (via substituteAll)', () => {
+    envFile.set({ $shared: {}, dev: { baseUrl: 'https://dev.test' } });
+    userEnvFile.set({ dev: { baseUrl: 'https://user-dev.test' } });
+    activeEnvironment.set('dev');
+
+    const result = substituteAll('{{baseUrl}}/api', {
+      fileVariables: [{ key: 'baseUrl', value: 'https://file.test' }],
+      environmentVariables: get(resolvedEnvVars),
+      namedResults: {},
+    });
+    expect(result).toBe('https://file.test/api');
+  });
+
+  it('returns an empty map when no environment is active', () => {
+    envFile.set({ $shared: { baseUrl: 'https://shared.test' }, dev: {} });
+    activeEnvironment.set(null);
+    expect(get(resolvedEnvVars)).toEqual({});
+  });
+
+  it('merges pb globals and file overrides on top of environment variables', () => {
+    envFile.set({ $shared: {}, dev: { token: 'env-token', baseUrl: 'https://dev.test' } });
+    activeEnvironment.set('dev');
+    pbGlobals.set({ token: 'global-token' });
+    pbFileOverrides.set({ '/ws/a.http': { token: 'file-token' } });
+    selectedLocation.set({ filePath: '/ws/a.http', requestIndex: 0 });
+
+    // File-scoped pb.set overrides win over pb.global, which wins over env
+    expect(get(resolvedEnvVars).token).toBe('file-token');
+    expect(get(resolvedEnvVars).baseUrl).toBe('https://dev.test');
+  });
+});
+
+// ─── resolvedEnvVars: varSourcePrefs ────────────────────────────────────────
+
+describe('resolvedEnvVars varSourcePrefs overrides', () => {
+  beforeEach(() => {
+    envFile.set({
+      $shared: { fromShared: 'shared-val' },
+      dev: { apiKey: 'env-key' },
+    });
+    userEnvFile.set({
+      $shared: { fromShared: 'user-shared-val' },
+      dev: { apiKey: 'user-key' },
+    });
+    activeEnvironment.set('dev');
+  });
+
+  it('prefers the base env value when pref is "local"', () => {
+    varSourcePrefs.set({ apiKey: 'local' });
+    expect(get(resolvedEnvVars).apiKey).toBe('env-key');
+  });
+
+  it('falls back to base $shared when pref is "local" and env has no value', () => {
+    varSourcePrefs.set({ fromShared: 'local' });
+    expect(get(resolvedEnvVars).fromShared).toBe('shared-val');
+  });
+
+  it('keeps the user value when pref is "user-local"', () => {
+    varSourcePrefs.set({ apiKey: 'user-local' });
+    expect(get(resolvedEnvVars).apiKey).toBe('user-key');
+  });
+
+  it('uses the default user-over-base resolution when no pref is set', () => {
+    expect(get(resolvedEnvVars).apiKey).toBe('user-key');
+    expect(get(resolvedEnvVars).fromShared).toBe('user-shared-val');
+  });
+
+  it('remaps the winning source in baseEnvVarsWithSource for "local" prefs', () => {
+    varSourcePrefs.set({ apiKey: 'local' });
+    const withSource = get(baseEnvVarsWithSource);
+    expect(withSource.apiKey.source).toBe('env');
+    expect(withSource.apiKey.value).toBe('env-key');
+  });
+});
+
+// ─── resolvedEnvVars: Key Vault conflicts ───────────────────────────────────
+
+describe('resolvedEnvVars Key Vault conflict preference', () => {
+  beforeEach(() => {
+    envFile.set({ $shared: {}, dev: { secret: 'env-secret' } });
+    activeEnvironment.set('dev');
+  });
+
+  function loadKv(vars: Record<string, string>, cacheKey = 'dev::https://vault.test') {
+    keyVaultState.set({ status: 'loaded', variables: vars, error: null, cacheKey });
+  }
+
+  it('lets Key Vault win a conflict by default', () => {
+    loadKv({ secret: 'kv-secret' });
+    expect(get(resolvedEnvVars).secret).toBe('kv-secret');
+  });
+
+  it('adds non-conflicting Key Vault variables', () => {
+    loadKv({ extra: 'kv-extra' });
+    expect(get(resolvedEnvVars).extra).toBe('kv-extra');
+    expect(get(resolvedEnvVars).secret).toBe('env-secret');
+  });
+
+  it('keeps the env value when the user prefers "local"', () => {
+    loadKv({ secret: 'kv-secret' });
+    varSourcePrefs.set({ secret: 'local' });
+    expect(get(resolvedEnvVars).secret).toBe('env-secret');
+  });
+
+  it('uses the Key Vault value when the user explicitly prefers "keyvault"', () => {
+    loadKv({ secret: 'kv-secret' });
+    varSourcePrefs.set({ secret: 'keyvault' });
+    expect(get(resolvedEnvVars).secret).toBe('kv-secret');
+  });
+
+  it('ignores Key Vault variables cached for a different environment', () => {
+    loadKv({ secret: 'kv-secret' }, 'prod::https://vault.test');
+    expect(get(resolvedEnvVars).secret).toBe('env-secret');
+  });
+
+  it('ignores Key Vault variables while still loading', () => {
+    keyVaultState.set({
+      status: 'loading',
+      variables: { secret: 'kv-secret' },
+      error: null,
+      cacheKey: 'dev::https://vault.test',
+    });
+    expect(get(resolvedEnvVars).secret).toBe('env-secret');
+  });
+});
+
+// ─── Tab lifecycle ──────────────────────────────────────────────────────────
+
+describe('tab lifecycle', () => {
+  const locA = { filePath: '/ws/a.http', requestIndex: 0 };
+  const locB = { filePath: '/ws/b.http', requestIndex: 0 };
+  const locC = { filePath: '/ws/c.http', requestIndex: 0 };
+
+  function pinThree() {
+    pinTab(locA, 'A');
+    pinTab(locB, 'B');
+    pinTab(locC, 'C');
+  }
+
+  it('pinTab does not duplicate an already pinned tab', () => {
+    pinTab(locA, 'A');
+    pinTab(locA, 'A');
+    expect(get(tabs)).toHaveLength(1);
+  });
+
+  it('closeTab of the active middle tab activates the tab that took its index', () => {
+    pinThree();
+    activateTab(locB);
+    closeTab(locB);
+    expect(get(tabs).map((t) => t.label)).toEqual(['A', 'C']);
+    expect(get(activeTabKey)).toBe('/ws/c.http::0');
+    expect(get(selectedLocation)).toEqual(locC);
+  });
+
+  it('closeTab of the active last tab activates the previous tab', () => {
+    pinThree();
+    activateTab(locC);
+    closeTab(locC);
+    expect(get(activeTabKey)).toBe('/ws/b.http::0');
+    expect(get(selectedLocation)).toEqual(locB);
+  });
+
+  it('closeTab of the only tab clears selection and response state', () => {
+    pinTab(locA, 'A');
+    closeTab(locA);
+    expect(get(tabs)).toHaveLength(0);
+    expect(get(activeTabKey)).toBeNull();
+    expect(get(selectedLocation)).toBeNull();
+    expect(get(currentResponse)).toBeNull();
+    expect(get(currentSentRequest)).toBeNull();
+  });
+
+  it('closeTab of an inactive tab keeps the active tab unchanged', () => {
+    pinThree();
+    activateTab(locC);
+    closeTab(locA);
+    expect(get(activeTabKey)).toBe('/ws/c.http::0');
+    expect(get(selectedLocation)).toEqual(locC);
+  });
+
+  it('closeTab of an unknown location is a no-op', () => {
+    pinThree();
+    activateTab(locB);
+    closeTab({ filePath: '/ws/missing.http', requestIndex: 0 });
+    expect(get(tabs)).toHaveLength(3);
+    expect(get(activeTabKey)).toBe('/ws/b.http::0');
+  });
+});
+
+// ─── renameFileInTree ───────────────────────────────────────────────────────
+
+describe('renameFileInTree', () => {
+  it('rewrites tab locations, activeTabKey, selection, and the tree node', () => {
+    const file = makeFile('/ws/old.http', 'old.http', 2);
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [file] });
+    pinTab({ filePath: '/ws/old.http', requestIndex: 0 }, 'req 0');
+    pinTab({ filePath: '/ws/old.http', requestIndex: 1 }, 'req 1');
+    activateTab({ filePath: '/ws/old.http', requestIndex: 1 });
+
+    renameFileInTree('/ws/old.http', '/ws/new.http', 'new.http');
+
+    expect(get(tabs).map((t) => t.location.filePath)).toEqual(['/ws/new.http', '/ws/new.http']);
+    expect(get(activeTabKey)).toBe('/ws/new.http::1');
+    expect(get(selectedLocation)).toEqual({ filePath: '/ws/new.http', requestIndex: 1 });
+
+    const tree = get(workspace).tree;
+    expect(tree).toHaveLength(1);
+    expect(tree[0].path).toBe('/ws/new.http');
+    expect(tree[0].name).toBe('new.http');
+  });
+
+  it('leaves tabs for other files untouched', () => {
+    const fileA = makeFile('/ws/a.http', 'a.http');
+    const fileB = makeFile('/ws/b.http', 'b.http');
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [fileA, fileB] });
+    pinTab({ filePath: '/ws/a.http', requestIndex: 0 }, 'A');
+    pinTab({ filePath: '/ws/b.http', requestIndex: 0 }, 'B');
+    activateTab({ filePath: '/ws/a.http', requestIndex: 0 });
+
+    renameFileInTree('/ws/b.http', '/ws/renamed.http', 'renamed.http');
+
+    expect(get(tabs)[0].location.filePath).toBe('/ws/a.http');
+    expect(get(tabs)[1].location.filePath).toBe('/ws/renamed.http');
+    expect(get(activeTabKey)).toBe('/ws/a.http::0');
+    expect(get(selectedLocation)).toEqual({ filePath: '/ws/a.http', requestIndex: 0 });
+  });
+
+  it('does not rewrite a file whose path shares a prefix with the renamed file', () => {
+    const fileA = makeFile('/ws/api.http', 'api.http');
+    const fileB = makeFile('/ws/api-admin.http', 'api-admin.http');
+    workspace.set({ rootPath: '/ws', rootName: 'ws', tree: [fileA, fileB] });
+    pinTab({ filePath: '/ws/api-admin.http', requestIndex: 0 }, 'admin');
+
+    renameFileInTree('/ws/api.http', '/ws/core.http', 'core.http');
+
+    expect(get(tabs)[0].location.filePath).toBe('/ws/api-admin.http');
+    const tree = get(workspace).tree;
+    expect(tree[0].path).toBe('/ws/core.http');
+    expect(tree[1].path).toBe('/ws/api-admin.http');
+  });
+});


### PR DESCRIPTION
## Summary

Item 14 of the review remediation plan: unit test coverage for core logic, with pure logic extracted out of components so it can be tested without component-testing infrastructure.

- `src/lib/stores.test.ts` (27 tests): resolvedEnvVars priority chain (file @vars via substituteAll, .user env-specific > env-specific > .user $shared > $shared), varSourcePrefs overrides (including baseEnvVarsWithSource source remapping), Key Vault conflict preference and cache-key scoping, closeTab adjacent activation, renameFileInTree key rewriting.
- `src/lib/envVarModel.ts` + tests (14 tests): buildVarList, defaultActiveSource, and envHasKv extracted from EnvironmentEditor.svelte. The component now imports the module.
- `src/lib/flowValidation.ts` + tests (18 tests): findFileForStep, isStepBroken, resolveStepUrls, and urlFromLabel extracted from FlowEditor.svelte. The component keeps thin wrappers bound to its reactive state.
- `filterTree` already lives in `src/lib/tree.ts` (item 16) with tests, so no re-extraction was needed.

No behavior change in either component; extraction plus imports only. Test count: 308 -> 367.

## Verification

- `pnpm check`: 0 errors
- `pnpm test`: 367 passed (was 308)
- `pnpm lint`: 0 errors (67 pre-existing warnings, unchanged)
- `pnpm exec prettier --check` clean on all touched files