### PR TITLE
refactor: migrate leaf components to Svelte 5 runes (phase 4, batch 1)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -761,8 +761,8 @@
   visible={showAddFavoriteModal}
   folderPath={pendingFavoritePath}
   defaultName={pendingFavoriteName}
-  on:confirm={(e) => confirmAddFavorite(e.detail.name)}
-  on:cancel={cancelAddFavorite}
+  onConfirm={confirmAddFavorite}
+  onCancel={cancelAddFavorite}
 />
 
 <svelte:window on:dragover|preventDefault={() => {}} on:drop|preventDefault={() => {}} />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -562,7 +562,7 @@
     pinTab({ filePath: e.detail.filePath, requestIndex: e.detail.requestIndex }, e.detail.label);
   }
 
-  function handleTabActivate(e: CustomEvent<RequestLocation>) {
+  function handleTabActivate(location: RequestLocation) {
     if (showEnvEditor) {
       if ($envFile) saveEnvFile($envFile);
       showEnvEditor = false;
@@ -570,11 +570,11 @@
     // Deactivate any flow tab when switching to a request tab
     activeFlowTabPath.set(null);
     activeFlowPath.set(null);
-    activateTab(e.detail);
+    activateTab(location);
   }
 
-  function handleTabClose(e: CustomEvent<RequestLocation>) {
-    closeTab(e.detail);
+  function handleTabClose(location: RequestLocation) {
+    closeTab(location);
   }
 
   function handleUpdateRequest(e: CustomEvent<HttpRequest>) {
@@ -839,12 +839,12 @@
         previewLabel={$activeRequest?.name ?? ''}
         flowTabs={$flowTabs}
         activeFlowPath={$activeFlowTabPath}
-        on:activate={handleTabActivate}
-        on:close={handleTabClose}
-        on:activateFlowTab={(e) => activateFlowTab(e.detail)}
-        on:closeFlowTab={(e) => {
-          delete flowUIState[e.detail];
-          closeFlowTab(e.detail);
+        onActivate={handleTabActivate}
+        onClose={handleTabClose}
+        onActivateFlowTab={(flowPath) => activateFlowTab(flowPath)}
+        onCloseFlowTab={(flowPath) => {
+          delete flowUIState[flowPath];
+          closeFlowTab(flowPath);
         }}
       />
       <div class="main-panels" bind:this={mainPanelsEl} class:dragging>

--- a/src/components/AddFavoriteModal.svelte
+++ b/src/components/AddFavoriteModal.svelte
@@ -1,48 +1,56 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  interface Props {
+    /** Whether the modal is visible */
+    visible?: boolean;
+    /** Absolute path of the folder being favorited (shown as a hint) */
+    folderPath?: string;
+    /** Default name to prefill (the folder basename) */
+    defaultName?: string;
+    onConfirm?: (name: string) => void;
+    onCancel?: () => void;
+  }
 
-  /** Whether the modal is visible */
-  export let visible: boolean = false;
-  /** Absolute path of the folder being favorited (shown as a hint) */
-  export let folderPath: string = '';
-  /** Default name to prefill (the folder basename) */
-  export let defaultName: string = '';
+  let { visible = false, folderPath = '', defaultName = '', onConfirm, onCancel }: Props = $props();
 
-  const dispatch = createEventDispatcher<{
-    confirm: { name: string };
-    cancel: void;
-  }>();
-
-  let name = '';
-  let inputEl: HTMLInputElement | null = null;
+  let name = $state('');
+  let inputEl: HTMLInputElement | null = $state(null);
 
   // Reset and focus when the modal opens.
-  $: if (visible) {
-    name = defaultName;
-    queueMicrotask(() => {
-      inputEl?.focus();
-      inputEl?.select();
-    });
-  }
+  $effect(() => {
+    if (visible) {
+      name = defaultName;
+      queueMicrotask(() => {
+        inputEl?.focus();
+        inputEl?.select();
+      });
+    }
+  });
 
   function confirm() {
     // Empty/whitespace name falls back to the folder basename.
     const trimmed = name.trim() || defaultName;
-    dispatch('confirm', { name: trimmed });
+    onConfirm?.(trimmed);
   }
 
   function cancel() {
-    dispatch('cancel');
+    onCancel?.();
   }
 </script>
 
 {#if visible}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div class="overlay" on:click|self={cancel} role="dialog" tabindex="-1">
+  <div
+    class="overlay"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) cancel();
+    }}
+    role="dialog"
+    tabindex="-1"
+  >
     <div class="modal">
       <div class="modal-header">
         <span class="modal-title">Name this favorite</span>
-        <button class="btn-close" on:click={cancel}>&times;</button>
+        <button class="btn-close" onclick={cancel}>&times;</button>
       </div>
 
       <div class="modal-body">
@@ -54,7 +62,7 @@
           bind:this={inputEl}
           bind:value={name}
           placeholder="Favorite name..."
-          on:keydown={(e) => {
+          onkeydown={(e) => {
             if (e.key === 'Enter') confirm();
             else if (e.key === 'Escape') cancel();
           }}
@@ -65,8 +73,8 @@
       </div>
 
       <div class="modal-footer">
-        <button class="btn-skip" on:click={cancel}>Cancel</button>
-        <button class="btn-confirm" on:click={confirm}>Save</button>
+        <button class="btn-skip" onclick={cancel}>Cancel</button>
+        <button class="btn-confirm" onclick={confirm}>Save</button>
       </div>
     </div>
   </div>

--- a/src/components/HelpTip.svelte
+++ b/src/components/HelpTip.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
-  export let label: string;
-  export let text: string;
+  interface Props {
+    label: string;
+    text: string;
+  }
+
+  let { label, text }: Props = $props();
 
   const id = `helptip-${Math.random().toString(36).slice(2, 8)}`;
   const anchorName = `--ht-${id}`;

--- a/src/components/PickerRow.svelte
+++ b/src/components/PickerRow.svelte
@@ -1,14 +1,28 @@
 <script lang="ts">
-  export let label: string;
-  export let value: string;
-  export let inserted: boolean = false;
-  export let nested: boolean = false;
-  export let maxValueLength: number = 30;
+  interface Props {
+    label: string;
+    value: string;
+    inserted?: boolean;
+    nested?: boolean;
+    maxValueLength?: number;
+    onclick?: (e: MouseEvent) => void;
+  }
 
-  $: truncated = value.length > maxValueLength ? value.slice(0, maxValueLength) + '...' : value;
+  let {
+    label,
+    value,
+    inserted = false,
+    nested = false,
+    maxValueLength = 30,
+    onclick,
+  }: Props = $props();
+
+  let truncated = $derived(
+    value.length > maxValueLength ? value.slice(0, maxValueLength) + '...' : value,
+  );
 </script>
 
-<button class="picker-row" class:row-nested={nested} class:inserted on:click>
+<button class={['picker-row', { 'row-nested': nested, inserted }]} {onclick}>
   <span class="row-key">{label}</span>
   <span class="row-value">{truncated}</span>
   <span class="row-action">{inserted ? 'Inserted' : 'Insert'}</span>

--- a/src/components/TabBar.svelte
+++ b/src/components/TabBar.svelte
@@ -1,23 +1,33 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
   import type { Tab, FlowTab } from '../lib/stores';
   import type { RequestLocation } from '../lib/types';
 
-  export let tabs: Tab[] = [];
-  export let activeLocation: RequestLocation | null = null;
-  export let isPreview: boolean = false;
-  export let previewLabel: string = '';
+  interface Props {
+    tabs?: Tab[];
+    activeLocation?: RequestLocation | null;
+    isPreview?: boolean;
+    previewLabel?: string;
+    // Flow tabs
+    flowTabs?: FlowTab[];
+    activeFlowPath?: string | null;
+    onActivate?: (location: RequestLocation) => void;
+    onClose?: (location: RequestLocation) => void;
+    onActivateFlowTab?: (flowPath: string) => void;
+    onCloseFlowTab?: (flowPath: string) => void;
+  }
 
-  // Flow tabs
-  export let flowTabs: FlowTab[] = [];
-  export let activeFlowPath: string | null = null;
-
-  const dispatch = createEventDispatcher<{
-    activate: RequestLocation;
-    close: RequestLocation;
-    activateFlowTab: string;
-    closeFlowTab: string;
-  }>();
+  let {
+    tabs = [],
+    activeLocation = null,
+    isPreview = false,
+    previewLabel = '',
+    flowTabs = [],
+    activeFlowPath = null,
+    onActivate,
+    onClose,
+    onActivateFlowTab,
+    onCloseFlowTab,
+  }: Props = $props();
 
   function isActive(tab: Tab): boolean {
     if (!activeLocation || activeFlowPath) return false;
@@ -32,13 +42,12 @@
   <div class="tab-bar">
     {#each flowTabs as ft}
       <div
-        class="tab flow-tab"
-        class:active={activeFlowPath === ft.flowPath}
-        on:click={() => dispatch('activateFlowTab', ft.flowPath)}
-        on:keydown={(e) => {
+        class={['tab', 'flow-tab', { active: activeFlowPath === ft.flowPath }]}
+        onclick={() => onActivateFlowTab?.(ft.flowPath)}
+        onkeydown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            dispatch('activateFlowTab', ft.flowPath);
+            onActivateFlowTab?.(ft.flowPath);
           }
         }}
         role="tab"
@@ -62,20 +71,22 @@
         <span class="tab-label">{ft.label}</span>
         <button
           class="tab-close"
-          on:click|stopPropagation={() => dispatch('closeFlowTab', ft.flowPath)}
+          onclick={(e) => {
+            e.stopPropagation();
+            onCloseFlowTab?.(ft.flowPath);
+          }}
           title="Close tab">&times;</button
         >
       </div>
     {/each}
     {#each tabs as tab}
       <div
-        class="tab"
-        class:active={isActive(tab) && !isPreview}
-        on:click={() => dispatch('activate', tab.location)}
-        on:keydown={(e) => {
+        class={['tab', { active: isActive(tab) && !isPreview }]}
+        onclick={() => onActivate?.(tab.location)}
+        onkeydown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            dispatch('activate', tab.location);
+            onActivate?.(tab.location);
           }
         }}
         role="tab"
@@ -84,7 +95,10 @@
         <span class="tab-label">{tab.label}</span>
         <button
           class="tab-close"
-          on:click|stopPropagation={() => dispatch('close', tab.location)}
+          onclick={(e) => {
+            e.stopPropagation();
+            onClose?.(tab.location);
+          }}
           title="Close tab">&times;</button
         >
       </div>

--- a/src/components/ToastContainer.svelte
+++ b/src/components/ToastContainer.svelte
@@ -7,7 +7,7 @@
     {#each $toasts as toast (toast.id)}
       <div class="toast toast-{toast.type}" role="alert">
         <span class="toast-message">{toast.message}</span>
-        <button class="toast-dismiss" on:click={() => dismissToast(toast.id)}>x</button>
+        <button class="toast-dismiss" onclick={() => dismissToast(toast.id)}>x</button>
       </div>
     {/each}
   </div>

--- a/src/components/VariablePicker.svelte
+++ b/src/components/VariablePicker.svelte
@@ -250,7 +250,7 @@
                       label={key}
                       {value}
                       inserted={insertedKey === rowKey}
-                      on:click={() => doInsert(rowKey, `{{${key}}}`)}
+                      onclick={() => doInsert(rowKey, `{{${key}}}`)}
                     />
                   {/each}
                 {/if}
@@ -306,7 +306,7 @@
                         label={field.path}
                         value={field.value}
                         inserted={insertedKey === rowKey}
-                        on:click={() => insertResponseBody(alias.name, field.path)}
+                        onclick={() => insertResponseBody(alias.name, field.path)}
                       />
                     {/each}
                     {#if bodyFields.length > 12}
@@ -319,7 +319,7 @@
                       label="$"
                       value={group ? 'no matches' : 'fill in JSONPath after $'}
                       inserted={insertedKey === bodyKey}
-                      on:click={() => doInsert(bodyKey, `{{${alias.name}.response.body.$.}}`)}
+                      onclick={() => doInsert(bodyKey, `{{${alias.name}.response.body.$.}}`)}
                     />
                   {/if}
 
@@ -332,7 +332,7 @@
                         label={field.path}
                         value={field.value}
                         inserted={insertedKey === rowKey}
-                        on:click={() => insertResponseHeader(alias.name, field.path)}
+                        onclick={() => insertResponseHeader(alias.name, field.path)}
                       />
                     {/each}
                   {:else}
@@ -342,7 +342,7 @@
                       label="headers"
                       value={group ? 'no matches' : 'fill in header name'}
                       inserted={insertedKey === hdrKey}
-                      on:click={() => doInsert(hdrKey, `{{${alias.name}.response.headers.}}`)}
+                      onclick={() => doInsert(hdrKey, `{{${alias.name}.response.headers.}}`)}
                     />
                   {/if}
                 {/if}
@@ -370,7 +370,7 @@
                   label={key}
                   {value}
                   inserted={insertedKey === key}
-                  on:click={() => insertEnvVar(key)}
+                  onclick={() => insertEnvVar(key)}
                 />
               {/each}
             {/if}
@@ -386,7 +386,7 @@
                   label={v.key}
                   value={v.value}
                   inserted={insertedKey === v.key}
-                  on:click={() => insertEnvVar(v.key)}
+                  onclick={() => insertEnvVar(v.key)}
                 />
               {/each}
             {/if}
@@ -409,7 +409,7 @@
                   label={d.key}
                   value={d.value}
                   inserted={insertedKey === d.key}
-                  on:click={() => doInsert(d.key, d.insert)}
+                  onclick={() => doInsert(d.key, d.insert)}
                 />
               {/each}
             {/if}
@@ -435,7 +435,7 @@
                       label={field.path}
                       value={field.value}
                       inserted={insertedKey === rowKey}
-                      on:click={() => insertResponseBody(group.name, field.path)}
+                      onclick={() => insertResponseBody(group.name, field.path)}
                     />
                   {/each}
                   {#if group.bodyFields.length > 12}
@@ -454,7 +454,7 @@
                       label={field.path}
                       value={field.value}
                       inserted={insertedKey === rowKey}
-                      on:click={() => insertResponseHeader(group.name, field.path)}
+                      onclick={() => insertResponseHeader(group.name, field.path)}
                     />
                   {/each}
                 {/if}


### PR DESCRIPTION
## Summary

First batch of the phase 4 Svelte 5 runes migration (plan item 6): the leaf components, one component per commit, with parent call sites updated in the same commit.

## Migrated components

- HelpTip: export let -> $props with a Props interface (no events, no parent changes)
- PickerRow: $props, $: -> $derived, class: -> clsx-style class attribute, forwarded on:click -> onclick callback prop; all 10 call sites in VariablePicker updated
- ToastContainer: on:click -> onclick (no props or dispatcher to migrate)
- TabBar: $props, createEventDispatcher -> onActivate/onClose/onActivateFlowTab/onCloseFlowTab callback props, on:x -> onx, class: -> clsx-style class attribute; App.svelte call site updated and handleTabActivate/handleTabClose simplified to take RequestLocation instead of CustomEvent
- AddFavoriteModal: $props, createEventDispatcher -> onConfirm/onCancel callback props, reset-on-open $: statement -> $effect, local state -> $state, on:x -> onx, |self modifier -> explicit e.target === e.currentTarget check; App.svelte call site updated
- ThemeSwitcher: already fully runes-based, no changes needed

## Pattern conversions applied

- export let -> $props() destructuring with a typed Props interface
- createEventDispatcher -> optional callback props (camelCase for semantic events, onclick for direct DOM forwarding)
- on:event -> onevent attributes; event modifiers replaced with inline logic
- $: -> $derived / $effect
- class:x -> class={{ x }} / class={[...]}

## Notes

- App.svelte stays pinned to legacy mode (per plan); legacy parents pass callback props to runes children without issues
- No behavior or visual changes intended
- Mid-tier and big components follow in later PRs

## Verification

- pnpm check: 0 errors, 0 warnings
- pnpm test: 367 passed (367)
- pnpm lint: 0 errors (67 pre-existing warnings, unchanged)
- prettier --check clean on every touched file