### PR TITLE
perf: reuse one shared reqwest client across requests

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
+use std::sync::OnceLock;
 use std::time::Duration;
 use tauri::Manager;
 
@@ -88,13 +89,14 @@ fn is_blocked_ip(ip: &IpAddr) -> bool {
 
 const BLOCKED_ADDR_MSG: &str =
     "Requests to this address are blocked (link-local, broadcast, or unspecified)";
+const NO_ADDRS_MSG: &str = "Host resolved to no addresses";
 
 /// Reject a DNS resolution if it is empty or contains any blocked address.
 /// Blocking when *any* resolved IP is blocked prevents an attacker-controlled
 /// DNS record from smuggling a blocked address in among safe ones.
 fn check_resolved_addrs(addrs: &[SocketAddr]) -> Result<(), String> {
     if addrs.is_empty() {
-        return Err("Host resolved to no addresses".to_string());
+        return Err(NO_ADDRS_MSG.to_string());
     }
     for sa in addrs {
         if is_blocked_ip(&sa.ip()) {
@@ -123,10 +125,27 @@ impl reqwest::dns::Resolve for BlocklistDnsResolver {
     }
 }
 
-/// Validate that a URL is safe to request: correct scheme and non-private host.
-/// Returns the validated (host, resolved IPs) pair so the caller can pin the
-/// DNS resolution and prevent TOCTOU attacks.
-async fn validate_url(url_str: &str) -> Result<(String, Vec<SocketAddr>), String> {
+/// Extract the IP address from a URL host when it is an IP literal.
+/// `url::Host` is used instead of parsing `host_str()` because `host_str()`
+/// returns IPv6 literals with their surrounding brackets ("[fe80::1]"),
+/// which `IpAddr::from_str` rejects - the connector strips the brackets and
+/// dials such hosts directly, so a string-based check would miss them.
+fn host_ip(url: &url::Url) -> Option<IpAddr> {
+    match url.host()? {
+        url::Host::Ipv4(v4) => Some(IpAddr::V4(v4)),
+        url::Host::Ipv6(v6) => Some(IpAddr::V6(v6)),
+        url::Host::Domain(_) => None,
+    }
+}
+
+/// Validate that a URL is safe to request: correct scheme, has a host, and
+/// if the host is an IP literal it is not a blocked address. IP literals
+/// must be checked here because the connector dials them directly without
+/// consulting the DNS resolver. Hostname targets are validated at resolution
+/// time by `BlocklistDnsResolver`, which checks every lookup the connector
+/// performs, so the addresses that are checked are exactly the addresses
+/// that are dialed (no TOCTOU window).
+fn validate_url(url_str: &str) -> Result<(), String> {
     let parsed = url::Url::parse(url_str).map_err(|_| "Invalid URL format".to_string())?;
 
     match parsed.scheme() {
@@ -134,31 +153,19 @@ async fn validate_url(url_str: &str) -> Result<(String, Vec<SocketAddr>), String
         _ => return Err("Only http:// and https:// URLs are allowed".to_string()),
     }
 
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| "URL must contain a host".to_string())?
-        .to_string();
-    let port = parsed.port_or_known_default().unwrap_or(80);
+    if parsed.host().is_none() {
+        return Err("URL must contain a host".to_string());
+    }
 
     // Block a narrow set of never-valid or dangerous direct IP addresses
     // (link-local/cloud metadata, broadcast, unspecified, CGNAT).
-    if let Ok(ip) = host.parse::<IpAddr>() {
+    if let Some(ip) = host_ip(&parsed) {
         if is_blocked_ip(&ip) {
             return Err(BLOCKED_ADDR_MSG.to_string());
         }
-        return Ok((host, vec![SocketAddr::new(ip, port)]));
     }
 
-    // Resolve hostname and check all resulting IPs
-    let addr = format!("{}:{}", host, port);
-    let resolved: Vec<SocketAddr> = tokio::net::lookup_host(&addr)
-        .await
-        .map_err(|_| "Failed to resolve host".to_string())?
-        .collect();
-
-    check_resolved_addrs(&resolved)?;
-
-    Ok((host, resolved))
+    Ok(())
 }
 
 /// Custom redirect policy that re-validates each redirect target URL to
@@ -175,35 +182,70 @@ fn ssrf_safe_redirect_policy() -> reqwest::redirect::Policy {
             "http" | "https" => {}
             _ => return attempt.error("Redirect to non-HTTP scheme blocked"),
         }
-        if let Some(host) = url.host_str() {
-            if let Ok(ip) = host.parse::<IpAddr>() {
-                if is_blocked_ip(&ip) {
-                    return attempt.error("Redirect to blocked address");
-                }
+        if let Some(ip) = host_ip(url) {
+            if is_blocked_ip(&ip) {
+                return attempt.error("Redirect to blocked address");
             }
         }
         attempt.follow()
     })
 }
 
-#[tauri::command]
-async fn http_request(payload: HttpRequestPayload) -> Result<HttpResponsePayload, String> {
-    let (host, resolved_addrs) = validate_url(&payload.url).await?;
+/// Shared HTTP client, built once and reused for every request so TCP
+/// connections and TLS sessions are pooled across requests. Sharing is safe
+/// because every builder setting (timeout, redirect policy, DNS resolver) is
+/// identical for all requests; anything request-specific (method, URL,
+/// headers, body) is set on the RequestBuilder.
+///
+/// SSRF enforcement does not need per-request DNS pinning: every hostname
+/// lookup the connector performs (initial request, each redirect hop, and
+/// any reconnect) goes through `BlocklistDnsResolver`, and the addresses it
+/// validates are exactly the addresses the connector then dials, so a DNS
+/// answer cannot swap to a blocked address between check and use. IP-literal
+/// hosts skip DNS entirely and are checked synchronously in `validate_url`
+/// (initial URL) and the redirect policy (redirect targets); literals cannot
+/// rebind, so there is no TOCTOU window for them either.
+static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
-    // Pin the DNS resolution we already validated to prevent TOCTOU attacks
-    // where a second lookup could return a different (private) IP. Hosts not
-    // pinned here (i.e. redirect targets) resolve through BlocklistDnsResolver,
-    // which enforces the same blocklist on every resolved address.
-    let mut builder = reqwest::Client::builder()
+fn http_client() -> Result<&'static reqwest::Client, String> {
+    if let Some(client) = HTTP_CLIENT.get() {
+        return Ok(client);
+    }
+    let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
         .redirect(ssrf_safe_redirect_policy())
-        .dns_resolver(BlocklistDnsResolver);
-
-    builder = builder.resolve_to_addrs(&host, &resolved_addrs);
-
-    let client = builder
+        .dns_resolver(BlocklistDnsResolver)
         .build()
         .map_err(|_| "Failed to initialize HTTP client".to_string())?;
+    // A concurrent first call may have won the race; get_or_init returns the
+    // stored client either way and the extra one is dropped.
+    Ok(HTTP_CLIENT.get_or_init(|| client))
+}
+
+/// Surface a `BlocklistDnsResolver` rejection from a send error. The
+/// resolver's error is wrapped in reqwest/hyper connect errors, so walk the
+/// source chain looking for our known messages; without this, a blocked
+/// hostname would show only a generic "Connection failed" message.
+fn resolver_block_message(e: &reqwest::Error) -> Option<String> {
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(e);
+    while let Some(err) = source {
+        let msg = err.to_string();
+        if msg.contains(BLOCKED_ADDR_MSG) {
+            return Some(BLOCKED_ADDR_MSG.to_string());
+        }
+        if msg.contains(NO_ADDRS_MSG) {
+            return Some(NO_ADDRS_MSG.to_string());
+        }
+        source = err.source();
+    }
+    None
+}
+
+#[tauri::command]
+async fn http_request(payload: HttpRequestPayload) -> Result<HttpResponsePayload, String> {
+    validate_url(&payload.url)?;
+
+    let client = http_client()?;
 
     let method = payload
         .method
@@ -221,7 +263,9 @@ async fn http_request(payload: HttpRequestPayload) -> Result<HttpResponsePayload
     }
 
     let res = req.send().await.map_err(|e| {
-        if e.is_timeout() {
+        if let Some(msg) = resolver_block_message(&e) {
+            msg
+        } else if e.is_timeout() {
             format!("Request timed out after {} seconds", REQUEST_TIMEOUT_SECS)
         } else if e.is_connect() {
             "Connection failed - check that the server is reachable".to_string()
@@ -530,40 +574,73 @@ mod tests {
         assert!(!is_blocked_ip(&ip("::ffff:127.0.0.1")));
     }
 
-    #[tokio::test]
-    async fn validate_url_allows_localhost_literal() {
-        let res = validate_url("http://127.0.0.1:8080/health").await;
+    #[test]
+    fn validate_url_allows_localhost_literal() {
+        let res = validate_url("http://127.0.0.1:8080/health");
         assert!(res.is_ok(), "expected Ok, got {:?}", res);
     }
 
-    #[tokio::test]
-    async fn validate_url_allows_ipv6_loopback_literal() {
-        let res = validate_url("http://[::1]:8080/").await;
+    #[test]
+    fn validate_url_allows_ipv6_loopback_literal() {
+        let res = validate_url("http://[::1]:8080/");
         assert!(res.is_ok(), "expected Ok, got {:?}", res);
     }
 
-    #[tokio::test]
-    async fn validate_url_allows_rfc1918_literal() {
-        let res = validate_url("http://192.168.1.10/").await;
+    #[test]
+    fn validate_url_allows_rfc1918_literal() {
+        let res = validate_url("http://192.168.1.10/");
         assert!(res.is_ok(), "expected Ok, got {:?}", res);
     }
 
-    #[tokio::test]
-    async fn validate_url_blocks_cloud_metadata() {
-        let res = validate_url("http://169.254.169.254/latest/meta-data/").await;
+    #[test]
+    fn validate_url_blocks_cloud_metadata() {
+        let res = validate_url("http://169.254.169.254/latest/meta-data/");
         assert!(res.is_err(), "expected Err, got {:?}", res);
     }
 
-    #[tokio::test]
-    async fn validate_url_blocks_unspecified() {
-        let res = validate_url("http://0.0.0.0/").await;
+    #[test]
+    fn validate_url_blocks_unspecified() {
+        let res = validate_url("http://0.0.0.0/");
         assert!(res.is_err(), "expected Err, got {:?}", res);
     }
 
-    #[tokio::test]
-    async fn validate_url_rejects_non_http_scheme() {
-        let res = validate_url("ftp://example.com/").await;
+    #[test]
+    fn validate_url_blocks_ipv6_link_local_literal() {
+        // host_str() would return "[fe80::1]" (with brackets), which does not
+        // parse as an IpAddr; host() must be used to catch bracketed literals.
+        let res = validate_url("http://[fe80::1]/");
+        assert!(res.is_err(), "expected Err, got {:?}", res);
+    }
+
+    #[test]
+    fn validate_url_defers_hostname_checks_to_resolver() {
+        // Hostnames pass URL validation; they are checked when the connector
+        // resolves them through BlocklistDnsResolver.
+        let res = validate_url("http://any-hostname.example/");
+        assert!(res.is_ok(), "expected Ok, got {:?}", res);
+    }
+
+    #[test]
+    fn validate_url_rejects_non_http_scheme() {
+        let res = validate_url("ftp://example.com/");
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn host_ip_parses_bracketed_ipv6_literal() {
+        let url = url::Url::parse("http://[fe80::1]:8080/").unwrap();
+        assert_eq!(host_ip(&url), Some(ip("fe80::1")));
+        let url = url::Url::parse("http://169.254.169.254/").unwrap();
+        assert_eq!(host_ip(&url), Some(ip("169.254.169.254")));
+        let url = url::Url::parse("http://example.com/").unwrap();
+        assert_eq!(host_ip(&url), None);
+    }
+
+    #[tokio::test]
+    async fn http_client_is_shared_across_calls() {
+        let a = http_client().expect("client should build");
+        let b = http_client().expect("client should build");
+        assert!(std::ptr::eq(a, b), "expected the same client instance");
     }
 
     fn sa(s: &str) -> SocketAddr {


### PR DESCRIPTION
## Summary

Item 24 of the remediation plan (phase 5). `http_request` built a fresh reqwest `Client` per request, so no TCP connection or TLS session was ever reused. This PR implements **option (b)**: one shared long-lived `Client` (via `OnceLock`), dropping the per-request DNS pre-resolution and `resolve_to_addrs` pinning, relying on `BlocklistDnsResolver` for hostname enforcement.

## TOCTOU analysis (why option (b) is sound)

The old pinning existed to prevent a second DNS lookup from returning a different (blocked) IP between `validate_url`'s check and the connection. That threat is fully covered at the resolver level: `BlocklistDnsResolver` is installed as the client's DNS resolver, and hyper-util's connector (`client/legacy/connect/http.rs`, `call_async`) resolves **every** hostname connection attempt through it - the initial request, each redirect hop, and any reconnect after a stale pooled connection. Crucially, the addresses the resolver validates in `check_resolved_addrs` are the exact addresses the connector then dials (the check and the use are the same resolution), so a rebinding DNS answer cannot swap in a blocked address between check and use. Pooled connections need no re-check: an established TCP connection cannot be rebound by DNS, and its peer address was validated when it was created. The only hosts that bypass the resolver are IP literals - hyper-util's `SocketAddrs::try_parse` short-circuits DNS for them - but literals cannot rebind, so they only need the synchronous checks that already exist: `validate_url` for the initial URL and the redirect policy for redirect targets. The code's own comment already trusted exactly this reasoning for redirect targets ("Hosts not pinned here ... resolve through BlocklistDnsResolver"), and the initial host is the identical threat model, so the pinning was redundant.

## Bonus fix found during the analysis

While verifying the IP-literal path, I found a latent gap in the redirect policy: it parsed `url.host_str()` as `IpAddr`, but `host_str()` returns IPv6 literals **with brackets** (`"[fe80::1]"`), which `IpAddr::from_str` rejects - while hyper-util strips the brackets and dials the address directly, bypassing the resolver. A redirect to `http://[fe80::1]/` therefore evaded both checks. Both `validate_url` and the redirect policy now match on `url::Host` via a `host_ip` helper, which handles bracketed v6 literals correctly (regression tests added).

## What moved where

- Client-level (identical for every request, stays on the shared `Client`): timeout, redirect policy, `dns_resolver`. Nothing per-request was ever set on the builder except the removed pinning, so no cache keying is needed.
- Request-level (unchanged, already on `RequestBuilder`): method, URL, headers, body.
- `validate_url` is now synchronous: scheme check, host presence, IP-literal blocklist. Hostname resolution/checking moved entirely into the resolver (it was previously done twice).
- Error fidelity preserved: a blocked hostname used to fail in `validate_url` with the blocklist message; it now fails inside `send()`, so `resolver_block_message` walks the error source chain and surfaces the blocklist / empty-resolution message instead of the generic "Connection failed" text. If the chain ever stops carrying the message it degrades to the generic connect error, never to an allowed request.

No proxy settings, TLS overrides, or cert options existed before; none were added. `is_blocked_ip`, `check_resolved_addrs`, and the redirect policy semantics are unchanged.

## Tests

- `validate_url` tests converted to sync, all originals kept.
- New: `validate_url_blocks_ipv6_link_local_literal` (the bracket bug), `validate_url_defers_hostname_checks_to_resolver`, `host_ip_parses_bracketed_ipv6_literal`, `http_client_is_shared_across_calls`.

## Verification

- `cargo check` - pass
- `cargo check --tests` - pass
- `cargo check --no-default-features` - pass
- `cargo clippy -- -D warnings` (also with `--tests`) - pass
- `cargo fmt --check` - pass
- `cargo test` does not launch on this Windows machine (pre-existing STATUS_ENTRYPOINT_NOT_FOUND); relying on CI ubuntu to run tests.