### PR TITLE
refactor: migrate mid-tier components to Svelte 5 runes (phase 4, batch 2)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -708,7 +708,7 @@
 </script>
 
 <ToastContainer />
-<HelpModal visible={showHelp} on:close={() => (showHelp = false)} />
+<HelpModal visible={showHelp} onClose={() => (showHelp = false)} />
 <SettingsModal
   visible={showSettings}
   {currentTheme}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -308,9 +308,9 @@
     return tab?.responseTab ?? ('body' as ResponseTab);
   })();
 
-  function handleResponseTabChange(e: CustomEvent<ResponseTab>) {
+  function handleResponseTabChange(tab: ResponseTab) {
     if ($selectedLocation) {
-      setTabResponseTab($selectedLocation, e.detail);
+      setTabResponseTab($selectedLocation, tab);
     }
   }
 
@@ -922,7 +922,7 @@
               sentRequest={$currentSentRequest}
               assertionResults={$pbAssertionResults}
               activeTab={activeResponseTab}
-              on:tabChange={handleResponseTabChange}
+              onTabChange={handleResponseTabChange}
             />
           </div>
         {:else}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -140,9 +140,9 @@
   let showImportEnvModal = false;
   let pendingImportVars: import('./lib/types').Variable[] = [];
 
-  async function handleImportEnvConfirm(e: CustomEvent<{ target: string }>) {
+  async function handleImportEnvConfirm(target: string) {
     showImportEnvModal = false;
-    await applyImportedVariables(e.detail.target, pendingImportVars);
+    await applyImportedVariables(target, pendingImportVars);
     pendingImportVars = [];
   }
 
@@ -748,8 +748,8 @@
   variables={pendingImportVars}
   existingEnvironments={$availableEnvironments}
   hasEnvFile={$envFile !== null}
-  on:confirm={handleImportEnvConfirm}
-  on:skip={handleImportEnvSkip}
+  onConfirm={handleImportEnvConfirm}
+  onSkip={handleImportEnvSkip}
 />
 <ImportCollectionModal
   visible={showImportCollectionModal}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -736,8 +736,8 @@
   namedResults={$namedResults}
   activeEnv={$activeEnvironment}
   activeFileName={$activeFile?.name?.replace(/\.(http|rest)$/, '') ?? ''}
-  on:close={() => (showVarInspector = false)}
-  on:clearRuntime={() => {
+  onClose={() => (showVarInspector = false)}
+  onClearRuntime={() => {
     pbFileOverrides.set({});
     pbGlobals.set({});
     namedResults.set({});

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -437,14 +437,14 @@
     }
   }
 
-  async function handleImportFile(e: CustomEvent<{ content: string; format: ImportFormat }>) {
+  async function handleImportFile(content: string, format: ImportFormat) {
     showImportCollectionModal = false;
-    showEnvModalIfNeeded(await importCollectionContent(e.detail.content, e.detail.format));
+    showEnvModalIfNeeded(await importCollectionContent(content, format));
   }
 
-  async function handleImportUrl(e: CustomEvent<{ content: string }>) {
+  async function handleImportUrl(content: string) {
     showImportCollectionModal = false;
-    showEnvModalIfNeeded(await importCollectionContent(e.detail.content, 'openapi'));
+    showEnvModalIfNeeded(await importCollectionContent(content, 'openapi'));
   }
 
   // ─── Save File ───
@@ -753,9 +753,9 @@
 />
 <ImportCollectionModal
   visible={showImportCollectionModal}
-  on:importFile={handleImportFile}
-  on:importUrl={handleImportUrl}
-  on:cancel={() => (showImportCollectionModal = false)}
+  onImportFile={handleImportFile}
+  onImportUrl={handleImportUrl}
+  onCancel={() => (showImportCollectionModal = false)}
 />
 <AddFavoriteModal
   visible={showAddFavoriteModal}

--- a/src/components/DependencyBar.svelte
+++ b/src/components/DependencyBar.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
   import type { NamedRequestResult } from '../lib/types';
 
-  /** The raw URL + headers + body text to scan for dependencies */
-  export let requestText: string = '';
-  /** Map of named request results that have been sent */
-  export let namedResults: Record<string, NamedRequestResult> = {};
+  interface Props {
+    /** The raw URL + headers + body text to scan for dependencies */
+    requestText?: string;
+    /** Map of named request results that have been sent */
+    namedResults?: Record<string, NamedRequestResult>;
+    onRunAll?: (dependencies: string[]) => void;
+  }
 
-  const dispatch = createEventDispatcher();
+  let { requestText = '', namedResults = {}, onRunAll }: Props = $props();
 
   // Extract all {{name.response...}} references
   const DEP_RE = /\{\{(\w+)\.(?:request|response)\./g;
 
-  $: dependencies = extractDeps(requestText);
+  const dependencies = $derived(extractDeps(requestText));
   // Force re-evaluation of statuses when namedResults changes
-  $: statuses = buildStatuses(dependencies, namedResults);
+  const statuses = $derived(buildStatuses(dependencies, namedResults));
 
   function extractDeps(text: string): string[] {
     const names = new Set<string>();
@@ -41,7 +43,7 @@
   }
 
   function runAll() {
-    dispatch('runAll', dependencies);
+    onRunAll?.(dependencies);
   }
 </script>
 
@@ -49,7 +51,7 @@
   <div class="dep-bar">
     <span class="dep-label">Depends on</span>
     {#each dependencies as dep}
-      <span class="dep-pill" class:sent={statuses[dep]?.sent} class:unsent={!statuses[dep]?.sent}>
+      <span class={['dep-pill', { sent: statuses[dep]?.sent, unsent: !statuses[dep]?.sent }]}>
         <span class="dep-dot"></span>
         <span class="dep-name">{dep}</span>
         {#if statuses[dep]?.sent}
@@ -60,7 +62,7 @@
       </span>
     {/each}
     {#if dependencies.some((d) => !namedResults[d])}
-      <button class="btn-run-all" on:click={runAll}>Run all</button>
+      <button class="btn-run-all" onclick={runAll}>Run all</button>
     {/if}
   </div>
 {/if}

--- a/src/components/FlowEditor.svelte
+++ b/src/components/FlowEditor.svelte
@@ -261,8 +261,8 @@
     dispatch('save', { flowPath, flow });
   }
 
-  function addStep(e: CustomEvent<FlowStep>) {
-    flow = { ...flow, steps: applyAliasSync([...flow.steps, e.detail]) };
+  function addStep(step: FlowStep) {
+    flow = { ...flow, steps: applyAliasSync([...flow.steps, step]) };
     save();
   }
 
@@ -1205,11 +1205,11 @@
   <FlowStepPicker
     {tree}
     {rootPath}
-    on:pick={(e) => {
-      addStep(e);
+    onPick={(step) => {
+      addStep(step);
       showPicker = false;
     }}
-    on:close={() => (showPicker = false)}
+    onClose={() => (showPicker = false)}
   />
 {/if}
 

--- a/src/components/FlowEditor.svelte
+++ b/src/components/FlowEditor.svelte
@@ -1195,7 +1195,7 @@
         runRecord={lastRunRecord}
         history={runHistory}
         flowFilePath={flowPath}
-        on:clearHistory={() => dispatch('clearHistory')}
+        onClearHistory={() => dispatch('clearHistory')}
       />
     </div>
   {/if}

--- a/src/components/FlowEditor.svelte
+++ b/src/components/FlowEditor.svelte
@@ -536,8 +536,7 @@
     showVarPicker = true;
   }
 
-  function handleVarPickerInsert(e: CustomEvent<string>) {
-    const value = e.detail;
+  function handleVarPickerInsert(value: string) {
     showVarPicker = false;
     const t = pickerTarget;
     if (!t) return;
@@ -1222,8 +1221,8 @@
   flowAliases={pickerFlowAliases}
   flowName={flow.name}
   flowSetVars={flowScopeVars}
-  on:insert={handleVarPickerInsert}
-  on:close={() => {
+  onInsert={handleVarPickerInsert}
+  onClose={() => {
     showVarPicker = false;
     pickerTarget = null;
   }}

--- a/src/components/FlowResults.svelte
+++ b/src/components/FlowResults.svelte
@@ -1,29 +1,33 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
   import type { FlowRunRecord } from '../lib/types';
 
-  const dispatch = createEventDispatcher<{ clearHistory: void }>();
+  interface Props {
+    runRecord?: FlowRunRecord | null;
+    history?: FlowRunRecord[];
+    flowFilePath?: string;
+    onClearHistory?: () => void;
+  }
 
-  export let runRecord: FlowRunRecord | null = null;
-  export let history: FlowRunRecord[] = [];
-  export let flowFilePath: string = '';
+  let { runRecord = null, history = [], flowFilePath = '', onClearHistory }: Props = $props();
 
-  let selectedRunId: string | null = null;
-  let expandedStep: string | null = null;
-  let stepsOpen: boolean = true;
+  let selectedRunId: string | null = $state(null);
+  let expandedStep: string | null = $state(null);
+  let stepsOpen: boolean = $state(true);
 
-  $: relevantHistory = history.filter((r) => r.flowFilePath === flowFilePath);
-  $: displayRecord = selectedRunId
-    ? (relevantHistory.find((r) => r.id === selectedRunId) ?? runRecord)
-    : runRecord;
+  const relevantHistory = $derived(history.filter((r) => r.flowFilePath === flowFilePath));
+  const displayRecord = $derived(
+    selectedRunId ? (relevantHistory.find((r) => r.id === selectedRunId) ?? runRecord) : runRecord,
+  );
 
   // Reset collapse state when the displayed record changes
   let prevDisplayId: string | null = null;
-  $: if (displayRecord?.id !== prevDisplayId) {
-    prevDisplayId = displayRecord?.id ?? null;
-    stepsOpen = true;
-    expandedStep = null;
-  }
+  $effect(() => {
+    if (displayRecord?.id !== prevDisplayId) {
+      prevDisplayId = displayRecord?.id ?? null;
+      stepsOpen = true;
+      expandedStep = null;
+    }
+  });
 
   function selectRun(id: string) {
     selectedRunId = selectedRunId === id ? null : id;
@@ -69,8 +73,8 @@
   {#if displayRecord}
     <div class="results-card">
       <!-- Summary bar (toggles step results) -->
-      <button class="results-summary" on:click={() => (stepsOpen = !stepsOpen)}>
-        <span class="summary-chevron" class:open={stepsOpen}>
+      <button class="results-summary" onclick={() => (stepsOpen = !stepsOpen)}>
+        <span class={['summary-chevron', { open: stepsOpen }]}>
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
             <path
               d="M3 1.5l4 3.5-4 3.5"
@@ -103,7 +107,7 @@
         <div class="results-steps">
           {#each displayRecord.stepResults as sr, i}
             <div class="result-step">
-              <button class="result-step-header" on:click={() => toggleStep(sr.stepId)}>
+              <button class="result-step-header" onclick={() => toggleStep(sr.stepId)}>
                 <span class="result-status-icon" style="color: {statusColor(sr.status)}">
                   {#if sr.status === 'passed'}&#10003;{:else if sr.status === 'failed'}&#10005;{:else if sr.status === 'running'}...{:else}-{/if}
                 </span>
@@ -121,15 +125,16 @@
                 {/if}
                 {#if sr.response}
                   <span
-                    class="result-http-code"
-                    class:ok={sr.response.status < 400}
-                    class:err={sr.response.status >= 400}>{sr.response.status}</span
+                    class={[
+                      'result-http-code',
+                      { ok: sr.response.status < 400, err: sr.response.status >= 400 },
+                    ]}>{sr.response.status}</span
                   >
                 {/if}
                 {#if sr.durationMs > 0}
                   <span class="result-dur">{sr.durationMs}ms</span>
                 {/if}
-                <span class="result-chevron" class:open={expandedStep === sr.stepId}>
+                <span class={['result-chevron', { open: expandedStep === sr.stepId }]}>
                   <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
                     <path
                       d="M3 1.5l4 3.5-4 3.5"
@@ -158,7 +163,7 @@
                       >
                       <div class="assertions-list">
                         {#each sr.assertionResults as ar}
-                          <div class="assertion-row" class:pass={ar.passed} class:fail={!ar.passed}>
+                          <div class={['assertion-row', { pass: ar.passed, fail: !ar.passed }]}>
                             <span class="assertion-icon">{ar.passed ? '\u2713' : '\u2717'}</span>
                             <span class="assertion-label">{ar.label}</span>
                           </div>
@@ -188,15 +193,16 @@
     <div class="results-history">
       <div class="history-header">
         <span class="history-title">Run history</span>
-        <button class="btn-clear-history" on:click={() => dispatch('clearHistory')}>Clear</button>
+        <button class="btn-clear-history" onclick={() => onClearHistory?.()}>Clear</button>
       </div>
       <div class="history-list">
         {#each relevantHistory.slice(0, 20) as rec}
           <button
-            class="history-item"
-            class:active={selectedRunId === rec.id}
-            class:is-current={rec.id === runRecord?.id}
-            on:click={() => selectRun(rec.id)}
+            class={[
+              'history-item',
+              { active: selectedRunId === rec.id, 'is-current': rec.id === runRecord?.id },
+            ]}
+            onclick={() => selectRun(rec.id)}
           >
             <span
               class="history-status"

--- a/src/components/FlowStepPicker.svelte
+++ b/src/components/FlowStepPicker.svelte
@@ -1,36 +1,38 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
   import type { TreeNode, FileNode, FlowStep } from '../lib/types';
   import { getAllFileNodes } from '../lib/tree';
   import { METHOD_COLORS } from '../lib/theme';
 
-  export let tree: TreeNode[] = [];
-  export let rootPath: string;
+  interface Props {
+    tree?: TreeNode[];
+    rootPath: string;
+    onPick?: (step: FlowStep) => void;
+    onClose?: () => void;
+  }
 
-  const dispatch = createEventDispatcher<{
-    pick: FlowStep;
-    close: void;
-  }>();
+  let { tree = [], rootPath, onPick, onClose }: Props = $props();
 
-  $: files = getAllFileNodes(tree);
+  const files = $derived(getAllFileNodes(tree));
 
-  let filter = '';
-  let displayMode: 'name' | 'url' = 'name';
+  let filter = $state('');
+  let displayMode: 'name' | 'url' = $state('name');
 
-  $: suffixMap = new Map(files.map((f) => [f.path, computeUrlSuffixes(f.requests)]));
+  const suffixMap = $derived(new Map(files.map((f) => [f.path, computeUrlSuffixes(f.requests)])));
 
-  $: filteredFiles = filter.trim()
-    ? files.filter(
-        (f) =>
-          f.name.toLowerCase().includes(filter.toLowerCase()) ||
-          f.requests.some(
-            (r) =>
-              r.url.toLowerCase().includes(filter.toLowerCase()) ||
-              r.name.toLowerCase().includes(filter.toLowerCase()) ||
-              r.method.toLowerCase().includes(filter.toLowerCase()),
-          ),
-      )
-    : files;
+  const filteredFiles = $derived(
+    filter.trim()
+      ? files.filter(
+          (f) =>
+            f.name.toLowerCase().includes(filter.toLowerCase()) ||
+            f.requests.some(
+              (r) =>
+                r.url.toLowerCase().includes(filter.toLowerCase()) ||
+                r.name.toLowerCase().includes(filter.toLowerCase()) ||
+                r.method.toLowerCase().includes(filter.toLowerCase()),
+            ),
+        )
+      : files,
+  );
 
   function pickRequest(file: FileNode, requestIndex: number) {
     const req = file.requests[requestIndex];
@@ -45,7 +47,7 @@
       label: `${req.method} ${req.url}`,
       continueOnFailure: false,
     };
-    dispatch('pick', step);
+    onPick?.(step);
   }
 
   /** Compute unique URL suffixes for requests in a file, stripping common prefix segments. */
@@ -67,30 +69,34 @@
   }
 
   function handleBackdropClick(e: MouseEvent) {
-    if (e.target === e.currentTarget) dispatch('close');
+    if (e.target === e.currentTarget) onClose?.();
   }
 
-  let expandedFiles: Set<string> = new Set();
+  let expandedFiles: Set<string> = $state(new Set());
 
   function toggleFile(path: string) {
-    if (expandedFiles.has(path)) {
-      expandedFiles.delete(path);
+    const next = new Set(expandedFiles);
+    if (next.has(path)) {
+      next.delete(path);
     } else {
-      expandedFiles.add(path);
+      next.add(path);
     }
-    expandedFiles = expandedFiles;
+    expandedFiles = next;
   }
 
-  let filterInputEl: HTMLInputElement;
-  $: if (filterInputEl) filterInputEl.focus();
+  let filterInputEl: HTMLInputElement | null = $state(null);
+  // Focus the filter input as soon as the picker mounts.
+  $effect(() => {
+    filterInputEl?.focus();
+  });
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="picker-backdrop"
-  on:click={handleBackdropClick}
-  on:keydown={(e) => {
-    if (e.key === 'Escape') dispatch('close');
+  onclick={handleBackdropClick}
+  onkeydown={(e) => {
+    if (e.key === 'Escape') onClose?.();
   }}
 >
   <div class="picker-panel">
@@ -98,7 +104,7 @@
       <span class="picker-title">Add step</span>
       <button
         class="picker-display-toggle"
-        on:click={() => (displayMode = displayMode === 'name' ? 'url' : 'name')}
+        onclick={() => (displayMode = displayMode === 'name' ? 'url' : 'name')}
         title={displayMode === 'name' ? 'Show URL paths' : 'Show request names'}
       >
         {#if displayMode === 'name'}
@@ -127,7 +133,7 @@
           </svg>
         {/if}
       </button>
-      <button class="picker-close" on:click={() => dispatch('close')}>&times;</button>
+      <button class="picker-close" onclick={() => onClose?.()}>&times;</button>
     </div>
     <div class="picker-filter">
       <input
@@ -136,8 +142,8 @@
         class="picker-filter-input"
         placeholder="Filter by file, URL, or method..."
         spellcheck="false"
-        on:keydown={(e) => {
-          if (e.key === 'Escape') dispatch('close');
+        onkeydown={(e) => {
+          if (e.key === 'Escape') onClose?.();
         }}
       />
     </div>
@@ -148,12 +154,12 @@
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <div
             class="picker-file-header"
-            on:click={() => toggleFile(file.path)}
-            on:keydown={(e) => {
+            onclick={() => toggleFile(file.path)}
+            onkeydown={(e) => {
               if (e.key === 'Enter') toggleFile(file.path);
             }}
           >
-            <span class="picker-chevron" class:open={expanded}>
+            <span class={['picker-chevron', { open: expanded }]}>
               <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
                 <path
                   d="M3 1.5l4 3.5-4 3.5"
@@ -180,7 +186,7 @@
             {#each file.requests as req, i (req.id)}
               <button
                 class="picker-request"
-                on:click={() => pickRequest(file, i)}
+                onclick={() => pickRequest(file, i)}
                 title={displayMode === 'name' ? req.url : req.name}
               >
                 <span class="picker-method" style="color: {METHOD_COLORS[req.method] || '#888'}"

--- a/src/components/HelpModal.svelte
+++ b/src/components/HelpModal.svelte
@@ -1,22 +1,30 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  interface Props {
+    visible?: boolean;
+    onClose?: () => void;
+  }
 
-  export let visible: boolean = false;
-
-  const dispatch = createEventDispatcher();
+  let { visible = false, onClose }: Props = $props();
 
   function close() {
-    dispatch('close');
+    onClose?.();
   }
 </script>
 
 {#if visible}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div class="overlay" on:click|self={close} role="dialog" tabindex="-1">
+  <div
+    class="overlay"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) close();
+    }}
+    role="dialog"
+    tabindex="-1"
+  >
     <div class="modal">
       <div class="modal-header">
         <span class="modal-title">Quick guide</span>
-        <button class="btn-close" on:click={close}>&times;</button>
+        <button class="btn-close" onclick={close}>&times;</button>
       </div>
 
       <div class="section">

--- a/src/components/ImportCollectionModal.svelte
+++ b/src/components/ImportCollectionModal.svelte
@@ -1,35 +1,34 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-  import { invoke } from '@tauri-apps/api/core';
   import { open } from '@tauri-apps/plugin-dialog';
   import { readTextFile } from '@tauri-apps/plugin-fs';
   import { basename } from '@tauri-apps/api/path';
   import { detectImportFormat, formatLabel, type ImportFormat } from '../lib/detect';
-  import type { HttpInvokeResult } from '../lib/requestExec';
+  import { fetchSpecFromUrl } from '../lib/importIO';
   import { errorMessage } from '../lib/errors';
 
-  export let visible: boolean = false;
+  interface Props {
+    visible?: boolean;
+    onImportFile?: (content: string, format: ImportFormat) => void;
+    onImportUrl?: (content: string) => void;
+    onCancel?: () => void;
+  }
 
-  const dispatch = createEventDispatcher<{
-    importFile: { content: string; format: ImportFormat };
-    importUrl: { content: string };
-    cancel: void;
-  }>();
+  let { visible = false, onImportFile, onImportUrl, onCancel }: Props = $props();
 
   const VALID_EXTENSIONS = ['json', 'yaml', 'yml'];
 
-  let mode: 'file' | 'url' = 'file';
-  let selectedFile: { name: string; size: string; content: string } | null = null;
-  let detectedFormat: ImportFormat | null = null;
-  let detectionError = '';
-  let isDragOver = false;
+  let mode: 'file' | 'url' = $state('file');
+  let selectedFile: { name: string; size: string; content: string } | null = $state(null);
+  let detectedFormat: ImportFormat | null = $state(null);
+  let detectionError = $state('');
+  let isDragOver = $state(false);
   let dragDepth = 0;
-  let error = '';
+  let error = $state('');
 
   // URL mode state
-  let url = '';
-  let urlLoading = false;
-  let urlError = '';
+  let url = $state('');
+  let urlLoading = $state(false);
+  let urlError = $state('');
 
   // HTML5 drag-drop handlers for the drop zone
   function handleDragEnter(e: DragEvent) {
@@ -80,18 +79,20 @@
   }
 
   // Reset state when modal opens
-  $: if (visible) {
-    mode = 'file';
-    selectedFile = null;
-    detectedFormat = null;
-    detectionError = '';
-    isDragOver = false;
-    dragDepth = 0;
-    error = '';
-    url = '';
-    urlLoading = false;
-    urlError = '';
-  }
+  $effect(() => {
+    if (visible) {
+      mode = 'file';
+      selectedFile = null;
+      detectedFormat = null;
+      detectionError = '';
+      isDragOver = false;
+      dragDepth = 0;
+      error = '';
+      url = '';
+      urlLoading = false;
+      urlError = '';
+    }
+  });
 
   function formatFileSize(bytes: number): string {
     if (bytes < 1024) return `${bytes} B`;
@@ -146,7 +147,7 @@
 
   function doImport() {
     if (!selectedFile || !detectedFormat) return;
-    dispatch('importFile', { content: selectedFile.content, format: detectedFormat });
+    onImportFile?.(selectedFile.content, detectedFormat);
   }
 
   // URL mode
@@ -163,26 +164,8 @@
     urlError = '';
 
     try {
-      const res: HttpInvokeResult = await invoke('http_request', {
-        payload: {
-          method: 'GET',
-          url: trimmedUrl,
-          headers: { Accept: 'application/json, application/yaml, text/yaml, */*' },
-          body: null,
-        },
-      });
-
-      if (res.status >= 400) {
-        urlError = `Server returned ${res.status} ${res.status_text}`;
-        return;
-      }
-
-      if (res.body_encoding === 'base64') {
-        urlError = 'URL returned binary content, not a text spec';
-        return;
-      }
-
-      dispatch('importUrl', { content: res.body });
+      const content = await fetchSpecFromUrl(trimmedUrl);
+      onImportUrl?.(content);
     } catch (e) {
       urlError = errorMessage(e) || 'Failed to fetch spec';
     } finally {
@@ -191,7 +174,7 @@
   }
 
   function cancel() {
-    dispatch('cancel');
+    onCancel?.();
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -199,15 +182,22 @@
   }
 </script>
 
-<svelte:window on:keydown={visible ? handleKeydown : undefined} />
+<svelte:window onkeydown={visible ? handleKeydown : undefined} />
 
 {#if visible}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div class="overlay" on:click|self={cancel} role="dialog" tabindex="-1">
+  <div
+    class="overlay"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) cancel();
+    }}
+    role="dialog"
+    tabindex="-1"
+  >
     <div class="modal">
       <div class="modal-header">
         <span class="modal-title">Import Collection</span>
-        <button class="btn-close" on:click={cancel}>&times;</button>
+        <button class="btn-close" onclick={cancel}>&times;</button>
       </div>
 
       <div class="modal-body">
@@ -215,12 +205,11 @@
           {#if !selectedFile}
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
-              class="drop-zone"
-              class:drag-over={isDragOver}
-              on:dragenter={handleDragEnter}
-              on:dragleave={handleDragLeave}
-              on:dragover={handleDragOver}
-              on:drop={handleDrop}
+              class={['drop-zone', { 'drag-over': isDragOver }]}
+              ondragenter={handleDragEnter}
+              ondragleave={handleDragLeave}
+              ondragover={handleDragOver}
+              ondrop={handleDrop}
             >
               <svg class="drop-icon" width="32" height="32" viewBox="0 0 32 32" fill="none">
                 <path
@@ -240,7 +229,7 @@
               </svg>
               <span class="drop-text">Drop a collection file here</span>
               <span class="drop-or">or</span>
-              <button class="btn-browse" on:click={browseFile}>Browse files</button>
+              <button class="btn-browse" onclick={browseFile}>Browse files</button>
             </div>
             <p class="supported-formats">
               Supports Postman, Insomnia, and OpenAPI / Swagger (.json, .yaml, .yml)
@@ -262,7 +251,7 @@
               {#if detectedFormat}
                 <span class="format-badge">{formatLabel(detectedFormat)}</span>
               {/if}
-              <button class="btn-clear" on:click={clearFile} title="Remove file">
+              <button class="btn-clear" onclick={clearFile} title="Remove file">
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
                   <path
                     d="M3 3l6 6M9 3l-6 6"
@@ -285,7 +274,7 @@
 
           <button
             class="mode-switch"
-            on:click={() => {
+            onclick={() => {
               mode = 'url';
               clearFile();
             }}
@@ -302,7 +291,7 @@
             bind:value={url}
             placeholder="https://petstore.swagger.io/v2/swagger.json"
             disabled={urlLoading}
-            on:keydown={(e) => {
+            onkeydown={(e) => {
               if (e.key === 'Enter') fetchSpec();
             }}
           />
@@ -313,7 +302,7 @@
 
           <button
             class="mode-switch"
-            on:click={() => {
+            onclick={() => {
               mode = 'file';
               urlError = '';
             }}
@@ -324,17 +313,17 @@
       </div>
 
       <div class="modal-footer">
-        <button class="btn-cancel" on:click={cancel} disabled={urlLoading}>Cancel</button>
+        <button class="btn-cancel" onclick={cancel} disabled={urlLoading}>Cancel</button>
         {#if mode === 'file'}
           <button
             class="btn-confirm"
-            on:click={doImport}
+            onclick={doImport}
             disabled={!selectedFile || !detectedFormat}
           >
             Import
           </button>
         {:else}
-          <button class="btn-confirm" on:click={fetchSpec} disabled={urlLoading || !url.trim()}>
+          <button class="btn-confirm" onclick={fetchSpec} disabled={urlLoading || !url.trim()}>
             {#if urlLoading}
               Fetching...
             {:else}

--- a/src/components/ImportEnvModal.svelte
+++ b/src/components/ImportEnvModal.svelte
@@ -1,53 +1,69 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
   import type { Variable } from '../lib/types';
 
-  /** Discovered {{variable}} references to add to the environment */
-  export let variables: Variable[] = [];
-  /** Names of existing environments found in env files */
-  export let existingEnvironments: string[] = [];
-  /** Whether environment files already exist in the workspace */
-  export let hasEnvFile: boolean = false;
-  /** Whether the modal is visible */
-  export let visible: boolean = false;
+  interface Props {
+    /** Discovered {{variable}} references to add to the environment */
+    variables?: Variable[];
+    /** Names of existing environments found in env files */
+    existingEnvironments?: string[];
+    /** Whether environment files already exist in the workspace */
+    hasEnvFile?: boolean;
+    /** Whether the modal is visible */
+    visible?: boolean;
+    onConfirm?: (target: string) => void;
+    onSkip?: () => void;
+  }
 
-  const dispatch = createEventDispatcher<{
-    confirm: { target: string };
-    skip: void;
-  }>();
+  let {
+    variables = [],
+    existingEnvironments = [],
+    hasEnvFile = false,
+    visible = false,
+    onConfirm,
+    onSkip,
+  }: Props = $props();
 
-  let selectedTarget = '';
-  let newEnvName = 'development';
+  let selectedTarget = $state('');
+  let newEnvName = $state('development');
 
   // Reset state when modal opens
-  $: if (visible) {
-    if (!hasEnvFile) {
-      selectedTarget = '__new__';
-      newEnvName = 'development';
-    } else {
-      selectedTarget = existingEnvironments[0] ?? '__new__';
-      newEnvName = '';
+  $effect(() => {
+    if (visible) {
+      if (!hasEnvFile) {
+        selectedTarget = '__new__';
+        newEnvName = 'development';
+      } else {
+        selectedTarget = existingEnvironments[0] ?? '__new__';
+        newEnvName = '';
+      }
     }
-  }
+  });
 
   function confirm() {
     const target = selectedTarget === '__new__' ? newEnvName.trim() : selectedTarget;
     if (!target) return;
-    dispatch('confirm', { target });
+    onConfirm?.(target);
   }
 
   function skip() {
-    dispatch('skip');
+    onSkip?.();
   }
 </script>
 
 {#if visible}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div class="overlay" on:click|self={skip} role="dialog" tabindex="-1">
+  <div
+    class="overlay"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) skip();
+    }}
+    role="dialog"
+    tabindex="-1"
+  >
     <div class="modal">
       <div class="modal-header">
         <span class="modal-title">Import variables to environment</span>
-        <button class="btn-close" on:click={skip}>&times;</button>
+        <button class="btn-close" onclick={skip}>&times;</button>
       </div>
 
       <div class="modal-body">
@@ -58,7 +74,9 @@
 
         <div class="var-list">
           {#each variables as v}
-            <span class="var-tag" class:has-value={!!v.value}>&#123;&#123;{v.key}&#125;&#125;</span>
+            <span class={['var-tag', { 'has-value': !!v.value }]}
+              >&#123;&#123;{v.key}&#125;&#125;</span
+            >
           {/each}
         </div>
 
@@ -86,7 +104,7 @@
               class="env-name-input"
               bind:value={newEnvName}
               placeholder="Environment name..."
-              on:keydown={(e) => {
+              onkeydown={(e) => {
                 if (e.key === 'Enter') confirm();
               }}
             />
@@ -95,8 +113,8 @@
       </div>
 
       <div class="modal-footer">
-        <button class="btn-skip" on:click={skip}>Skip</button>
-        <button class="btn-confirm" on:click={confirm}>Add variables</button>
+        <button class="btn-skip" onclick={skip}>Skip</button>
+        <button class="btn-confirm" onclick={confirm}>Add variables</button>
       </div>
     </div>
   </div>

--- a/src/components/RequestEditor.svelte
+++ b/src/components/RequestEditor.svelte
@@ -283,8 +283,7 @@
     showPicker = true;
   }
 
-  function handlePickerInsert(e: CustomEvent<string>) {
-    const value = e.detail;
+  function handlePickerInsert(value: string) {
     showPicker = false;
     if (pickerTarget === 'url') {
       update({ url: insertAtCursor(request.url, value) });
@@ -633,8 +632,8 @@
   {fileVariables}
   {envVariables}
   {namedResults}
-  on:insert={handlePickerInsert}
-  on:close={() => (showPicker = false)}
+  onInsert={handlePickerInsert}
+  onClose={() => (showPicker = false)}
 />
 
 <style>

--- a/src/components/RequestEditor.svelte
+++ b/src/components/RequestEditor.svelte
@@ -431,7 +431,7 @@
   {/if}
 
   <!-- Dependency bar -->
-  <DependencyBar {requestText} {namedResults} on:runAll />
+  <DependencyBar {requestText} {namedResults} onRunAll={(deps) => dispatch('runAll', deps)} />
 
   <!-- Headers (collapsible) -->
   <div class="section">

--- a/src/components/ResponseViewer.svelte
+++ b/src/components/ResponseViewer.svelte
@@ -1,31 +1,44 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
   import type { HttpResponse, PbAssertionResult } from '../lib/types';
   import type { ResponseTab } from '../lib/stores';
 
-  export let response: HttpResponse | null = null;
-  export let loading: boolean = false;
-  export let sentRequest: {
-    method: string;
-    url: string;
-    headers: Record<string, string>;
-    body: string;
-  } | null = null;
-  export let assertionResults: PbAssertionResult[] = [];
-  export let activeTab: ResponseTab = 'body';
+  interface Props {
+    response?: HttpResponse | null;
+    loading?: boolean;
+    sentRequest?: {
+      method: string;
+      url: string;
+      headers: Record<string, string>;
+      body: string;
+    } | null;
+    assertionResults?: PbAssertionResult[];
+    activeTab?: ResponseTab;
+    onTabChange?: (tab: ResponseTab) => void;
+  }
 
-  const dispatch = createEventDispatcher<{ tabChange: ResponseTab }>();
+  let {
+    response = null,
+    loading = false,
+    sentRequest = null,
+    assertionResults = [],
+    activeTab: activeTabProp = 'body',
+    onTabChange,
+  }: Props = $props();
+
+  // Writable derived: local tab switches take effect immediately and are
+  // overridden whenever the parent passes a new activeTab value.
+  let activeTab = $derived(activeTabProp);
 
   function setTab(tab: ResponseTab) {
     activeTab = tab;
-    dispatch('tabChange', tab);
+    onTabChange?.(tab);
   }
 
-  $: passedCount = assertionResults.filter((t) => t.passed).length;
-  $: failedCount = assertionResults.filter((t) => !t.passed).length;
+  const passedCount = $derived(assertionResults.filter((t) => t.passed).length);
+  const failedCount = $derived(assertionResults.filter((t) => !t.passed).length);
   // Binary bodies arrive base64-encoded from the backend; show a notice
   // instead of the (useless) base64 text.
-  $: isBinaryBody = response?.bodyEncoding === 'base64';
+  const isBinaryBody = $derived(response?.bodyEncoding === 'base64');
 
   function getStatusClass(status: number): string {
     if (status >= 200 && status < 300) return 'status-success';
@@ -129,7 +142,7 @@
 
     <!-- Response Tabs -->
     <div class="tabs">
-      <button class="tab" class:active={activeTab === 'body'} on:click={() => setTab('body')}>
+      <button class={['tab', { active: activeTab === 'body' }]} onclick={() => setTab('body')}>
         Body
         {#if !isBinaryBody && isJson(response.body)}
           <span class="tab-badge">JSON</span>
@@ -137,30 +150,32 @@
           <span class="tab-badge">Binary</span>
         {/if}
       </button>
-      <button class="tab" class:active={activeTab === 'headers'} on:click={() => setTab('headers')}>
+      <button
+        class={['tab', { active: activeTab === 'headers' }]}
+        onclick={() => setTab('headers')}
+      >
         Headers
         <span class="tab-count">{Object.keys(response.headers).length}</span>
       </button>
       {#if sentRequest}
         <button
-          class="tab"
-          class:active={activeTab === 'request'}
-          on:click={() => setTab('request')}
+          class={['tab', { active: activeTab === 'request' }]}
+          onclick={() => setTab('request')}
         >
           Request
         </button>
       {/if}
       {#if assertionResults.length > 0}
         <button
-          class="tab"
-          class:active={activeTab === 'assertions'}
-          on:click={() => setTab('assertions')}
+          class={['tab', { active: activeTab === 'assertions' }]}
+          onclick={() => setTab('assertions')}
         >
           Assertions
           <span
-            class="tab-count assertion-count"
-            class:all-pass={failedCount === 0}
-            class:has-fail={failedCount > 0}
+            class={[
+              'tab-count assertion-count',
+              { 'all-pass': failedCount === 0, 'has-fail': failedCount > 0 },
+            ]}
           >
             {passedCount}/{assertionResults.length}
           </span>
@@ -176,7 +191,7 @@
             Binary response body ({formatSize(response.size)}). Text preview is not available.
           </div>
         {:else}
-          <pre class="body-output" class:json={isJson(response.body)}>{formatBody(
+          <pre class={['body-output', { json: isJson(response.body) }]}>{formatBody(
               response.body,
             )}</pre>
         {/if}
@@ -197,7 +212,7 @@
       {:else if activeTab === 'assertions'}
         <div class="assertion-results">
           {#each assertionResults as result}
-            <div class="assertion-entry" class:pass={result.passed} class:fail={!result.passed}>
+            <div class={['assertion-entry', { pass: result.passed, fail: !result.passed }]}>
               <span class="assertion-icon">{result.passed ? '\u2713' : '\u2717'}</span>
               <span class="assertion-label">{result.label}</span>
             </div>

--- a/src/components/VariableInspector.svelte
+++ b/src/components/VariableInspector.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
   import type {
     Variable,
     NamedRequestResult,
@@ -8,33 +7,48 @@
     VarSource,
   } from '../lib/types';
 
-  export let visible: boolean = false;
-  export let fileVariables: Variable[] = [];
-  export let envVariables: Record<string, string> = {};
-  export let envVarSources: Record<string, ResolvedVarWithCascade> = {};
-  export let kvVariables: Record<string, string> = {};
-  export let varSourcePrefs: Record<string, VarSource> = {};
-  export let pbOverrides: Record<string, string> = {};
-  export let pbGlobals: Record<string, string> = {};
-  export let namedResults: Record<string, NamedRequestResult> = {};
-  export let activeEnv: string | null = null;
-  export let activeFileName: string = '';
+  interface Props {
+    visible?: boolean;
+    fileVariables?: Variable[];
+    envVariables?: Record<string, string>;
+    envVarSources?: Record<string, ResolvedVarWithCascade>;
+    kvVariables?: Record<string, string>;
+    varSourcePrefs?: Record<string, VarSource>;
+    pbOverrides?: Record<string, string>;
+    pbGlobals?: Record<string, string>;
+    namedResults?: Record<string, NamedRequestResult>;
+    activeEnv?: string | null;
+    activeFileName?: string;
+    onClose?: () => void;
+    onClearRuntime?: () => void;
+  }
 
-  const dispatch = createEventDispatcher<{
-    close: void;
-    clearRuntime: void;
-  }>();
+  let {
+    visible = false,
+    fileVariables = [],
+    envVariables = {},
+    envVarSources = {},
+    kvVariables = {},
+    varSourcePrefs = {},
+    pbOverrides = {},
+    pbGlobals = {},
+    namedResults = {},
+    activeEnv = null,
+    activeFileName = '',
+    onClose,
+    onClearRuntime,
+  }: Props = $props();
 
-  let fileExpanded = true;
-  let envExpanded = true;
-  let runtimeExpanded = true;
+  let fileExpanded = $state(true);
+  let envExpanded = $state(true);
+  let runtimeExpanded = $state(true);
 
-  let searchQuery = '';
-  let showKvSecrets = false;
-  let copiedKey: string | null = null;
+  let searchQuery = $state('');
+  let showKvSecrets = $state(false);
+  let copiedKey: string | null = $state(null);
   let copiedTimeout: ReturnType<typeof setTimeout> | null = null;
 
-  let expandedCascadeKey: string | null = null;
+  let expandedCascadeKey: string | null = $state(null);
 
   function sourceTagLabel(source: VarSourceLayer): string {
     switch (source) {
@@ -90,66 +104,87 @@
     }
   }
 
-  $: if (visible) {
-    searchQuery = '';
-    copiedKey = null;
-    showKvSecrets = false;
-    expandedCascadeKey = null;
-  }
+  // Reset transient inspector state each time the modal opens.
+  $effect(() => {
+    if (visible) {
+      searchQuery = '';
+      copiedKey = null;
+      showKvSecrets = false;
+      expandedCascadeKey = null;
+    }
+  });
 
-  $: envEntries = Object.entries(envVariables).filter(
-    ([k]) => !(k in pbOverrides) && !(k in pbGlobals),
+  const envEntries = $derived(
+    Object.entries(envVariables).filter(([k]) => !(k in pbOverrides) && !(k in pbGlobals)),
   );
-  $: overrideEntries = Object.entries(pbOverrides).filter(([k]) => !(k in pbGlobals));
-  $: globalEntries = Object.entries(pbGlobals);
-  $: namedEntries = Object.entries(namedResults);
+  const overrideEntries = $derived(Object.entries(pbOverrides).filter(([k]) => !(k in pbGlobals)));
+  const globalEntries = $derived(Object.entries(pbGlobals));
+  const namedEntries = $derived(Object.entries(namedResults));
 
-  $: runtimeCount = overrideEntries.length + globalEntries.length + namedEntries.length;
-  $: hasRuntime = runtimeCount > 0;
+  const runtimeCount = $derived(
+    overrideEntries.length + globalEntries.length + namedEntries.length,
+  );
+  const hasRuntime = $derived(runtimeCount > 0);
 
-  $: searchQueryLower = searchQuery.trim().toLowerCase();
+  const searchQueryLower = $derived(searchQuery.trim().toLowerCase());
 
-  $: filteredFileVars = searchQueryLower
-    ? fileVariables.filter(
-        (v) =>
-          v.key.toLowerCase().includes(searchQueryLower) ||
-          v.value.toLowerCase().includes(searchQueryLower),
-      )
-    : fileVariables;
-  $: filteredEnvEntries = (
+  const filteredFileVars = $derived(
     searchQueryLower
+      ? fileVariables.filter(
+          (v) =>
+            v.key.toLowerCase().includes(searchQueryLower) ||
+            v.value.toLowerCase().includes(searchQueryLower),
+        )
+      : fileVariables,
+  );
+  const filteredEnvEntries = $derived(
+    (searchQueryLower
       ? envEntries.filter(
           ([k, v]) =>
             k.toLowerCase().includes(searchQueryLower) ||
             v.toLowerCase().includes(searchQueryLower),
         )
       : envEntries
-  )
-    .slice()
-    .sort((a, b) => sourcePriority(a[0]) - sourcePriority(b[0]));
-  $: filteredOverrides = searchQueryLower
-    ? overrideEntries.filter(
-        ([k, v]) =>
-          k.toLowerCase().includes(searchQueryLower) || v.toLowerCase().includes(searchQueryLower),
-      )
-    : overrideEntries;
-  $: filteredGlobals = searchQueryLower
-    ? globalEntries.filter(
-        ([k, v]) =>
-          k.toLowerCase().includes(searchQueryLower) || v.toLowerCase().includes(searchQueryLower),
-      )
-    : globalEntries;
-  $: filteredNamed = searchQueryLower
-    ? namedEntries.filter(([name, result]) => {
-        const summary = `${result.request.method} ${result.response.status}`.toLowerCase();
-        return name.toLowerCase().includes(searchQueryLower) || summary.includes(searchQueryLower);
-      })
-    : namedEntries;
-  $: filteredRuntimeCount =
-    filteredOverrides.length + filteredGlobals.length + filteredNamed.length;
+    )
+      .slice()
+      .sort((a, b) => sourcePriority(a[0]) - sourcePriority(b[0])),
+  );
+  const filteredOverrides = $derived(
+    searchQueryLower
+      ? overrideEntries.filter(
+          ([k, v]) =>
+            k.toLowerCase().includes(searchQueryLower) ||
+            v.toLowerCase().includes(searchQueryLower),
+        )
+      : overrideEntries,
+  );
+  const filteredGlobals = $derived(
+    searchQueryLower
+      ? globalEntries.filter(
+          ([k, v]) =>
+            k.toLowerCase().includes(searchQueryLower) ||
+            v.toLowerCase().includes(searchQueryLower),
+        )
+      : globalEntries,
+  );
+  const filteredNamed = $derived(
+    searchQueryLower
+      ? namedEntries.filter(([name, result]) => {
+          const summary = `${result.request.method} ${result.response.status}`.toLowerCase();
+          return (
+            name.toLowerCase().includes(searchQueryLower) || summary.includes(searchQueryLower)
+          );
+        })
+      : namedEntries,
+  );
+  const filteredRuntimeCount = $derived(
+    filteredOverrides.length + filteredGlobals.length + filteredNamed.length,
+  );
 
-  $: totalCount = fileVariables.length + envEntries.length + runtimeCount;
-  $: filteredTotal = filteredFileVars.length + filteredEnvEntries.length + filteredRuntimeCount;
+  const totalCount = $derived(fileVariables.length + envEntries.length + runtimeCount);
+  const filteredTotal = $derived(
+    filteredFileVars.length + filteredEnvEntries.length + filteredRuntimeCount,
+  );
 
   function masked(val: string): string {
     return '*'.repeat(Math.min(val.length, 12));
@@ -173,7 +208,7 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') dispatch('close');
+    if (e.key === 'Escape') onClose?.();
   }
 
   function badgeText(filtered: number, total: number): string {
@@ -182,11 +217,18 @@
   }
 </script>
 
-<svelte:window on:keydown={visible ? handleKeydown : undefined} />
+<svelte:window onkeydown={visible ? handleKeydown : undefined} />
 
 {#if visible}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div class="overlay" on:click|self={() => dispatch('close')} role="dialog" tabindex="-1">
+  <div
+    class="overlay"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) onClose?.();
+    }}
+    role="dialog"
+    tabindex="-1"
+  >
     <div class="modal">
       <div class="modal-header">
         <span class="title-group">
@@ -195,7 +237,7 @@
             <span class="active-env-badge">{activeEnv}</span>
           {/if}
         </span>
-        <button class="btn-close" on:click={() => dispatch('close')}>&times;</button>
+        <button class="btn-close" onclick={() => onClose?.()}>&times;</button>
       </div>
 
       <div class="modal-body">
@@ -241,8 +283,8 @@
             <!-- File Variables -->
             {#if fileVariables.length > 0}
               <section class="group">
-                <button class="group-header" on:click={() => (fileExpanded = !fileExpanded)}>
-                  <span class="chevron" class:open={fileExpanded}>
+                <button class="group-header" onclick={() => (fileExpanded = !fileExpanded)}>
+                  <span class={['chevron', { open: fileExpanded }]}>
                     <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
                       <path
                         d="M3 1.5l4 3.5-4 3.5"
@@ -265,9 +307,8 @@
                     {:else}
                       {#each filteredFileVars as v}
                         <button
-                          class="row"
-                          class:copied={copiedKey === v.key}
-                          on:click={() => copyRef(v.key)}
+                          class={['row', { copied: copiedKey === v.key }]}
+                          onclick={() => copyRef(v.key)}
                         >
                           <span class="tag file">FILE</span>
                           <span class="key" title={v.key}>{v.key}</span>
@@ -287,8 +328,8 @@
             <!-- Environment Variables -->
             {#if envEntries.length > 0}
               <section class="group">
-                <button class="group-header" on:click={() => (envExpanded = !envExpanded)}>
-                  <span class="chevron" class:open={envExpanded}>
+                <button class="group-header" onclick={() => (envExpanded = !envExpanded)}>
+                  <span class={['chevron', { open: envExpanded }]}>
                     <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
                       <path
                         d="M3 1.5l4 3.5-4 3.5"
@@ -309,8 +350,10 @@
                       class="kv-reveal-toggle"
                       role="button"
                       tabindex="0"
-                      on:click|stopPropagation={() => (showKvSecrets = !showKvSecrets)}
-                      >{showKvSecrets ? '[Hide secrets]' : '[Show secrets]'}</span
+                      onclick={(e) => {
+                        e.stopPropagation();
+                        showKvSecrets = !showKvSecrets;
+                      }}>{showKvSecrets ? '[Hide secrets]' : '[Show secrets]'}</span
                     >
                   {/if}
                 </button>
@@ -337,9 +380,8 @@
                           : value}
                         <div class="env-row-wrapper">
                           <button
-                            class="row"
-                            class:copied={copiedKey === key}
-                            on:click={() => copyRef(key)}
+                            class={['row', { copied: copiedKey === key }]}
+                            onclick={() => copyRef(key)}
                           >
                             {#if isKv}
                               <span class="tag kv">KV</span>
@@ -362,8 +404,10 @@
                                 role="button"
                                 tabindex="0"
                                 title="Defined in {cascadeCount} layers"
-                                on:click|stopPropagation={() => toggleCascade(key)}
-                                >{cascadeCount} layers</span
+                                onclick={(e) => {
+                                  e.stopPropagation();
+                                  toggleCascade(key);
+                                }}>{cascadeCount} layers</span
                               >
                             {/if}
                             <span class="row-action"
@@ -412,8 +456,8 @@
             <!-- Runtime Variables -->
             {#if runtimeCount > 0}
               <section class="group">
-                <button class="group-header" on:click={() => (runtimeExpanded = !runtimeExpanded)}>
-                  <span class="chevron" class:open={runtimeExpanded}>
+                <button class="group-header" onclick={() => (runtimeExpanded = !runtimeExpanded)}>
+                  <span class={['chevron', { open: runtimeExpanded }]}>
                     <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
                       <path
                         d="M3 1.5l4 3.5-4 3.5"
@@ -439,9 +483,8 @@
                           >
                           {#each filteredOverrides as [key, value]}
                             <button
-                              class="row"
-                              class:copied={copiedKey === key}
-                              on:click={() => copyRef(key)}
+                              class={['row', { copied: copiedKey === key }]}
+                              onclick={() => copyRef(key)}
                             >
                               <span class="tag set">SET</span>
                               <span class="key" title={key}>{key}</span>
@@ -459,9 +502,8 @@
                           <span class="subgroup-label">Workspace scope</span>
                           {#each filteredGlobals as [key, value]}
                             <button
-                              class="row"
-                              class:copied={copiedKey === key}
-                              on:click={() => copyRef(key)}
+                              class={['row', { copied: copiedKey === key }]}
+                              onclick={() => copyRef(key)}
                             >
                               <span class="tag global">GLOBAL</span>
                               <span class="key" title={key}>{key}</span>
@@ -479,9 +521,8 @@
                           <span class="subgroup-label">Named responses</span>
                           {#each filteredNamed as [name, result]}
                             <button
-                              class="row"
-                              class:copied={copiedKey === name}
-                              on:click={() => copyRef(name + '.response.body.$')}
+                              class={['row', { copied: copiedKey === name }]}
+                              onclick={() => copyRef(name + '.response.body.$')}
                             >
                               <span class="tag response">RESPONSE</span>
                               <span class="key" title={name}>{name}</span>
@@ -507,7 +548,7 @@
 
       {#if hasRuntime}
         <div class="modal-footer">
-          <button class="btn-clear-runtime" on:click={() => dispatch('clearRuntime')}
+          <button class="btn-clear-runtime" onclick={() => onClearRuntime?.()}
             >Clear all runtime variables</button
           >
         </div>

--- a/src/components/VariablePicker.svelte
+++ b/src/components/VariablePicker.svelte
@@ -1,43 +1,57 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
   import type { Variable, NamedRequestResult } from '../lib/types';
   import PickerRow from './PickerRow.svelte';
 
-  export let fileVariables: Variable[] = [];
-  export let envVariables: Record<string, string> = {};
-  export let namedResults: Record<string, NamedRequestResult> = {};
-  export let visible: boolean = false;
-  /** When non-null, scopes the response section to these aliases (from the active test flow).
-   *  Aliases without a captured result still appear with placeholder body/header rows. */
-  export let flowAliases: { name: string; stepNumber: number }[] | null = null;
-  /** Flow display name; used as the header of the flow-scope variables section. */
-  export let flowName: string = '';
-  /** Variables set via `pb.set` / `pb.global` during the flow's most recent run.
-   *  Rendered as a collapsible section at the top of the flow-scoped picker. */
-  export let flowSetVars: Record<string, string> = {};
-
-  let expandedAliases: Record<string, boolean> = {};
-  let flowVarsExpanded = false;
-  $: if (visible) {
-    expandedAliases = {};
-    flowVarsExpanded = false;
+  interface Props {
+    fileVariables?: Variable[];
+    envVariables?: Record<string, string>;
+    namedResults?: Record<string, NamedRequestResult>;
+    visible?: boolean;
+    /** When non-null, scopes the response section to these aliases (from the active test flow).
+     *  Aliases without a captured result still appear with placeholder body/header rows. */
+    flowAliases?: { name: string; stepNumber: number }[] | null;
+    /** Flow display name; used as the header of the flow-scope variables section. */
+    flowName?: string;
+    /** Variables set via `pb.set` / `pb.global` during the flow's most recent run.
+     *  Rendered as a collapsible section at the top of the flow-scoped picker. */
+    flowSetVars?: Record<string, string>;
+    onInsert?: (value: string) => void;
+    onClose?: () => void;
   }
+
+  let {
+    fileVariables = [],
+    envVariables = {},
+    namedResults = {},
+    visible = false,
+    flowAliases = null,
+    flowName = '',
+    flowSetVars = {},
+    onInsert,
+    onClose,
+  }: Props = $props();
+
+  let expandedAliases: Record<string, boolean> = $state({});
+  let flowVarsExpanded = $state(false);
   function toggleAlias(name: string) {
     expandedAliases = { ...expandedAliases, [name]: !expandedAliases[name] };
   }
 
-  const dispatch = createEventDispatcher();
-
-  let searchQuery = '';
-  let insertedKey: string | null = null;
+  let searchQuery = $state('');
+  let insertedKey: string | null = $state(null);
   let insertedTimeout: ReturnType<typeof setTimeout> | null = null;
 
-  $: if (visible) {
-    searchQuery = '';
-    insertedKey = null;
-  }
+  // Reset transient picker state each time the modal opens.
+  $effect(() => {
+    if (visible) {
+      expandedAliases = {};
+      flowVarsExpanded = false;
+      searchQuery = '';
+      insertedKey = null;
+    }
+  });
 
-  $: searchQueryLower = searchQuery.trim().toLowerCase();
+  const searchQueryLower = $derived(searchQuery.trim().toLowerCase());
 
   // Flatten JSON object into dot-path entries
   function flattenJson(
@@ -75,110 +89,127 @@
   }
 
   // Env entries (excluding file vars that overlap)
-  $: envEntries = Object.entries(envVariables);
-  $: fileOnly = fileVariables.filter((v) => !(v.key in envVariables));
+  const envEntries = $derived(Object.entries(envVariables));
+  const fileOnly = $derived(fileVariables.filter((v) => !(v.key in envVariables)));
 
   // Filtered lists
-  $: filteredEnv = searchQueryLower
-    ? envEntries.filter(
-        ([k, v]) =>
-          k.toLowerCase().includes(searchQueryLower) || v.toLowerCase().includes(searchQueryLower),
-      )
-    : envEntries;
-  $: filteredFile = searchQueryLower
-    ? fileOnly.filter(
-        (v) =>
-          v.key.toLowerCase().includes(searchQueryLower) ||
-          v.value.toLowerCase().includes(searchQueryLower),
-      )
-    : fileOnly;
+  const filteredEnv = $derived(
+    searchQueryLower
+      ? envEntries.filter(
+          ([k, v]) =>
+            k.toLowerCase().includes(searchQueryLower) ||
+            v.toLowerCase().includes(searchQueryLower),
+        )
+      : envEntries,
+  );
+  const filteredFile = $derived(
+    searchQueryLower
+      ? fileOnly.filter(
+          (v) =>
+            v.key.toLowerCase().includes(searchQueryLower) ||
+            v.value.toLowerCase().includes(searchQueryLower),
+        )
+      : fileOnly,
+  );
   const dynamicVars = [
     { key: '$randomInt', value: 'random number', insert: '{{$randomInt 1 100}}' },
     { key: '$timestamp', value: 'unix epoch', insert: '{{$timestamp}}' },
     { key: '$datetime', value: 'ISO 8601 date', insert: '{{$datetime iso8601}}' },
   ];
-  $: filteredDynamic = searchQueryLower
-    ? dynamicVars.filter(
-        (d) =>
-          d.key.toLowerCase().includes(searchQueryLower) ||
-          d.value.toLowerCase().includes(searchQueryLower),
-      )
-    : dynamicVars;
+  const filteredDynamic = $derived(
+    searchQueryLower
+      ? dynamicVars.filter(
+          (d) =>
+            d.key.toLowerCase().includes(searchQueryLower) ||
+            d.value.toLowerCase().includes(searchQueryLower),
+        )
+      : dynamicVars,
+  );
 
   // Build response field options for each named result
-  $: responseGroups = Object.entries(namedResults).map(([name, result]) => {
-    let bodyFields: { path: string; value: string }[] = [];
-    try {
-      const parsed = JSON.parse(result.response.body);
-      bodyFields = flattenJson(parsed);
-    } catch {
-      bodyFields = [{ path: '*', value: result.response.body.slice(0, 50) }];
-    }
+  const responseGroups = $derived(
+    Object.entries(namedResults).map(([name, result]) => {
+      let bodyFields: { path: string; value: string }[] = [];
+      try {
+        const parsed = JSON.parse(result.response.body);
+        bodyFields = flattenJson(parsed);
+      } catch {
+        bodyFields = [{ path: '*', value: result.response.body.slice(0, 50) }];
+      }
 
-    const headerFields = Object.entries(result.response.headers).map(([k, v]) => ({
-      path: k,
-      value: String(v),
-    }));
+      const headerFields = Object.entries(result.response.headers).map(([k, v]) => ({
+        path: k,
+        value: String(v),
+      }));
 
-    return { name, status: result.response.status, bodyFields, headerFields };
-  });
+      return { name, status: result.response.status, bodyFields, headerFields };
+    }),
+  );
 
-  $: filteredResponseGroups = responseGroups
-    .map((group) => ({
-      ...group,
-      bodyFields: searchQueryLower
-        ? group.bodyFields.filter(
-            (f) =>
-              f.path.toLowerCase().includes(searchQueryLower) ||
-              f.value.toLowerCase().includes(searchQueryLower),
-          )
-        : group.bodyFields,
-      headerFields: searchQueryLower
-        ? group.headerFields.filter(
-            (f) =>
-              f.path.toLowerCase().includes(searchQueryLower) ||
-              f.value.toLowerCase().includes(searchQueryLower),
-          )
-        : group.headerFields,
-    }))
-    .filter((g) => g.bodyFields.length > 0 || g.headerFields.length > 0);
+  const filteredResponseGroups = $derived(
+    responseGroups
+      .map((group) => ({
+        ...group,
+        bodyFields: searchQueryLower
+          ? group.bodyFields.filter(
+              (f) =>
+                f.path.toLowerCase().includes(searchQueryLower) ||
+                f.value.toLowerCase().includes(searchQueryLower),
+            )
+          : group.bodyFields,
+        headerFields: searchQueryLower
+          ? group.headerFields.filter(
+              (f) =>
+                f.path.toLowerCase().includes(searchQueryLower) ||
+                f.value.toLowerCase().includes(searchQueryLower),
+            )
+          : group.headerFields,
+      }))
+      .filter((g) => g.bodyFields.length > 0 || g.headerFields.length > 0),
+  );
 
-  $: responseGroupMap = Object.fromEntries(responseGroups.map((g) => [g.name, g]));
+  const responseGroupMap = $derived(Object.fromEntries(responseGroups.map((g) => [g.name, g])));
 
-  $: hasEnvOrFile = envEntries.length > 0 || fileOnly.length > 0;
+  const hasEnvOrFile = $derived(envEntries.length > 0 || fileOnly.length > 0);
 
   // Flow-scoped aliases filtered by search query (match on name).
-  $: filteredFlowAliases = flowAliases
-    ? searchQueryLower
-      ? flowAliases.filter((a) => a.name.toLowerCase().includes(searchQueryLower))
-      : flowAliases
-    : [];
+  const filteredFlowAliases = $derived(
+    flowAliases
+      ? searchQueryLower
+        ? flowAliases.filter((a) => a.name.toLowerCase().includes(searchQueryLower))
+        : flowAliases
+      : [],
+  );
 
   // Flow-scope variables (pb.set / pb.global captured last run), filtered by search.
-  $: flowSetEntries = Object.entries(flowSetVars);
-  $: filteredFlowSet = searchQueryLower
-    ? flowSetEntries.filter(
-        ([k, v]) =>
-          k.toLowerCase().includes(searchQueryLower) || v.toLowerCase().includes(searchQueryLower),
-      )
-    : flowSetEntries;
+  const flowSetEntries = $derived(Object.entries(flowSetVars));
+  const filteredFlowSet = $derived(
+    searchQueryLower
+      ? flowSetEntries.filter(
+          ([k, v]) =>
+            k.toLowerCase().includes(searchQueryLower) ||
+            v.toLowerCase().includes(searchQueryLower),
+        )
+      : flowSetEntries,
+  );
 
-  $: totalVisible =
+  const totalVisible = $derived(
     filteredEnv.length +
-    filteredFile.length +
-    filteredDynamic.length +
-    (flowAliases
-      ? filteredFlowAliases.length + filteredFlowSet.length
-      : filteredResponseGroups.reduce(
-          (s, g) => s + g.bodyFields.length + g.headerFields.length,
-          0,
-        ));
+      filteredFile.length +
+      filteredDynamic.length +
+      (flowAliases
+        ? filteredFlowAliases.length + filteredFlowSet.length
+        : filteredResponseGroups.reduce(
+            (s, g) => s + g.bodyFields.length + g.headerFields.length,
+            0,
+          )),
+  );
 
   function doInsert(key: string, value: string) {
     insertedKey = key;
     if (insertedTimeout) clearTimeout(insertedTimeout);
     insertedTimeout = setTimeout(() => {
-      dispatch('insert', value);
+      onInsert?.(value);
       insertedKey = null;
     }, 150);
   }
@@ -196,7 +227,7 @@
   }
 
   function close() {
-    dispatch('close');
+    onClose?.();
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -204,15 +235,22 @@
   }
 </script>
 
-<svelte:window on:keydown={visible ? handleKeydown : undefined} />
+<svelte:window onkeydown={visible ? handleKeydown : undefined} />
 
 {#if visible}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div class="overlay" on:click|self={close} role="dialog" tabindex="-1">
+  <div
+    class="overlay"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) close();
+    }}
+    role="dialog"
+    tabindex="-1"
+  >
     <div class="modal">
       <div class="modal-header">
         <span class="modal-title">Insert variable</span>
-        <button class="btn-close" on:click={close}>&times;</button>
+        <button class="btn-close" onclick={close}>&times;</button>
       </div>
 
       <div class="modal-body">
@@ -232,9 +270,8 @@
               <!-- Flow-scope variables: pb.set / pb.global captured on the most recent run. -->
               {#if filteredFlowSet.length > 0}
                 <button
-                  class="group-header group-header-button"
-                  class:open={flowVarsExpanded}
-                  on:click={() => (flowVarsExpanded = !flowVarsExpanded)}
+                  class={['group-header group-header-button', { open: flowVarsExpanded }]}
+                  onclick={() => (flowVarsExpanded = !flowVarsExpanded)}
                   aria-expanded={flowVarsExpanded}
                   title="Variables set by this flow via pb.set or pb.global on its last run"
                 >
@@ -278,9 +315,8 @@
                     : group.headerFields
                   : []}
                 <button
-                  class="group-header group-header-button"
-                  class:open={isOpen}
-                  on:click={() => toggleAlias(alias.name)}
+                  class={['group-header group-header-button', { open: isOpen }]}
+                  onclick={() => toggleAlias(alias.name)}
                   aria-expanded={isOpen}
                 >
                   <span class="chevron" aria-hidden="true">{isOpen ? '▾' : '▸'}</span>
@@ -288,9 +324,10 @@
                   <span class="group-label">{alias.name} - Response</span>
                   {#if group}
                     <span
-                      class="status-badge"
-                      class:success={group.status < 400}
-                      class:error={group.status >= 400}>{group.status}</span
+                      class={[
+                        'status-badge',
+                        { success: group.status < 400, error: group.status >= 400 },
+                      ]}>{group.status}</span
                     >
                   {:else}
                     <span class="status-badge pending">not run</span>
@@ -421,9 +458,10 @@
                   <div class="group-header">
                     <span class="group-label">Response body - {group.name}</span>
                     <span
-                      class="status-badge"
-                      class:success={group.status < 400}
-                      class:error={group.status >= 400}
+                      class={[
+                        'status-badge',
+                        { success: group.status < 400, error: group.status >= 400 },
+                      ]}
                     >
                       {group.status}
                     </span>

--- a/src/lib/importIO.ts
+++ b/src/lib/importIO.ts
@@ -5,10 +5,12 @@
 // still need the target-environment modal (empty when nothing is pending).
 
 import { get } from 'svelte/store';
+import { invoke } from '@tauri-apps/api/core';
 import { writeTextFile, mkdir } from '@tauri-apps/plugin-fs';
 import { join, basename, dirname } from '@tauri-apps/api/path';
 import { workspace, envFile, activeEnvironment, addToast } from './stores';
 import { errorMessage } from './errors';
+import type { HttpInvokeResult } from './requestExec';
 import { ensureSharedEnvironment } from './envFiles';
 import { buildWorkspaceTree } from './workspaceTree';
 import { scanForHttpFiles, safeJoinPath } from './workspaceIO';
@@ -17,6 +19,32 @@ import { importInsomniaExport } from './insomnia';
 import { importOpenApiSpec } from './openapi';
 import type { ImportFormat } from './detect';
 import type { ImportResult, EnvironmentFile, Variable } from './types';
+
+/**
+ * Fetch a collection/spec over HTTP (via the Tauri http_request proxy) and
+ * return its text body. Throws an Error with a user-facing message on HTTP
+ * error statuses or binary responses.
+ */
+export async function fetchSpecFromUrl(url: string): Promise<string> {
+  const res: HttpInvokeResult = await invoke('http_request', {
+    payload: {
+      method: 'GET',
+      url,
+      headers: { Accept: 'application/json, application/yaml, text/yaml, */*' },
+      body: null,
+    },
+  });
+
+  if (res.status >= 400) {
+    throw new Error(`Server returned ${res.status} ${res.status_text}`);
+  }
+
+  if (res.body_encoding === 'base64') {
+    throw new Error('URL returned binary content, not a text spec');
+  }
+
+  return res.body;
+}
 
 export async function writeImportedFiles(result: ImportResult): Promise<number> {
   const rootPath = get(workspace).rootPath!;


### PR DESCRIPTION
## Summary

Second batch of the Svelte 5 runes migration (remediation plan item 6): the ten mid-tier components in src/components/. One component per commit; pnpm check and pnpm test green after every commit.

Per component: export let -> $props() with a Props interface, createEventDispatcher -> callback props (parents updated in the same commit), on:x -> onx, $: -> $derived / $effect, event modifiers (|self, |stopPropagation) inlined, class:x -> class objects. No behavior or visual changes.

## Migrated components

- VariablePicker (onInsert/onClose; call sites in RequestEditor and FlowEditor)
- VariableInspector (onClose/onClearRuntime; call site in App.svelte)
- HelpModal (onClose; call site in App.svelte)
- ImportEnvModal (onConfirm/onSkip; call site and handler in App.svelte)
- ImportCollectionModal (onImportFile/onImportUrl/onCancel; call site and handlers in App.svelte)
- ResponseViewer (onTabChange; the locally-mutated activeTab prop became a writable $derived to preserve the legacy local-override behavior)
- DependencyBar (onRunAll; RequestEditor bridges it to its own legacy runAll dispatch)
- FlowStepPicker (onPick/onClose; call site in FlowEditor)
- FlowResults (onClearHistory; call site in FlowEditor)
- SettingsModal: already fully runes - no changes needed (like ThemeSwitcher in batch 1)

Parents (App.svelte, RequestEditor, FlowEditor) received only the minimal call-site edits; they stay in legacy mode until their own migration.

## Item 26 (folded in)

The fetchSpec network logic moved out of ImportCollectionModal into src/lib/importIO.ts as fetchSpecFromUrl(url), which the modal imports back. It throws user-facing errors on HTTP error statuses and binary responses; the modal keeps the URL-prefix validation and error display.

## Verification

- pnpm check: 0 errors, 0 warnings (after every commit)
- pnpm test: 367 passed (after every commit)
- pnpm lint: 0 errors, 67 warnings (identical to the develop baseline)
- prettier --check clean on every touched file
- grep for createEventDispatcher / export let / $: / on: / class: in the ten components: only CSS pseudo-class false positives remain

## Remaining (later PRs)

Big four (TreeNode, TreeSidebar, RequestEditor, EnvironmentEditor, FlowEditor) with items 25/26, then App.svelte.