### PR TITLE
refactor: migrate RequestEditor to Svelte 5 runes

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -291,9 +291,9 @@
     return tab?.bottomTab ?? ('body' as BottomTab);
   })();
 
-  function handleBottomTabChange(e: CustomEvent<BottomTab>) {
+  function handleBottomTabChange(tab: BottomTab) {
     if ($selectedLocation) {
-      setTabBottomTab($selectedLocation, e.detail);
+      setTabBottomTab($selectedLocation, tab);
     }
   }
 
@@ -577,9 +577,9 @@
     closeTab(location);
   }
 
-  function handleUpdateRequest(e: CustomEvent<HttpRequest>) {
+  function handleUpdateRequest(updated: HttpRequest) {
     if (!$selectedLocation) return;
-    updateRequestInTree($selectedLocation.filePath, $selectedLocation.requestIndex, e.detail);
+    updateRequestInTree($selectedLocation.filePath, $selectedLocation.requestIndex, updated);
   }
 
   function handleAddRequest(e: CustomEvent<string>) {
@@ -906,11 +906,11 @@
               envVariables={$resolvedEnvVars}
               namedResults={$namedResults}
               bottomTab={activeBottomTab}
-              on:update={handleUpdateRequest}
-              on:send={(e) => sendRequest(e.detail)}
-              on:save={saveActiveFile}
-              on:runAll={(e) => runAllRequests(e.detail, sendRequest)}
-              on:bottomTabChange={handleBottomTabChange}
+              onUpdate={handleUpdateRequest}
+              onSend={sendRequest}
+              onSave={saveActiveFile}
+              onRunAll={(deps) => runAllRequests(deps, sendRequest)}
+              onBottomTabChange={handleBottomTabChange}
             />
           </div>
           <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->

--- a/src/components/RequestEditor.svelte
+++ b/src/components/RequestEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { untrack } from 'svelte';
   import type {
     HttpRequest,
     HttpMethod,
@@ -12,39 +12,62 @@
   import DependencyBar from './DependencyBar.svelte';
   import VariablePicker from './VariablePicker.svelte';
 
-  export let request: HttpRequest;
-  export let loading: boolean = false;
-  export let resolvedUrl: string = '';
-  export let dirty: boolean = false;
-  export let fileVariables: Variable[] = [];
-  export let envVariables: Record<string, string> = {};
-  export let namedResults: Record<string, NamedRequestResult> = {};
+  type BottomTab = 'body' | 'assertions' | 'before-send' | 'after-receive';
 
-  const dispatch = createEventDispatcher();
+  interface Props {
+    request: HttpRequest;
+    loading?: boolean;
+    resolvedUrl?: string;
+    dirty?: boolean;
+    fileVariables?: Variable[];
+    envVariables?: Record<string, string>;
+    namedResults?: Record<string, NamedRequestResult>;
+    bottomTab?: BottomTab;
+    onUpdate?: (request: HttpRequest) => void;
+    onSend?: (request: HttpRequest) => void;
+    onSave?: () => void;
+    onRunAll?: (dependencies: string[]) => void;
+    onBottomTabChange?: (tab: BottomTab) => void;
+  }
+
+  let {
+    request,
+    loading = false,
+    resolvedUrl = '',
+    dirty = false,
+    fileVariables = [],
+    envVariables = {},
+    namedResults = {},
+    bottomTab = $bindable('body'),
+    onUpdate,
+    onSend,
+    onSave,
+    onRunAll,
+    onBottomTabChange,
+  }: Props = $props();
 
   function autoGrow(el: HTMLTextAreaElement) {
     el.style.height = 'auto';
     el.style.height = `${el.scrollHeight}px`;
   }
 
-  // Svelte action: keeps the name textarea sized to its content. Re-measures
-  // when the bound value changes (switching requests) and when the available
+  // Attachment: keeps the name textarea sized to its content. Re-runs when
+  // the value changes (switching requests) and re-measures when the available
   // width changes (resizing the editor pane), so wrapping grows/shrinks the row.
-  function autosize(node: HTMLTextAreaElement, _value: string) {
-    const grow = () => autoGrow(node);
-    let lastWidth = 0;
-    const ro = new ResizeObserver((entries) => {
-      const w = entries[0].contentRect.width;
-      if (w !== lastWidth) {
-        lastWidth = w;
-        grow();
-      }
-    });
-    ro.observe(node);
-    requestAnimationFrame(grow);
-    return {
-      update: grow,
-      destroy: () => ro.disconnect(),
+  function autosize(_value: string) {
+    return (node: HTMLTextAreaElement) => {
+      const grow = () => autoGrow(node);
+      let lastWidth = 0;
+      const ro = new ResizeObserver((entries) => {
+        const w = entries[0].contentRect.width;
+        if (w !== lastWidth) {
+          lastWidth = w;
+          grow();
+        }
+      });
+      ro.observe(node);
+      requestAnimationFrame(grow);
+      return () => ro.disconnect();
     };
   }
 
@@ -60,10 +83,8 @@
     'CONNECT',
   ];
 
-  export let bottomTab: 'body' | 'assertions' | 'before-send' | 'after-receive' = 'body';
-
-  let headersOpen = true;
-  let showPicker = false;
+  let headersOpen = $state(true);
+  let showPicker = $state(false);
   let pickerTarget:
     | 'url'
     | 'headerKey'
@@ -85,11 +106,11 @@
   }
 
   function update(changes: Partial<HttpRequest>) {
-    dispatch('update', { ...request, ...changes });
+    onUpdate?.({ ...request, ...changes });
   }
 
   function send() {
-    dispatch('send', request);
+    onSend?.(request);
   }
 
   function addHeader() {
@@ -150,9 +171,9 @@
     'X-Forwarded-Proto',
   ];
 
-  let headerSuggestIndex: number = -1;
-  let headerSuggestItems: string[] = [];
-  let headerSuggestSelected: number = -1;
+  let headerSuggestIndex: number = $state(-1);
+  let headerSuggestItems: string[] = $state([]);
+  let headerSuggestSelected: number = $state(-1);
 
   function onHeaderKeyFocus(index: number) {
     headerSuggestIndex = index;
@@ -209,8 +230,10 @@
   }
 
   // ── Assertion directive helpers ──
-  $: assertionDirectives = (request.directives ?? []).filter(
-    (d): d is { type: 'assert'; expr: string; label: string } => d.type === 'assert',
+  const assertionDirectives = $derived(
+    (request.directives ?? []).filter(
+      (d): d is { type: 'assert'; expr: string; label: string } => d.type === 'assert',
+    ),
   );
 
   function countScriptLines(text: string | undefined): number {
@@ -221,11 +244,8 @@
     }).length;
   }
 
-  $: beforeSendCount = countScriptLines(request.beforeSend);
-  $: afterReceiveCount = countScriptLines(request.afterReceive);
-
-  let assertionsTextInternal = '';
-  let lastRequestId = '';
+  const beforeSendCount = $derived(countScriptLines(request.beforeSend));
+  const afterReceiveCount = $derived(countScriptLines(request.afterReceive));
 
   function directivesToText(directives: PbDirective[]): string {
     return directives
@@ -234,14 +254,15 @@
       .join('\n');
   }
 
-  // Only sync from directives when switching to a different request
-  $: {
-    const id = `${request.name}::${request.method}::${request.url}`;
-    if (id !== lastRequestId) {
-      lastRequestId = id;
-      assertionsTextInternal = directivesToText(request.directives ?? []);
-    }
-  }
+  const requestId = $derived(`${request.name}::${request.method}::${request.url}`);
+
+  // Writable derived: only resyncs from directives when switching to a
+  // different request (tracked via requestId); local edits made through the
+  // assertions textarea are assigned directly and win until the next switch.
+  let assertionsTextInternal = $derived.by(() => {
+    void requestId;
+    return untrack(() => directivesToText(request.directives ?? []));
+  });
 
   function onAssertionsTextInput(e: Event) {
     const text = (e.target as HTMLTextAreaElement).value;
@@ -265,11 +286,9 @@
   }
 
   // Combine all request text for dependency scanning
-  $: requestText = [
-    request.url,
-    ...request.headers.map((h) => `${h.key}: ${h.value}`),
-    request.body,
-  ].join('\n');
+  const requestText = $derived(
+    [request.url, ...request.headers.map((h) => `${h.key}: ${h.value}`), request.body].join('\n'),
+  );
 
   function openPicker(
     target: 'url' | 'body' | 'assertions' | 'before-send' | 'after-receive' | 'headerValue',
@@ -325,24 +344,24 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="editor" on:keydown={handleKeydown}>
+<div class="editor" onkeydown={handleKeydown}>
   <!-- Request Name -->
   <div class="name-row">
     <textarea
       class="name-input"
       rows="1"
       value={request.name}
-      on:input={(e) => {
+      oninput={(e) => {
         update({ name: e.currentTarget.value });
         autoGrow(e.currentTarget);
       }}
-      on:keydown={(e) => {
+      onkeydown={(e) => {
         if (e.key === 'Enter') e.preventDefault();
       }}
       placeholder="Request name"
-      use:autosize={request.name}></textarea>
+      {@attach autosize(request.name)}></textarea>
     {#if dirty}
-      <button class="btn-save-file" on:click={() => dispatch('save')}>
+      <button class="btn-save-file" onclick={() => onSave?.()}>
         <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
           <path
             d="M12 14H4a1 1 0 01-1-1V3a1 1 0 011-1h6l3 3v8a1 1 0 01-1 1z"
@@ -363,7 +382,7 @@
         class="method-select"
         value={request.method}
         style="color: {METHOD_COLORS[request.method]}"
-        on:change={(e) => update({ method: e.currentTarget.value as HttpMethod })}
+        onchange={(e) => update({ method: e.currentTarget.value as HttpMethod })}
       >
         {#each methods as method}
           <option value={method} style="color: {METHOD_COLORS[method]}">{method}</option>
@@ -384,15 +403,15 @@
       class="url-input"
       type="text"
       value={request.url}
-      on:input={(e) => update({ url: e.currentTarget.value })}
+      oninput={(e) => update({ url: e.currentTarget.value })}
       placeholder="https://api.example.com/endpoint"
       spellcheck="false"
     />
 
     <button
       class="btn-insert-url"
-      on:mousedown|preventDefault
-      on:click={() => openPicker('url')}
+      onmousedown={(e) => e.preventDefault()}
+      onclick={() => openPicker('url')}
       title="Insert variable"
     >
       <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
@@ -405,7 +424,7 @@
       </svg>
     </button>
 
-    <button class="btn-send" on:click={send} disabled={loading} class:loading>
+    <button class={['btn-send', { loading }]} onclick={send} disabled={loading}>
       {#if loading}
         <span class="spinner"></span>
       {:else}
@@ -431,12 +450,12 @@
   {/if}
 
   <!-- Dependency bar -->
-  <DependencyBar {requestText} {namedResults} onRunAll={(deps) => dispatch('runAll', deps)} />
+  <DependencyBar {requestText} {namedResults} {onRunAll} />
 
   <!-- Headers (collapsible) -->
   <div class="section">
-    <button class="section-toggle" on:click={() => (headersOpen = !headersOpen)}>
-      <span class="chevron" class:open={headersOpen}>
+    <button class="section-toggle" onclick={() => (headersOpen = !headersOpen)}>
+      <span class={['chevron', { open: headersOpen }]}>
         <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
           <path
             d="M3 1.5l4 3.5-4 3.5"
@@ -460,17 +479,17 @@
               type="checkbox"
               class="header-toggle"
               checked={header.enabled}
-              on:change={(e) => updateHeader(i, { enabled: e.currentTarget.checked })}
+              onchange={(e) => updateHeader(i, { enabled: e.currentTarget.checked })}
             />
             <div class="header-key-wrapper">
               <input
                 class="header-key"
                 type="text"
                 value={header.key}
-                on:input={(e) => onHeaderKeyInput(i, e.currentTarget.value)}
-                on:focus={() => onHeaderKeyFocus(i)}
-                on:blur={onHeaderKeyBlur}
-                on:keydown={(e) => onHeaderKeyKeydown(e, i)}
+                oninput={(e) => onHeaderKeyInput(i, e.currentTarget.value)}
+                onfocus={() => onHeaderKeyFocus(i)}
+                onblur={onHeaderKeyBlur}
+                onkeydown={(e) => onHeaderKeyKeydown(e, i)}
                 placeholder="Header name"
                 spellcheck="false"
                 autocomplete="off"
@@ -479,9 +498,11 @@
                 <div class="header-suggest">
                   {#each headerSuggestItems as item, si}
                     <button
-                      class="suggest-item"
-                      class:selected={si === headerSuggestSelected}
-                      on:mousedown|preventDefault={() => selectSuggestion(i, item)}>{item}</button
+                      class={['suggest-item', { selected: si === headerSuggestSelected }]}
+                      onmousedown={(e) => {
+                        e.preventDefault();
+                        selectSuggestion(i, item);
+                      }}>{item}</button
                     >
                   {/each}
                 </div>
@@ -491,14 +512,14 @@
               class="header-value"
               type="text"
               value={header.value}
-              on:input={(e) => updateHeader(i, { value: e.currentTarget.value })}
+              oninput={(e) => updateHeader(i, { value: e.currentTarget.value })}
               placeholder="Value"
               spellcheck="false"
             />
             <button
               class="btn-insert"
-              on:mousedown|preventDefault
-              on:click={() => openPicker('headerValue', i)}
+              onmousedown={(e) => e.preventDefault()}
+              onclick={() => openPicker('headerValue', i)}
               title="Insert variable"
             >
               <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
@@ -510,10 +531,10 @@
                 />
               </svg>
             </button>
-            <button class="btn-remove" on:click={() => removeHeader(i)}>×</button>
+            <button class="btn-remove" onclick={() => removeHeader(i)}>×</button>
           </div>
         {/each}
-        <button class="btn-add-header" on:click={addHeader}>+ Add Header</button>
+        <button class="btn-add-header" onclick={addHeader}>+ Add Header</button>
       </div>
     {/if}
   </div>
@@ -522,21 +543,19 @@
   <div class="bottom-panel">
     <div class="bottom-tabs">
       <button
-        class="bottom-tab"
-        class:active={bottomTab === 'body'}
-        on:click={() => {
+        class={['bottom-tab', { active: bottomTab === 'body' }]}
+        onclick={() => {
           bottomTab = 'body';
-          dispatch('bottomTabChange', bottomTab);
+          onBottomTabChange?.(bottomTab);
         }}
       >
         Body
       </button>
       <button
-        class="bottom-tab"
-        class:active={bottomTab === 'assertions'}
-        on:click={() => {
+        class={['bottom-tab', { active: bottomTab === 'assertions' }]}
+        onclick={() => {
           bottomTab = 'assertions';
-          dispatch('bottomTabChange', bottomTab);
+          onBottomTabChange?.(bottomTab);
         }}
       >
         Assertions
@@ -545,11 +564,10 @@
         {/if}
       </button>
       <button
-        class="bottom-tab"
-        class:active={bottomTab === 'before-send'}
-        on:click={() => {
+        class={['bottom-tab', { active: bottomTab === 'before-send' }]}
+        onclick={() => {
           bottomTab = 'before-send';
-          dispatch('bottomTabChange', bottomTab);
+          onBottomTabChange?.(bottomTab);
         }}
       >
         Before Send
@@ -558,11 +576,10 @@
         {/if}
       </button>
       <button
-        class="bottom-tab"
-        class:active={bottomTab === 'after-receive'}
-        on:click={() => {
+        class={['bottom-tab', { active: bottomTab === 'after-receive' }]}
+        onclick={() => {
           bottomTab = 'after-receive';
-          dispatch('bottomTabChange', bottomTab);
+          onBottomTabChange?.(bottomTab);
         }}
       >
         After Receive
@@ -573,8 +590,8 @@
       <div class="bottom-tab-actions">
         <button
           class="btn-insert"
-          on:mousedown|preventDefault
-          on:click={() => openPicker(bottomTab)}
+          onmousedown={(e) => e.preventDefault()}
+          onclick={() => openPicker(bottomTab)}
           title="Insert variable"
         >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
@@ -593,28 +610,28 @@
         <textarea
           class="body-editor"
           value={request.body}
-          on:input={(e) => update({ body: e.currentTarget.value })}
+          oninput={(e) => update({ body: e.currentTarget.value })}
           placeholder={'{"key": "value"}'}
           spellcheck="false"></textarea>
       {:else if bottomTab === 'assertions'}
         <textarea
           class="body-editor"
           value={assertionsTextInternal}
-          on:input={onAssertionsTextInput}
+          oninput={onAssertionsTextInput}
           placeholder={'# One assertion per line:\n# pb.response.status == 200 | Should return 200\n# pb.response.body.$.name != null | Name should exist'}
           spellcheck="false"></textarea>
       {:else if bottomTab === 'before-send'}
         <textarea
           class="body-editor"
           value={request.beforeSend ?? ''}
-          on:input={(e) => update({ beforeSend: e.currentTarget.value })}
+          oninput={(e) => update({ beforeSend: e.currentTarget.value })}
           placeholder={'# Scripts to run before sending the request\npb.set(pb.request.header.X-Custom, "value")\npb.set(pb.request.body.$.field, "value")'}
           spellcheck="false"></textarea>
       {:else if bottomTab === 'after-receive'}
         <textarea
           class="body-editor"
           value={request.afterReceive ?? ''}
-          on:input={(e) => update({ afterReceive: e.currentTarget.value })}
+          oninput={(e) => update({ afterReceive: e.currentTarget.value })}
           placeholder={'# Scripts to run after receiving the response\npb.set("token", pb.response.body.$.token)\npb.global("sessionId", pb.response.body.$.id)'}
           spellcheck="false"></textarea>
       {/if}


### PR DESCRIPTION
Part of the review remediation plan, phase 4 (item 6), big-component batch. Migrates `src/components/RequestEditor.svelte` to runes and updates its wiring in App.svelte. No behavior change intended.

## Component changes

- `export let` -> `$props()` with a `Props` interface.
- `bottomTab` is `$bindable('body')`: the component switches tabs locally (App only persists the choice for pinned tabs), so the prop must stay locally mutable - matching the legacy prop-mutation semantics without App using `bind:`.
- `createEventDispatcher` -> callback props: `onUpdate`, `onSend`, `onSave`, `onRunAll`, `onBottomTabChange`. The old `onRunAll={(deps) => dispatch('runAll', deps)}` bridge to the runes DependencyBar collapses into passing `{onRunAll}` straight through.
- `$:` classification:
  - `assertionDirectives`, `beforeSendCount`, `afterReceiveCount`, `requestText`: pure computations -> `$derived`.
  - The "only sync assertions text when switching requests" block (previously a `$:` block with side effects and a `lastRequestId` guard) becomes a writable `$derived.by` keyed on a `requestId` derived, with `untrack` around the directives read. Local textarea edits assign into the derived and win until the request identity changes; directive updates caused by those same edits do not clobber the user's in-progress text. This keeps the pre-render timing of the legacy reactive statement (no post-render flicker an `$effect` would introduce).
- `on:x` -> `onx`; `|preventDefault` modifiers -> explicit `e.preventDefault()` in handlers.
- `class:loading` / `class:open` / `class:active` / `class:selected` -> clsx-style class arrays.
- The `autosize` action (`use:autosize={request.name}`) -> an `{@attach autosize(request.name)}` factory. It re-runs on name change (recreating the ResizeObserver) instead of the action's lighter `update` path; growth on typing is still handled synchronously by the `oninput` handler, so behavior is unchanged.
- Non-reactive scratch vars (`pickerTarget`, `pickerHeaderIndex`, `cursorPosition`) stay plain `let`; template-read state (`headersOpen`, `showPicker`, header-suggest vars) becomes `$state`.

## App.svelte changes (RequestEditor wiring only)

- `on:update/send/save/runAll/bottomTabChange` -> callback props.
- `handleUpdateRequest` and `handleBottomTabChange` take plain values instead of `CustomEvent` (both exist solely for RequestEditor).
- No other component call sites touched; legacy-mode pin untouched (three sibling PRs migrate TreeSidebar/TreeNode, EnvironmentEditor, FlowEditor concurrently).

## Verification

- `pnpm check`: 0 errors, 0 warnings
- `pnpm test`: 367 passed
- `pnpm lint`: 0 errors (pre-existing warnings only)
- `prettier --check` clean on both touched files (modulo the known local CRLF artifact, verified with `--end-of-line auto`)
- Grep: no `createEventDispatcher`, `export let`, `$:`, `on:`, `class:`, or `use:` left in RequestEditor.svelte
- Manual smoke test (send request, edit assertions, tab switching) still recommended before merge