### PR TITLE
refactor: migrate TreeNode and TreeSidebar to Svelte 5 runes (item 6 + item 26)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -38,11 +38,8 @@
     keyVaultState,
     varSourcePrefs,
     updateRequestInTree,
-    addRequestToFile,
-    deleteRequestFromFile,
     editingFilePath,
     editingFolderPath,
-    toggleFolder,
     markFileSaved,
     addToast,
     tabs,
@@ -55,12 +52,10 @@
     currentSentRequest,
     setTabBottomTab,
     setTabResponseTab,
-    flows,
     flowRunHistory,
     flowRunState,
     flowTabs,
     activeFlowTabPath,
-    openFlowTab,
     closeFlowTab,
     activateFlowTab,
     activeFlowPath,
@@ -81,18 +76,8 @@
   import { saveFlowRunRecord, clearFlowRunHistory } from './lib/flowIO';
   import { openFolderByPath } from './lib/workspaceIO';
   import { importCollectionContent, applyImportedVariables } from './lib/importIO';
-  import { createFlow, duplicateFlow, saveFlow, deleteFlow } from './lib/flowOps';
-  import { runAllRequests, nameRequest } from './lib/requestOps';
-  import {
-    createFile,
-    createFolder,
-    renameFile,
-    renameFolder,
-    duplicateFile,
-    deleteFile,
-    deleteFolder,
-    cancelRename,
-  } from './lib/fileOps';
+  import { saveFlow, deleteFlow } from './lib/flowOps';
+  import { runAllRequests } from './lib/requestOps';
   import { runFlow } from './lib/flowRunner';
   import { executeHttpRequest } from './lib/requestExec';
   import { startMcpBridge } from './lib/mcpBridge';
@@ -401,13 +386,6 @@
     });
   }
 
-  /**
-   * Name shown for the open folder: the favorite's custom name when the open
-   * folder is favorited, otherwise the folder basename.
-   */
-  $: rootDisplayName =
-    $favorites.find((f) => f.path === $workspace.rootPath)?.name ?? $workspace.rootName;
-
   /** Open a favorited folder, surfacing an error toast if it can no longer be read. */
   async function openFavorite(path: string) {
     try {
@@ -533,7 +511,7 @@
 
   // ─── Event Handlers ───
 
-  function handleSelect(e: CustomEvent<RequestLocation>) {
+  function handleSelect(loc: RequestLocation) {
     if (showEnvEditor) {
       if ($envFile) saveEnvFile($envFile);
       showEnvEditor = false;
@@ -541,7 +519,6 @@
     // Deactivate any flow tab when selecting a request
     activeFlowTabPath.set(null);
     activeFlowPath.set(null);
-    const loc = e.detail;
     const hasTab = $tabs.some(
       (t) => t.location.filePath === loc.filePath && t.location.requestIndex === loc.requestIndex,
     );
@@ -552,14 +529,12 @@
     }
   }
 
-  function handlePinRequest(
-    e: CustomEvent<{ filePath: string; requestIndex: number; label: string }>,
-  ) {
+  function handlePinRequest(detail: { filePath: string; requestIndex: number; label: string }) {
     if (showEnvEditor) {
       if ($envFile) saveEnvFile($envFile);
       showEnvEditor = false;
     }
-    pinTab({ filePath: e.detail.filePath, requestIndex: e.detail.requestIndex }, e.detail.label);
+    pinTab({ filePath: detail.filePath, requestIndex: detail.requestIndex }, detail.label);
   }
 
   function handleTabActivate(location: RequestLocation) {
@@ -582,26 +557,7 @@
     updateRequestInTree($selectedLocation.filePath, $selectedLocation.requestIndex, e.detail);
   }
 
-  function handleAddRequest(e: CustomEvent<string>) {
-    addRequestToFile(e.detail);
-  }
-
-  function handleDeleteRequest(e: CustomEvent<{ filePath: string; requestIndex: number }>) {
-    deleteRequestFromFile(e.detail.filePath, e.detail.requestIndex);
-  }
-
-  function handleToggleFolder(e: CustomEvent<string>) {
-    toggleFolder(e.detail);
-  }
-
   // ─── Flow Handlers ───
-
-  function handleOpenFlow(e: CustomEvent<string>) {
-    const path = e.detail;
-    const flow = $flows[path];
-    if (!flow) return;
-    openFlowTab(path, flow.name);
-  }
 
   let flowAbortController: AbortController | null = null;
   let lastFlowRunRecords: Record<string, FlowRunRecord> = {};
@@ -701,9 +657,9 @@
     flowAbortController?.abort();
   }
 
-  async function handleDeleteFlow(e: CustomEvent<string>) {
-    delete flowUIState[e.detail];
-    await deleteFlow(e.detail);
+  async function handleDeleteFlow(path: string) {
+    delete flowUIState[path];
+    await deleteFlow(path);
   }
 </script>
 
@@ -784,48 +740,22 @@
   <div class="layout" bind:this={layoutEl} class:sidebar-dragging={sidebarDragging}>
     <div class="sidebar-container" style="width: {sidebarWidth}px; min-width: {sidebarWidth}px">
       <TreeSidebar
-        tree={$workspace.tree}
         selected={$selectedLocation}
-        rootName={rootDisplayName}
-        hasWorkspace={!!$workspace.rootPath}
-        rootPath={$workspace.rootPath}
-        favorites={$favorites}
         editingFilePath={$editingFilePath}
         editingFolderPath={$editingFolderPath}
-        environments={$availableEnvironments}
-        activeEnv={$activeEnvironment}
-        flows={$flows}
-        activeFlowPath={$activeFlowTabPath}
-        on:openFolder={openFolder}
-        on:openGettingStarted={openGettingStarted}
-        on:toggleFavorite={toggleFavorite}
-        on:openFavorite={(e) => openFavorite(e.detail)}
-        on:removeFavorite={(e) => removeFavorite(e.detail)}
-        on:importCollection={() => (showImportCollectionModal = true)}
-        on:select={handleSelect}
-        on:pinRequest={handlePinRequest}
-        on:toggleFolder={handleToggleFolder}
-        on:addRequest={handleAddRequest}
-        on:deleteRequest={handleDeleteRequest}
-        on:deleteFile={(e) => deleteFile(e.detail)}
-        on:deleteFolder={(e) => deleteFolder(e.detail)}
-        on:createFile={(e) => createFile(e.detail)}
-        on:createFolder={(e) => createFolder(e.detail)}
-        on:renameFile={(e) => renameFile(e.detail.oldPath, e.detail.newName)}
-        on:renameFolder={(e) => renameFolder(e.detail.oldPath, e.detail.newName)}
-        on:duplicateFile={(e) => duplicateFile(e.detail)}
-        on:cancelRename={cancelRename}
-        on:changeEnv={(e) => activeEnvironment.set(e.detail)}
-        on:editEnv={() => (showEnvEditor = true)}
-        on:openVarInspector={() => (showVarInspector = true)}
-        on:openHelp={() => (showHelp = true)}
-        on:openSettings={() => (showSettings = true)}
-        on:nameRequest={(e) =>
-          nameRequest(e.detail.filePath, e.detail.requestIndex, e.detail.varName)}
-        on:openFlow={handleOpenFlow}
-        on:createFlow={(e) => createFlow(e.detail)}
-        on:duplicateFlow={(e) => duplicateFlow(e.detail)}
-        on:deleteFlow={handleDeleteFlow}
+        onOpenFolder={openFolder}
+        onOpenGettingStarted={openGettingStarted}
+        onToggleFavorite={toggleFavorite}
+        onOpenFavorite={openFavorite}
+        onRemoveFavorite={removeFavorite}
+        onImportCollection={() => (showImportCollectionModal = true)}
+        onSelect={handleSelect}
+        onPinRequest={handlePinRequest}
+        onEditEnv={() => (showEnvEditor = true)}
+        onOpenVarInspector={() => (showVarInspector = true)}
+        onOpenHelp={() => (showHelp = true)}
+        onOpenSettings={() => (showSettings = true)}
+        onDeleteFlow={handleDeleteFlow}
       />
     </div>
     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->

--- a/src/components/TreeNode.svelte
+++ b/src/components/TreeNode.svelte
@@ -1,30 +1,73 @@
 <script lang="ts">
-  import { createEventDispatcher, tick } from 'svelte';
+  import { tick } from 'svelte';
+  import Self from './TreeNode.svelte';
   import type { TreeNode as TNode, RequestLocation } from '../lib/types';
   import { METHOD_COLORS } from '../lib/theme';
 
-  export let node: TNode;
-  export let selected: RequestLocation | null = null;
-  export let depth: number = 0;
-  export let displayMode: 'name' | 'url' = 'name';
-  export let sortByUrl: boolean = false;
-  export let usedNames: string[] = [];
-  export let forceExpand: boolean = false;
-  /** When set and matches this node's path, auto-enter inline rename mode */
-  export let editingFilePath: string | null = null;
-  /** When set and matches this folder's path, auto-enter inline folder rename mode */
-  export let editingFolderPath: string | null = null;
-  /** Sibling file names in the same folder (for collision detection) */
-  export let siblingNames: string[] = [];
-  /** Sibling folder/file names in the same folder (for folder rename collision detection) */
-  export let siblingFolderNames: string[] = [];
+  interface Props {
+    node: TNode;
+    selected?: RequestLocation | null;
+    depth?: number;
+    displayMode?: 'name' | 'url';
+    sortByUrl?: boolean;
+    usedNames?: string[];
+    forceExpand?: boolean;
+    /** When set and matches this node's path, auto-enter inline rename mode */
+    editingFilePath?: string | null;
+    /** When set and matches this folder's path, auto-enter inline folder rename mode */
+    editingFolderPath?: string | null;
+    /** Sibling file names in the same folder (for collision detection) */
+    siblingNames?: string[];
+    /** Sibling folder/file names in the same folder (for folder rename collision detection) */
+    siblingFolderNames?: string[];
+    onToggleFolder?: (folderPath: string) => void;
+    onSelect?: (location: RequestLocation) => void;
+    onPinRequest?: (detail: { filePath: string; requestIndex: number; label: string }) => void;
+    onAddRequest?: (filePath: string) => void;
+    onDeleteRequest?: (detail: { filePath: string; requestIndex: number }) => void;
+    onDeleteFile?: (filePath: string) => void;
+    onDeleteFolder?: (folderPath: string) => void;
+    onNameRequest?: (detail: { filePath: string; requestIndex: number; varName: string }) => void;
+    onRenameFile?: (detail: { oldPath: string; newName: string }) => void;
+    onRenameFolder?: (detail: { oldPath: string; newName: string }) => void;
+    onDuplicateFile?: (filePath: string) => void;
+    onCreateFile?: (parentPath: string) => void;
+    onCreateFolder?: (parentPath: string) => void;
+    onCancelRename?: () => void;
+  }
 
-  const dispatch = createEventDispatcher();
+  let {
+    node,
+    selected = null,
+    depth = 0,
+    displayMode = 'name',
+    sortByUrl = false,
+    usedNames = [],
+    forceExpand = false,
+    editingFilePath = null,
+    editingFolderPath = null,
+    siblingNames = [],
+    siblingFolderNames = [],
+    onToggleFolder,
+    onSelect,
+    onPinRequest,
+    onAddRequest,
+    onDeleteRequest,
+    onDeleteFile,
+    onDeleteFolder,
+    onNameRequest,
+    onRenameFile,
+    onRenameFolder,
+    onDuplicateFile,
+    onCreateFile,
+    onCreateFolder,
+    onCancelRename,
+  }: Props = $props();
 
   const INVALID_FS_CHARS = /[/\\:*?"<>|]/;
 
-  let fileExpanded = false;
-  let namingIndex: number = -1;
+  let fileExpanded = $state(false);
+  let namingIndex = $state(-1);
 
   /** Compute unique URL suffixes for requests in a file node */
   function computeUrlSuffixes(requests: { url: string }[]): string[] {
@@ -44,47 +87,52 @@
     });
   }
 
-  $: urlSuffixes = node.type === 'file' ? computeUrlSuffixes(node.requests) : [];
-  $: sortedIndices =
+  const urlSuffixes = $derived(node.type === 'file' ? computeUrlSuffixes(node.requests) : []);
+  const sortedIndices = $derived(
     node.type === 'file'
       ? sortByUrl
         ? [...Array(node.requests.length).keys()].sort((a, b) =>
             node.requests[a].url.localeCompare(node.requests[b].url),
           )
         : [...Array(node.requests.length).keys()]
-      : [];
-  let namingValue: string = '';
-  let confirmDeleteIndex: number = -1;
-  let showFileMenu = false;
-  let fileMenuPos = { x: 0, y: 0 };
-  let confirmDeleteFile = false;
-  let confirmDeleteFolder = false;
+      : [],
+  );
+  let namingValue = $state('');
+  let confirmDeleteIndex = $state(-1);
+  let showFileMenu = $state(false);
+  let fileMenuPos = $state({ x: 0, y: 0 });
+  let confirmDeleteFile = $state(false);
+  let confirmDeleteFolder = $state(false);
 
   // Inline file rename state
-  let renamingFile = false;
-  let renamingValue = '';
-  let renameInputEl: HTMLInputElement;
+  let renamingFile = $state(false);
+  let renamingValue = $state('');
+  let renameInputEl: HTMLInputElement | null = $state(null);
   let cancelledRename = false;
 
   // Folder context menu state
-  let showFolderMenu = false;
-  let folderMenuPos = { x: 0, y: 0 };
+  let showFolderMenu = $state(false);
+  let folderMenuPos = $state({ x: 0, y: 0 });
 
   // Inline folder rename state
-  let renamingFolder = false;
-  let renamingFolderValue = '';
-  let folderRenameInputEl: HTMLInputElement;
+  let renamingFolder = $state(false);
+  let renamingFolderValue = $state('');
+  let folderRenameInputEl: HTMLInputElement | null = $state(null);
   let cancelledFolderRename = false;
 
   // Auto-enter rename mode when editingFilePath matches this node
-  $: if (node.type === 'file' && editingFilePath === node.path && !renamingFile) {
-    enterFileRename();
-  }
+  $effect(() => {
+    if (node.type === 'file' && editingFilePath === node.path && !renamingFile) {
+      enterFileRename();
+    }
+  });
 
   // Auto-enter folder rename mode when editingFolderPath matches this folder
-  $: if (node.type === 'folder' && editingFolderPath === node.path && !renamingFolder) {
-    enterFolderRename();
-  }
+  $effect(() => {
+    if (node.type === 'folder' && editingFolderPath === node.path && !renamingFolder) {
+      enterFolderRename();
+    }
+  });
 
   function enterFileRename() {
     cancelledRename = false;
@@ -96,7 +144,7 @@
     });
   }
 
-  $: fileRenameError = (() => {
+  const fileRenameError = $derived.by(() => {
     if (!renamingFile) return '';
     const v = renamingValue.trim();
     if (!v) return 'Name required';
@@ -105,7 +153,7 @@
     if (node.type === 'file' && fullName !== node.name && siblingNames.includes(fullName))
       return 'Name in use';
     return '';
-  })();
+  });
 
   function confirmFileRename() {
     if (!renamingFile) return;
@@ -120,17 +168,17 @@
     if (node.type === 'file') {
       const currentStem = node.name.replace(/\.(http|rest)$/, '');
       if (newName !== currentStem) {
-        dispatch('renameFile', { oldPath: node.path, newName: newName + '.http' });
+        onRenameFile?.({ oldPath: node.path, newName: newName + '.http' });
       }
     }
-    dispatch('cancelRename');
+    onCancelRename?.();
   }
 
   function cancelFileRename() {
     cancelledRename = true;
     renamingFile = false;
     renamingValue = '';
-    dispatch('cancelRename');
+    onCancelRename?.();
   }
 
   function enterFolderRename() {
@@ -143,7 +191,7 @@
     });
   }
 
-  $: folderRenameError = (() => {
+  const folderRenameError = $derived.by(() => {
     if (!renamingFolder) return '';
     const v = renamingFolderValue.trim();
     if (!v) return 'Name required';
@@ -151,7 +199,7 @@
     if (node.type === 'folder' && v !== node.name && siblingFolderNames.includes(v))
       return 'Name in use';
     return '';
-  })();
+  });
 
   function confirmFolderRename() {
     if (!renamingFolder) return;
@@ -164,16 +212,16 @@
     renamingFolder = false;
     renamingFolderValue = '';
     if (node.type === 'folder' && newName !== node.name) {
-      dispatch('renameFolder', { oldPath: node.path, newName });
+      onRenameFolder?.({ oldPath: node.path, newName });
     }
-    dispatch('cancelRename');
+    onCancelRename?.();
   }
 
   function cancelFolderRename() {
     cancelledFolderRename = true;
     renamingFolder = false;
     renamingFolderValue = '';
-    dispatch('cancelRename');
+    onCancelRename?.();
   }
 
   function handleFileContextMenu(e: MouseEvent) {
@@ -215,13 +263,13 @@
     });
   }
 
-  $: isDuplicate = (() => {
+  const isDuplicate = $derived.by(() => {
     const v = namingValue.trim();
     if (!v || namingIndex < 0) return false;
     const currentVarName = node.type === 'file' ? node.requests[namingIndex]?.varName : null;
     if (v === currentVarName) return false;
     return usedNames.includes(v);
-  })();
+  });
 
   function isSel(fp: string, ri: number): boolean {
     return selected?.filePath === fp && selected?.requestIndex === ri;
@@ -234,15 +282,17 @@
 
   function confirmNaming(filePath: string) {
     if (isDuplicate) return;
-    dispatch('nameRequest', { filePath, requestIndex: namingIndex, varName: namingValue.trim() });
+    onNameRequest?.({ filePath, requestIndex: namingIndex, varName: namingValue.trim() });
     namingIndex = -1;
     namingValue = '';
   }
 
   // Keep file expanded when it contains the selection
-  $: if (node.type === 'file' && selected?.filePath === node.path) {
-    fileExpanded = true;
-  }
+  $effect(() => {
+    if (node.type === 'file' && selected?.filePath === node.path) {
+      fileExpanded = true;
+    }
+  });
 
   /** Compute sibling file names for child nodes in a folder */
   function childSiblingNames(children: TNode[]): string[] {
@@ -276,14 +326,13 @@
       <!-- svelte-ignore a11y_autofocus -->
       <input
         bind:this={folderRenameInputEl}
-        class="file-rename-input"
-        class:naming-error={!!folderRenameError}
+        class={['file-rename-input', { 'naming-error': !!folderRenameError }]}
         bind:value={renamingFolderValue}
-        on:keydown={(e) => {
+        onkeydown={(e) => {
           if (e.key === 'Enter') confirmFolderRename();
           if (e.key === 'Escape') cancelFolderRename();
         }}
-        on:blur={confirmFolderRename}
+        onblur={confirmFolderRename}
         spellcheck="false"
         autofocus
       />
@@ -295,10 +344,10 @@
     <button
       class="tree-row folder-row"
       style="padding-left: {12 + depth * 16}px"
-      on:click={() => dispatch('toggleFolder', node.path)}
-      on:contextmenu={handleFolderContextMenu}
+      onclick={() => onToggleFolder?.(node.path)}
+      oncontextmenu={handleFolderContextMenu}
     >
-      <span class="chevron" class:open={node.expanded}>
+      <span class={['chevron', { open: node.expanded }]}>
         <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
           <path
             d="M3 1.5l4 3.5-4 3.5"
@@ -326,22 +375,24 @@
     <div
       class="file-context-menu folder-context-menu"
       style="left: {folderMenuPos.x}px; top: {folderMenuPos.y}px"
-      on:click|stopPropagation
-      on:keydown|stopPropagation
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
     >
       {#if confirmDeleteFolder}
         <span class="confirm-delete-text">Has items, delete anyway?</span>
         <button
           class="confirm-delete-yes"
-          on:click|stopPropagation={() => {
-            dispatch('deleteFolder', node.path);
+          onclick={(e) => {
+            e.stopPropagation();
+            onDeleteFolder?.(node.path);
             showFolderMenu = false;
             confirmDeleteFolder = false;
           }}>Yes</button
         >
         <button
           class="confirm-delete-no"
-          on:click|stopPropagation={() => {
+          onclick={(e) => {
+            e.stopPropagation();
             showFolderMenu = false;
             confirmDeleteFolder = false;
           }}>No</button
@@ -349,31 +400,35 @@
       {:else}
         <button
           class="file-context-item"
-          on:click|stopPropagation={() => {
-            dispatch('createFile', node.path);
+          onclick={(e) => {
+            e.stopPropagation();
+            onCreateFile?.(node.path);
             showFolderMenu = false;
           }}>New .http file</button
         >
         <button
           class="file-context-item"
-          on:click|stopPropagation={() => {
-            dispatch('createFolder', node.path);
+          onclick={(e) => {
+            e.stopPropagation();
+            onCreateFolder?.(node.path);
             showFolderMenu = false;
           }}>New subfolder</button
         >
         <div class="context-menu-divider"></div>
         <button
           class="file-context-item"
-          on:click|stopPropagation={() => {
+          onclick={(e) => {
+            e.stopPropagation();
             showFolderMenu = false;
             enterFolderRename();
           }}>Rename</button
         >
         <button
           class="file-context-item file-context-delete"
-          on:click|stopPropagation={() => {
+          onclick={(e) => {
+            e.stopPropagation();
             if (node.type === 'folder' && node.children.length === 0) {
-              dispatch('deleteFolder', node.path);
+              onDeleteFolder?.(node.path);
               showFolderMenu = false;
             } else {
               confirmDeleteFolder = true;
@@ -387,7 +442,7 @@
   {#if node.expanded}
     <div class="children">
       {#each node.children as child}
-        <svelte:self
+        <Self
           node={child}
           {selected}
           depth={depth + 1}
@@ -399,20 +454,20 @@
           {editingFolderPath}
           siblingNames={childSiblingNames(node.children)}
           siblingFolderNames={node.children.map((c) => c.name)}
-          on:toggleFolder
-          on:select
-          on:pinRequest
-          on:addRequest
-          on:deleteRequest
-          on:deleteFile
-          on:nameRequest
-          on:renameFile
-          on:renameFolder
-          on:duplicateFile
-          on:createFile
-          on:createFolder
-          on:deleteFolder
-          on:cancelRename
+          {onToggleFolder}
+          {onSelect}
+          {onPinRequest}
+          {onAddRequest}
+          {onDeleteRequest}
+          {onDeleteFile}
+          {onDeleteFolder}
+          {onNameRequest}
+          {onRenameFile}
+          {onRenameFolder}
+          {onDuplicateFile}
+          {onCreateFile}
+          {onCreateFolder}
+          {onCancelRename}
         />
       {/each}
     </div>
@@ -444,14 +499,13 @@
       <!-- svelte-ignore a11y_autofocus -->
       <input
         bind:this={renameInputEl}
-        class="file-rename-input"
-        class:naming-error={!!fileRenameError}
+        class={['file-rename-input', { 'naming-error': !!fileRenameError }]}
         bind:value={renamingValue}
-        on:keydown={(e) => {
+        onkeydown={(e) => {
           if (e.key === 'Enter') confirmFileRename();
           if (e.key === 'Escape') cancelFileRename();
         }}
-        on:blur={confirmFileRename}
+        onblur={confirmFileRename}
         spellcheck="false"
         autofocus
       />
@@ -462,21 +516,20 @@
     </div>
   {:else}
     <div
-      class="tree-row file-row"
-      class:dirty={node.dirty}
+      class={['tree-row', 'file-row', { dirty: node.dirty }]}
       style="padding-left: {12 + depth * 16}px"
-      on:click={() => (fileExpanded = !fileExpanded)}
-      on:keydown={(e) => {
+      onclick={() => (fileExpanded = !fileExpanded)}
+      onkeydown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           fileExpanded = !fileExpanded;
         }
       }}
-      on:contextmenu={handleFileContextMenu}
+      oncontextmenu={handleFileContextMenu}
       role="button"
       tabindex="0"
     >
-      <span class="chevron" class:open={fileExpanded}>
+      <span class={['chevron', { open: fileExpanded }]}>
         <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
           <path
             d="M3 1.5l4 3.5-4 3.5"
@@ -502,7 +555,10 @@
       {/if}
       <button
         class="btn-add-req"
-        on:click|stopPropagation={() => dispatch('addRequest', node.path)}
+        onclick={(e) => {
+          e.stopPropagation();
+          onAddRequest?.(node.path);
+        }}
         title="Add request">+</button
       >
       <span class="req-count">{node.requests.length}</span>
@@ -514,22 +570,24 @@
     <div
       class="file-context-menu"
       style="left: {fileMenuPos.x}px; top: {fileMenuPos.y}px"
-      on:click|stopPropagation
-      on:keydown|stopPropagation
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
     >
       {#if confirmDeleteFile}
         <span class="confirm-delete-text">Delete file?</span>
         <button
           class="confirm-delete-yes"
-          on:click|stopPropagation={() => {
-            dispatch('deleteFile', node.path);
+          onclick={(e) => {
+            e.stopPropagation();
+            onDeleteFile?.(node.path);
             showFileMenu = false;
             confirmDeleteFile = false;
           }}>Yes</button
         >
         <button
           class="confirm-delete-no"
-          on:click|stopPropagation={() => {
+          onclick={(e) => {
+            e.stopPropagation();
             showFileMenu = false;
             confirmDeleteFile = false;
           }}>No</button
@@ -537,22 +595,27 @@
       {:else}
         <button
           class="file-context-item"
-          on:click|stopPropagation={() => {
+          onclick={(e) => {
+            e.stopPropagation();
             showFileMenu = false;
             enterFileRename();
           }}>Rename</button
         >
         <button
           class="file-context-item"
-          on:click|stopPropagation={() => {
-            dispatch('duplicateFile', node.path);
+          onclick={(e) => {
+            e.stopPropagation();
+            onDuplicateFile?.(node.path);
             showFileMenu = false;
           }}>Duplicate</button
         >
         <div class="context-menu-divider"></div>
         <button
           class="file-context-item file-context-delete"
-          on:click|stopPropagation={() => (confirmDeleteFile = true)}>Delete file</button
+          onclick={(e) => {
+            e.stopPropagation();
+            confirmDeleteFile = true;
+          }}>Delete file</button
         >
       {/if}
     </div>
@@ -567,16 +630,15 @@
             <span class="naming-label">@name</span>
             <!-- svelte-ignore a11y_autofocus -->
             <input
-              class="naming-input"
-              class:naming-error={isDuplicate}
+              class={['naming-input', { 'naming-error': isDuplicate }]}
               bind:value={namingValue}
-              on:keydown={(e) => {
+              onkeydown={(e) => {
                 if (e.key === 'Enter') confirmNaming(node.path);
                 if (e.key === 'Escape') {
                   namingIndex = -1;
                 }
               }}
-              on:blur={() => confirmNaming(node.path)}
+              onblur={() => confirmNaming(node.path)}
               placeholder="responseAlias"
               spellcheck="false"
               autofocus
@@ -587,17 +649,19 @@
           </div>
         {:else}
           <div
-            class="tree-row request-row"
-            class:active={isSel(node.path, i)}
+            class={['tree-row', 'request-row', { active: isSel(node.path, i) }]}
             style="padding-left: {28 + depth * 16}px"
-            on:click={() => dispatch('select', { filePath: node.path, requestIndex: i })}
-            on:dblclick={() =>
-              dispatch('pinRequest', { filePath: node.path, requestIndex: i, label: req.name })}
-            on:contextmenu|preventDefault={() => startNaming(i, req.varName)}
-            on:keydown={(e) => {
+            onclick={() => onSelect?.({ filePath: node.path, requestIndex: i })}
+            ondblclick={() =>
+              onPinRequest?.({ filePath: node.path, requestIndex: i, label: req.name })}
+            oncontextmenu={(e) => {
+              e.preventDefault();
+              startNaming(i, req.varName);
+            }}
+            onkeydown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
-                dispatch('select', { filePath: node.path, requestIndex: i });
+                onSelect?.({ filePath: node.path, requestIndex: i });
               }
             }}
             role="button"
@@ -617,27 +681,34 @@
                 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                 <div
                   class="confirm-delete-popup"
-                  on:click|stopPropagation
-                  on:keydown|stopPropagation
+                  onclick={(e) => e.stopPropagation()}
+                  onkeydown={(e) => e.stopPropagation()}
                   role="alert"
                 >
                   <span class="confirm-delete-text">Delete?</span>
                   <button
                     class="confirm-delete-yes"
-                    on:click|stopPropagation={() => {
-                      dispatch('deleteRequest', { filePath: node.path, requestIndex: i });
+                    onclick={(e) => {
+                      e.stopPropagation();
+                      onDeleteRequest?.({ filePath: node.path, requestIndex: i });
                       confirmDeleteIndex = -1;
                     }}>Yes</button
                   >
                   <button
                     class="confirm-delete-no"
-                    on:click|stopPropagation={() => (confirmDeleteIndex = -1)}>No</button
+                    onclick={(e) => {
+                      e.stopPropagation();
+                      confirmDeleteIndex = -1;
+                    }}>No</button
                   >
                 </div>
               {:else}
                 <button
                   class="btn-del-req"
-                  on:click|stopPropagation={() => (confirmDeleteIndex = i)}
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    confirmDeleteIndex = i;
+                  }}
                   title="Delete request">×</button
                 >
               {/if}

--- a/src/components/TreeSidebar.svelte
+++ b/src/components/TreeSidebar.svelte
@@ -1,48 +1,98 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount } from 'svelte';
+  import { onMount } from 'svelte';
   import { getVersion } from '@tauri-apps/api/app';
   import TreeNode from './TreeNode.svelte';
-  import type { TreeNode as TNode, RequestLocation, FlowDefinition, Favorite } from '../lib/types';
+  import type { RequestLocation } from '../lib/types';
   import { getAllFileNodes, filterTreeByQuery } from '../lib/tree';
+  import {
+    workspace,
+    favorites,
+    availableEnvironments,
+    activeEnvironment,
+    flows,
+    activeFlowPath,
+    addRequestToFile,
+    deleteRequestFromFile,
+    toggleFolder,
+    openFlowTab,
+  } from '../lib/stores';
+  import {
+    createFile,
+    createFolder,
+    renameFile,
+    renameFolder,
+    duplicateFile,
+    deleteFile,
+    deleteFolder,
+    cancelRename,
+  } from '../lib/fileOps';
+  import { nameRequest } from '../lib/requestOps';
+  import { createFlow, duplicateFlow } from '../lib/flowOps';
 
-  let appVersion = '';
+  interface Props {
+    selected?: RequestLocation | null;
+    editingFilePath?: string | null;
+    editingFolderPath?: string | null;
+    onOpenFolder?: () => void;
+    onOpenGettingStarted?: () => void;
+    onToggleFavorite?: () => void;
+    onOpenFavorite?: (path: string) => void;
+    onRemoveFavorite?: (path: string) => void;
+    onImportCollection?: () => void;
+    onSelect?: (location: RequestLocation) => void;
+    onPinRequest?: (detail: { filePath: string; requestIndex: number; label: string }) => void;
+    onEditEnv?: () => void;
+    onOpenVarInspector?: () => void;
+    onOpenHelp?: () => void;
+    onOpenSettings?: () => void;
+    onDeleteFlow?: (path: string) => void;
+  }
 
-  export let tree: TNode[] = [];
-  export let selected: RequestLocation | null = null;
-  export let rootName: string = 'Workspace';
-  export let hasWorkspace: boolean = false;
+  let {
+    selected = null,
+    editingFilePath = null,
+    editingFolderPath = null,
+    onOpenFolder,
+    onOpenGettingStarted,
+    onToggleFavorite,
+    onOpenFavorite,
+    onRemoveFavorite,
+    onImportCollection,
+    onSelect,
+    onPinRequest,
+    onEditEnv,
+    onOpenVarInspector,
+    onOpenHelp,
+    onOpenSettings,
+    onDeleteFlow,
+  }: Props = $props();
 
-  // Environment props
-  export let environments: string[] = [];
-  export let activeEnv: string | null = null;
+  let appVersion = $state('');
 
-  // File management props
-  export let editingFilePath: string | null = null;
-  export let editingFolderPath: string | null = null;
+  const tree = $derived($workspace.tree);
+  const rootPath = $derived($workspace.rootPath);
+  const hasWorkspace = $derived(!!$workspace.rootPath);
+  /**
+   * Name shown for the open folder: the favorite's custom name when the open
+   * folder is favorited, otherwise the folder basename.
+   */
+  const rootName = $derived(
+    $favorites.find((f) => f.path === $workspace.rootPath)?.name ?? $workspace.rootName,
+  );
 
-  // Flow props
-  export let flows: Record<string, FlowDefinition> = {};
-  export let activeFlowPath: string | null = null;
-
-  // Favorites props
-  export let favorites: Favorite[] = [];
-  export let rootPath: string | null = null;
-
-  const dispatch = createEventDispatcher();
-
-  let displayMode: 'name' | 'url' = 'name';
-  let flowsExpanded = false;
-  let showNewFlow = false;
-  let newFlowName = '';
-  let newFlowInputEl: HTMLInputElement;
-  let confirmDeleteFlow: string | null = null;
-  let sortByUrl = false;
-  let filterText = '';
-  let filterInputEl: HTMLInputElement;
-  let showFavorites = false;
-  let favBtnEl: HTMLButtonElement;
-  let favMenuPos = { top: 0, left: 0 };
-  $: isFavorite = !!rootPath && favorites.some((f) => f.path === rootPath);
+  let displayMode: 'name' | 'url' = $state('name');
+  let flowsExpanded = $state(false);
+  let showNewFlow = $state(false);
+  let newFlowName = $state('');
+  let newFlowInputEl: HTMLInputElement | null = $state(null);
+  let confirmDeleteFlow: string | null = $state(null);
+  let sortByUrl = $state(false);
+  let filterText = $state('');
+  let filterInputEl: HTMLInputElement | null = $state(null);
+  let showFavorites = $state(false);
+  let favBtnEl: HTMLButtonElement | null = $state(null);
+  let favMenuPos = $state({ top: 0, left: 0 });
+  const isFavorite = $derived(!!rootPath && $favorites.some((f) => f.path === rootPath));
 
   function toggleFavorites() {
     showFavorites = !showFavorites;
@@ -58,21 +108,29 @@
     } catch {}
   });
 
-  $: usedNames = getAllFileNodes(tree)
-    .flatMap((f) => f.requests)
-    .map((r) => r.varName)
-    .filter((n): n is string => !!n);
+  const usedNames = $derived(
+    getAllFileNodes(tree)
+      .flatMap((f) => f.requests)
+      .map((r) => r.varName)
+      .filter((n): n is string => !!n),
+  );
 
-  $: displayTree = filterText.trim() ? filterTreeByQuery(tree, filterText.trim()) : tree;
+  const displayTree = $derived(
+    filterText.trim() ? filterTreeByQuery(tree, filterText.trim()) : tree,
+  );
 
-  $: if (showNewFlow && newFlowInputEl) newFlowInputEl.focus();
+  $effect(() => {
+    if (showNewFlow && newFlowInputEl) newFlowInputEl.focus();
+  });
 
-  $: flowEntries = Object.entries(flows).sort(([, a], [, b]) => a.name.localeCompare(b.name));
+  const flowEntries = $derived(
+    Object.entries($flows).sort(([, a], [, b]) => a.name.localeCompare(b.name)),
+  );
 
   function addFlow() {
     const name = newFlowName.trim();
     if (!name) return;
-    dispatch('createFlow', name);
+    createFlow(name);
     newFlowName = '';
     showNewFlow = false;
   }
@@ -81,10 +139,16 @@
     if (e.key === 'Enter') addFlow();
     if (e.key === 'Escape') showNewFlow = false;
   }
+
+  function openFlow(path: string) {
+    const flow = $flows[path];
+    if (!flow) return;
+    openFlowTab(path, flow.name);
+  }
 </script>
 
 <svelte:window
-  on:keydown={(e) => {
+  onkeydown={(e) => {
     if (e.key === 'Escape' && showFavorites) showFavorites = false;
   }}
 />
@@ -93,7 +157,7 @@
   <!-- Root folder button -->
   <div class="section root-section">
     <div class="root-row">
-      <button class="root-btn" on:click={() => dispatch('openFolder')} title="Open folder">
+      <button class="root-btn" onclick={() => onOpenFolder?.()} title="Open folder">
         <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
           <path
             d="M2 13V3a1 1 0 011-1h4l2 2h4a1 1 0 011 1v8a1 1 0 01-1 1H3a1 1 0 01-1-1z"
@@ -104,11 +168,9 @@
         <span class="root-name">{rootName}</span>
       </button>
       <button
-        class="btn-star"
-        class:active={isFavorite}
-        class:disabled={!hasWorkspace}
-        on:click={() => {
-          if (hasWorkspace) dispatch('toggleFavorite');
+        class={['btn-star', { active: isFavorite, disabled: !hasWorkspace }]}
+        onclick={() => {
+          if (hasWorkspace) onToggleFavorite?.();
         }}
         title={!hasWorkspace
           ? 'Open a folder first'
@@ -141,7 +203,7 @@
       <button
         class="btn-favorites"
         bind:this={favBtnEl}
-        on:click={toggleFavorites}
+        onclick={toggleFavorites}
         title="Favorites"
       >
         <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
@@ -161,10 +223,9 @@
         </svg>
       </button>
       <button
-        class="btn-import"
-        class:disabled={!hasWorkspace}
-        on:click={() => {
-          if (hasWorkspace) dispatch('importCollection');
+        class={['btn-import', { disabled: !hasWorkspace }]}
+        onclick={() => {
+          if (hasWorkspace) onImportCollection?.();
         }}
         title={hasWorkspace ? 'Import collection' : 'Open a folder before importing'}
       >
@@ -182,8 +243,8 @@
       {#if showFavorites}
         <div
           class="favorites-backdrop"
-          on:click={() => (showFavorites = false)}
-          on:keydown={(e) => {
+          onclick={() => (showFavorites = false)}
+          onkeydown={(e) => {
             if (e.key === 'Escape') showFavorites = false;
           }}
           role="button"
@@ -192,21 +253,21 @@
         ></div>
         <div class="favorites-dropdown" style="top: {favMenuPos.top}px; left: {favMenuPos.left}px;">
           <div class="favorites-dropdown-header">Favorites</div>
-          {#if favorites.length === 0}
+          {#if $favorites.length === 0}
             <div class="favorites-empty">No favorites yet</div>
           {:else}
-            {#each favorites as fav (fav.path)}
-              <div class="favorite-item" class:current={fav.path === rootPath}>
+            {#each $favorites as fav (fav.path)}
+              <div class={['favorite-item', { current: fav.path === rootPath }]}>
                 <div
                   class="favorite-open"
-                  on:click={() => {
-                    dispatch('openFavorite', fav.path);
+                  onclick={() => {
+                    onOpenFavorite?.(fav.path);
                     showFavorites = false;
                   }}
-                  on:keydown={(e) => {
+                  onkeydown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault();
-                      dispatch('openFavorite', fav.path);
+                      onOpenFavorite?.(fav.path);
                       showFavorites = false;
                     }
                   }}
@@ -219,7 +280,10 @@
                 </div>
                 <button
                   class="btn-remove-fav"
-                  on:click|stopPropagation={() => dispatch('removeFavorite', fav.path)}
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    onRemoveFavorite?.(fav.path);
+                  }}
                   title="Remove from favorites">&times;</button
                 >
               </div>
@@ -236,18 +300,17 @@
       <span class="env-dot"></span>
       <select
         class="env-select"
-        value={activeEnv ?? ''}
-        on:change={(e) => dispatch('changeEnv', e.currentTarget.value || null)}
+        value={$activeEnvironment ?? ''}
+        onchange={(e) => activeEnvironment.set(e.currentTarget.value || null)}
       >
-        {#each environments as env}
+        {#each $availableEnvironments as env}
           <option value={env}>{env}</option>
         {/each}
       </select>
       <button
-        class="btn-edit-env"
-        class:disabled={!hasWorkspace}
-        on:click={() => {
-          if (hasWorkspace) dispatch('editEnv');
+        class={['btn-edit-env', { disabled: !hasWorkspace }]}
+        onclick={() => {
+          if (hasWorkspace) onEditEnv?.();
         }}
         title={hasWorkspace ? 'Edit environment variables' : 'Open a folder first'}
       >
@@ -261,10 +324,9 @@
         </svg>
       </button>
       <button
-        class="btn-var-inspector"
-        class:disabled={!hasWorkspace}
-        on:click={() => {
-          if (hasWorkspace) dispatch('openVarInspector');
+        class={['btn-var-inspector', { disabled: !hasWorkspace }]}
+        onclick={() => {
+          if (hasWorkspace) onOpenVarInspector?.();
         }}
         title={hasWorkspace ? 'Variable inspector' : 'Open a folder first'}
       >
@@ -294,18 +356,18 @@
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="flow-header"
-        on:click={(e) => {
+        onclick={(e) => {
           if ((e.target as HTMLElement).closest('.btn-new-flow')) return;
           flowsExpanded = !flowsExpanded;
         }}
-        on:keydown={(e) => {
+        onkeydown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             flowsExpanded = !flowsExpanded;
           }
         }}
       >
-        <span class="chevron" class:open={flowsExpanded}>
+        <span class={['chevron', { open: flowsExpanded }]}>
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
             <path
               d="M3 1.5l4 3.5-4 3.5"
@@ -335,7 +397,8 @@
         <span class="flow-count">{flowEntries.length}</span>
         <button
           class="btn-new-flow"
-          on:click|stopPropagation={() => {
+          onclick={(e) => {
+            e.stopPropagation();
             showNewFlow = !showNewFlow;
             flowsExpanded = true;
           }}
@@ -349,24 +412,23 @@
             <input
               bind:this={newFlowInputEl}
               bind:value={newFlowName}
-              on:keydown={handleFlowKeydown}
+              onkeydown={handleFlowKeydown}
               placeholder="Flow name..."
               class="new-flow-input"
             />
-            <button class="btn-confirm-flow" on:click={addFlow}>Add</button>
+            <button class="btn-confirm-flow" onclick={addFlow}>Add</button>
           </div>
         {/if}
 
         {#each flowEntries as [path, flow]}
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <div
-            class="flow-item"
-            class:active={activeFlowPath === path}
-            on:click={() => dispatch('openFlow', path)}
-            on:keydown={(e) => {
+            class={['flow-item', { active: $activeFlowPath === path }]}
+            onclick={() => openFlow(path)}
+            onkeydown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
-                dispatch('openFlow', path);
+                openFlow(path);
               }
             }}
             role="button"
@@ -376,23 +438,34 @@
             <span class="flow-item-name">{flow.name}</span>
             {#if confirmDeleteFlow === path}
               <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <span class="flow-confirm-delete" on:click|stopPropagation on:keydown|stopPropagation>
+              <span
+                class="flow-confirm-delete"
+                onclick={(e) => e.stopPropagation()}
+                onkeydown={(e) => e.stopPropagation()}
+              >
                 <button
                   class="flow-del-yes"
-                  on:click|stopPropagation={() => {
-                    dispatch('deleteFlow', path);
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    onDeleteFlow?.(path);
                     confirmDeleteFlow = null;
                   }}>Del</button
                 >
                 <button
                   class="flow-del-no"
-                  on:click|stopPropagation={() => (confirmDeleteFlow = null)}>No</button
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    confirmDeleteFlow = null;
+                  }}>No</button
                 >
               </span>
             {:else}
               <button
                 class="btn-dup-flow"
-                on:click|stopPropagation={() => dispatch('duplicateFlow', path)}
+                onclick={(e) => {
+                  e.stopPropagation();
+                  duplicateFlow(path);
+                }}
                 title="Duplicate flow"
               >
                 <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
@@ -414,7 +487,10 @@
               </button>
               <button
                 class="btn-del-flow"
-                on:click|stopPropagation={() => (confirmDeleteFlow = path)}
+                onclick={(e) => {
+                  e.stopPropagation();
+                  confirmDeleteFlow = path;
+                }}
                 title="Delete flow">&times;</button
               >
             {/if}
@@ -446,17 +522,17 @@
         class="filter-input"
         placeholder="Filter..."
         spellcheck="false"
-        on:keydown={(e) => {
+        onkeydown={(e) => {
           if (e.key === 'Escape') {
             filterText = '';
-            filterInputEl.blur();
+            filterInputEl?.blur();
           }
         }}
       />
       {#if filterText}
         <button
           class="filter-clear"
-          on:click={() => {
+          onclick={() => {
             filterText = '';
           }}
           title="Clear filter">&times;</button
@@ -464,10 +540,8 @@
       {/if}
     </div>
     <button
-      class="btn-display-mode"
-      class:active={sortByUrl}
-      class:disabled={!hasWorkspace}
-      on:click={() => {
+      class={['btn-display-mode', { active: sortByUrl, disabled: !hasWorkspace }]}
+      onclick={() => {
         if (hasWorkspace) sortByUrl = !sortByUrl;
       }}
       title={!hasWorkspace
@@ -503,9 +577,8 @@
       </svg>
     </button>
     <button
-      class="btn-display-mode"
-      class:disabled={!hasWorkspace}
-      on:click={() => {
+      class={['btn-display-mode', { disabled: !hasWorkspace }]}
+      onclick={() => {
         if (hasWorkspace) displayMode = displayMode === 'name' ? 'url' : 'name';
       }}
       title={!hasWorkspace
@@ -541,10 +614,9 @@
       {/if}
     </button>
     <button
-      class="btn-display-mode"
-      class:disabled={!hasWorkspace}
-      on:click={() => {
-        if (hasWorkspace) dispatch('createFile', null);
+      class={['btn-display-mode', { disabled: !hasWorkspace }]}
+      onclick={() => {
+        if (hasWorkspace) createFile(null);
       }}
       title={!hasWorkspace ? 'Open a folder first' : 'New .http file'}
     >
@@ -553,10 +625,9 @@
       </svg>
     </button>
     <button
-      class="btn-display-mode"
-      class:disabled={!hasWorkspace}
-      on:click={() => {
-        if (hasWorkspace) dispatch('createFolder', null);
+      class={['btn-display-mode', { disabled: !hasWorkspace }]}
+      onclick={() => {
+        if (hasWorkspace) createFolder(null);
       }}
       title={!hasWorkspace ? 'Open a folder first' : 'New folder'}
     >
@@ -581,8 +652,8 @@
       <div class="empty-tree">
         <span class="empty-icon">📂</span>
         <span class="empty-text">Open a folder to browse .http files</span>
-        <button class="btn-open" on:click={() => dispatch('openFolder')}>Open Folder</button>
-        <button class="btn-getting-started" on:click={() => dispatch('openGettingStarted')}
+        <button class="btn-open" onclick={() => onOpenFolder?.()}>Open Folder</button>
+        <button class="btn-getting-started" onclick={() => onOpenGettingStarted?.()}
           >Getting Started</button
         >
       </div>
@@ -604,26 +675,28 @@
           {editingFolderPath}
           siblingNames={tree.filter((n) => n.type === 'file').map((n) => n.name)}
           siblingFolderNames={tree.map((n) => n.name)}
-          onToggleFolder={(path) => dispatch('toggleFolder', path)}
-          onSelect={(location) => dispatch('select', location)}
-          onPinRequest={(detail) => dispatch('pinRequest', detail)}
-          onAddRequest={(filePath) => dispatch('addRequest', filePath)}
-          onDeleteRequest={(detail) => dispatch('deleteRequest', detail)}
-          onDeleteFile={(filePath) => dispatch('deleteFile', filePath)}
-          onDeleteFolder={(folderPath) => dispatch('deleteFolder', folderPath)}
-          onNameRequest={(detail) => dispatch('nameRequest', detail)}
-          onRenameFile={(detail) => dispatch('renameFile', detail)}
-          onRenameFolder={(detail) => dispatch('renameFolder', detail)}
-          onDuplicateFile={(filePath) => dispatch('duplicateFile', filePath)}
-          onCreateFile={(parentPath) => dispatch('createFile', parentPath)}
-          onCreateFolder={(parentPath) => dispatch('createFolder', parentPath)}
-          onCancelRename={() => dispatch('cancelRename')}
+          onToggleFolder={toggleFolder}
+          {onSelect}
+          {onPinRequest}
+          onAddRequest={addRequestToFile}
+          onDeleteRequest={({ filePath, requestIndex }) =>
+            deleteRequestFromFile(filePath, requestIndex)}
+          onDeleteFile={deleteFile}
+          onDeleteFolder={deleteFolder}
+          onNameRequest={({ filePath, requestIndex, varName }) =>
+            nameRequest(filePath, requestIndex, varName)}
+          onRenameFile={({ oldPath, newName }) => renameFile(oldPath, newName)}
+          onRenameFolder={({ oldPath, newName }) => renameFolder(oldPath, newName)}
+          onDuplicateFile={duplicateFile}
+          onCreateFile={createFile}
+          onCreateFolder={createFolder}
+          onCancelRename={cancelRename}
         />
       {/each}
     {/if}
   </div>
   <div class="sidebar-footer">
-    <button class="btn-help" on:click={() => dispatch('openSettings')} title="Settings">
+    <button class="btn-help" onclick={() => onOpenSettings?.()} title="Settings">
       <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
         <path d="M8 10a2 2 0 100-4 2 2 0 000 4z" stroke="currentColor" stroke-width="1.3" />
         <path
@@ -635,11 +708,7 @@
       </svg>
       <span>Settings</span>
     </button>
-    <button
-      class="btn-help"
-      on:click={() => dispatch('openHelp')}
-      title="Help and keyboard shortcuts"
-    >
+    <button class="btn-help" onclick={() => onOpenHelp?.()} title="Help and keyboard shortcuts">
       <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
         <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.3" />
         <path

--- a/src/components/TreeSidebar.svelte
+++ b/src/components/TreeSidebar.svelte
@@ -604,20 +604,20 @@
           {editingFolderPath}
           siblingNames={tree.filter((n) => n.type === 'file').map((n) => n.name)}
           siblingFolderNames={tree.map((n) => n.name)}
-          on:toggleFolder
-          on:select
-          on:pinRequest
-          on:addRequest
-          on:deleteRequest
-          on:deleteFile
-          on:deleteFolder
-          on:nameRequest
-          on:renameFile
-          on:renameFolder
-          on:duplicateFile
-          on:createFile
-          on:createFolder
-          on:cancelRename
+          onToggleFolder={(path) => dispatch('toggleFolder', path)}
+          onSelect={(location) => dispatch('select', location)}
+          onPinRequest={(detail) => dispatch('pinRequest', detail)}
+          onAddRequest={(filePath) => dispatch('addRequest', filePath)}
+          onDeleteRequest={(detail) => dispatch('deleteRequest', detail)}
+          onDeleteFile={(filePath) => dispatch('deleteFile', filePath)}
+          onDeleteFolder={(folderPath) => dispatch('deleteFolder', folderPath)}
+          onNameRequest={(detail) => dispatch('nameRequest', detail)}
+          onRenameFile={(detail) => dispatch('renameFile', detail)}
+          onRenameFolder={(detail) => dispatch('renameFolder', detail)}
+          onDuplicateFile={(filePath) => dispatch('duplicateFile', filePath)}
+          onCreateFile={(parentPath) => dispatch('createFile', parentPath)}
+          onCreateFolder={(parentPath) => dispatch('createFolder', parentPath)}
+          onCancelRename={() => dispatch('cancelRename')}
         />
       {/each}
     {/if}


### PR DESCRIPTION
Part of phase 4 (item 6, Svelte 5 runes migration) plus item 26's TreeSidebar prop-drilling cleanup. No behavior change, no visual change.

## TreeNode.svelte (commit 1)

- `export let` (11 props) -> `$props()` with a typed `Props` interface
- `createEventDispatcher` (14 events) -> callback props: `onToggleFolder`, `onSelect`, `onPinRequest`, `onAddRequest`, `onDeleteRequest`, `onDeleteFile`, `onDeleteFolder`, `onNameRequest`, `onRenameFile`, `onRenameFolder`, `onDuplicateFile`, `onCreateFile`, `onCreateFolder`, `onCancelRename`
- `$:` -> `$derived`/`$derived.by` (urlSuffixes, sortedIndices, fileRenameError, folderRenameError, isDuplicate) and `$effect` (auto-enter rename mode, keep-expanded-on-selection)
- local mutable state -> `$state`; `bind:this` targets typed `| null = $state(null)`
- `on:x` -> `onx`; `|stopPropagation`/`|preventDefault` modifiers -> explicit `e.stopPropagation()`/`e.preventDefault()` in handlers
- `class:x` -> `class={[..., { x }]}` array/object syntax
- recursion: `<svelte:self>` -> self-import (`import Self from './TreeNode.svelte'`), callbacks passed down explicitly

## TreeSidebar.svelte (commit 2)

Same rune conversions as above (props interface, callback props, `$derived`/`$effect`, `$state`, `onx`, class arrays), plus the item 26 store-subscription change:

- now subscribes directly to `workspace` (tree, rootPath, rootName incl. favorite display name), `availableEnvironments`, `activeEnvironment`, `flows`, `activeFlowPath`, `favorites`
- calls store/lib mutators directly instead of dispatching to App: `toggleFolder`, `addRequestToFile`, `deleteRequestFromFile`, `openFlowTab`, `activeEnvironment.set`, fileOps (`createFile`, `createFolder`, `renameFile`, `renameFolder`, `duplicateFile`, `deleteFile`, `deleteFolder`, `cancelRename`), `nameRequest`, `createFlow`, `duplicateFlow`
- genuinely parent-owned actions remain callback props (things only App can do: dialogs, modals, env-editor autosave, App-owned `flowUIState`): `onOpenFolder`, `onOpenGettingStarted`, `onToggleFavorite`, `onOpenFavorite`, `onRemoveFavorite`, `onImportCollection`, `onSelect`, `onPinRequest`, `onEditEnv`, `onOpenVarInspector`, `onOpenHelp`, `onOpenSettings`, `onDeleteFlow`
- prop count: 13 data props + 30 `on:` listeners (43 attributes) -> 3 data props + 14 callbacks (17 attributes at the App call site)

## App.svelte

Only the TreeSidebar element block and its dedicated wiring were touched (concurrent migrations of RequestEditor/EnvironmentEditor/FlowEditor are on separate branches; legacy pin untouched):

- removed handlers that existed solely for TreeSidebar/TreeNode: `handleAddRequest`, `handleDeleteRequest`, `handleToggleFolder`, `handleOpenFlow`, and the `rootDisplayName` reactive statement (moved into TreeSidebar)
- `handleSelect`/`handlePinRequest`/`handleDeleteFlow` converted from `CustomEvent` signatures to plain-argument callbacks
- dropped now-unused imports: `addRequestToFile`, `deleteRequestFromFile`, `toggleFolder`, `openFlowTab`, `flows`, `nameRequest`, `createFlow`, `duplicateFlow`, and the whole fileOps import block

## Notes

- `activeFlowPath` is used for the sidebar's active-flow highlight; App previously passed `$activeFlowTabPath`, but the two stores are set/cleared together everywhere (`activateFlowTab`, `closeFlowTab`, `handleSelect`, `handleTabActivate`), so behavior is identical.
- Legacy-pattern grep on both files (`createEventDispatcher`, `export let`, `$:`, `on:`, `class:`) is clean.

## Verification

- `pnpm check`: 0 errors, 0 warnings (after each commit)
- `pnpm test`: 367 passed (after each commit)
- `pnpm lint`: 0 errors; warning count unchanged (pre-existing)
- `pnpm exec prettier --check`: clean on both migrated files; App.svelte content is prettier-clean (local CRLF checkout artifact only, same as untouched files)