### PR TITLE
refactor: migrate EnvironmentEditor to Svelte 5 runes, extract KeyVaultPanel

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -855,16 +855,16 @@
               userEnvFile={$userEnvFile}
               activeEnv={$activeEnvironment ?? '$shared'}
               kvState={$keyVaultState}
-              on:update={(e) => {
-                envFile.set(e.detail);
-                saveEnvFile(e.detail);
+              onUpdate={(updated) => {
+                envFile.set(updated);
+                saveEnvFile(updated);
               }}
-              on:changeEnv={(e) => activeEnvironment.set(e.detail)}
-              on:close={() => (showEnvEditor = false)}
-              on:sourcePref={(e) => {
-                varSourcePrefs.update((p) => ({ ...p, [e.detail.key]: e.detail.source }));
+              onChangeEnv={(env) => activeEnvironment.set(env)}
+              onClose={() => (showEnvEditor = false)}
+              onSourcePref={(key, source) => {
+                varSourcePrefs.update((p) => ({ ...p, [key]: source }));
               }}
-              on:refreshKv={(e) => refreshKeyVaultForEnv(e.detail)}
+              onRefreshKv={(env) => refreshKeyVaultForEnv(env)}
             />
           </div>
         {:else if $activeFlowTabPath && $activeFlow}

--- a/src/components/EnvironmentEditor.svelte
+++ b/src/components/EnvironmentEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { createEventDispatcher, tick, onMount } from 'svelte';
+  import { tick, onMount } from 'svelte';
+  import { SvelteSet } from 'svelte/reactivity';
   import type {
     EnvironmentFile,
     EnvironmentVariables,
@@ -10,25 +11,41 @@
   import { buildVarList, type EnvVar } from '../lib/envVarModel';
   import HelpTip from './HelpTip.svelte';
 
-  export let envFile: EnvironmentFile;
-  export let userEnvFile: EnvironmentFile | null = null;
-  export let activeEnv: string;
-  export let kvState: KeyVaultState;
+  interface Props {
+    envFile: EnvironmentFile;
+    userEnvFile?: EnvironmentFile | null;
+    activeEnv: string;
+    kvState: KeyVaultState;
+    onUpdate?: (envFile: EnvironmentFile) => void;
+    onChangeEnv?: (env: string | null) => void;
+    onClose?: () => void;
+    onSourcePref?: (key: string, source: VarSource) => void;
+    onRefreshKv?: (env: string) => void;
+  }
 
-  const dispatch = createEventDispatcher();
+  let {
+    envFile,
+    userEnvFile = null,
+    activeEnv,
+    kvState,
+    onUpdate,
+    onChangeEnv,
+    onClose,
+    onSourcePref,
+    onRefreshKv,
+  }: Props = $props();
 
-  let showSecrets = false;
-  let showKvSetup = false;
-  let kvVaultUrl = '';
-  let kvSecretName = '';
+  let showSecrets = $state(false);
 
   function masked(val: string | undefined): string {
     if (!val) return '';
     return '*'.repeat(Math.min(val.length, 12));
   }
 
-  // Local editing state - independent from sidebar's active env
-  let editingEnv = activeEnv;
+  // Local editing state - independent from sidebar's active env; intentionally
+  // captures only the initial value (the editor keeps its own tab selection)
+  // svelte-ignore state_referenced_locally
+  let editingEnv = $state(activeEnv);
 
   // ─── Unified grouped variable model (see lib/envVarModel.ts) ───────────────
 
@@ -49,54 +66,31 @@
     }
   }
 
-  function envFileFingerprint(
-    ef: EnvironmentFile,
-    uef: EnvironmentFile | null,
-    env: string,
-  ): string {
-    const envData = ef?.[env];
-    const userData = uef?.[env];
-    return (
-      (envData ? JSON.stringify(envData) : '') + '|' + (userData ? JSON.stringify(userData) : '')
-    );
-  }
+  // Local editable array - recomputed when switching environments, when KV state
+  // changes, or when the env files change externally (writable $derived: local
+  // edits assign to it directly and are persisted back via saveVars, which
+  // round-trips through the parent as a new envFile prop).
+  let envVars: EnvVar[] = $derived(buildVarList(envFile, userEnvFile, editingEnv, kvState));
 
-  // Local editable array - rebuilt when switching environments, KV status changes, or envFile changes externally
-  let envVars: EnvVar[] = buildVarList(envFile, userEnvFile, editingEnv, kvState);
-  let lastEditingEnv = editingEnv;
-  let lastKvStatus = kvState.status;
-  let lastEnvFingerprint = envFileFingerprint(envFile, userEnvFile, editingEnv);
-  $: {
-    const currentFingerprint = envFileFingerprint(envFile, userEnvFile, editingEnv);
-    if (
-      editingEnv !== lastEditingEnv ||
-      kvState.status !== lastKvStatus ||
-      currentFingerprint !== lastEnvFingerprint
-    ) {
-      envVars = buildVarList(envFile, userEnvFile, editingEnv, kvState);
-      lastEditingEnv = editingEnv;
-      lastKvStatus = kvState.status;
-      lastEnvFingerprint = currentFingerprint;
-    }
-  }
-
-  $: groupedCount = envVars.filter((v) => v.sources.length > 1).length;
+  let groupedCount = $derived(envVars.filter((v) => v.sources.length > 1).length);
 
   // Environments list: $shared first, then the rest (including user-file-only envs)
-  $: envNames = [
+  let envNames = $derived([
     ...new Set([
       ...Object.keys(envFile || {}).filter((k) => k !== '$shared'),
       ...Object.keys(userEnvFile || {}).filter((k) => k !== '$shared'),
     ]),
-  ];
-  $: userOnlyEnvs = new Set(
-    Object.keys(userEnvFile || {}).filter((k) => k !== '$shared' && !(envFile || {})[k]),
+  ]);
+  let userOnlyEnvs = $derived(
+    new Set(Object.keys(userEnvFile || {}).filter((k) => k !== '$shared' && !(envFile || {})[k])),
   );
-  $: hasShared = envFile?.['$shared'] !== undefined || userEnvFile?.['$shared'] !== undefined;
-  $: allTabs = hasShared ? ['$shared', ...envNames] : envNames;
+  let hasShared = $derived(
+    envFile?.['$shared'] !== undefined || userEnvFile?.['$shared'] !== undefined,
+  );
+  let allTabs = $derived(hasShared ? ['$shared', ...envNames] : envNames);
 
   // Track which variable keys have their source group expanded
-  let expandedGroups = new Set<string>();
+  const expandedGroups = new SvelteSet<string>();
 
   function toggleGroupExpand(key: string) {
     if (expandedGroups.has(key)) {
@@ -104,7 +98,6 @@
     } else {
       expandedGroups.add(key);
     }
-    expandedGroups = expandedGroups; // trigger reactivity
   }
 
   /** Switch the active source for a grouped variable. */
@@ -112,23 +105,22 @@
     const v = envVars[index];
     if (v.activeSource === newSource) return;
     envVars = envVars.map((item, i) => (i === index ? { ...item, activeSource: newSource } : item));
-    dispatch('sourcePref', { key: v.key, source: newSource });
+    onSourcePref?.(v.key, newSource);
   }
 
   // Editing state
-  let renaming = false;
-  let renameValue = '';
-  let confirmingDelete = false;
-  let showAddEnv = false;
-  let newEnvName = '';
-  let addEnvInputEl: HTMLInputElement;
+  let renaming = $state(false);
+  let renameValue = $state('');
+  let confirmingDelete = $state(false);
+  let showAddEnv = $state(false);
+  let newEnvName = $state('');
 
   function addEnvironment() {
     const name = newEnvName.trim();
     if (!name || envFile[name]) return;
     const updated = { ...envFile, [name]: {} };
-    dispatch('update', updated);
-    dispatch('changeEnv', name);
+    onUpdate?.(updated);
+    onChangeEnv?.(name);
     editingEnv = name;
     newEnvName = '';
     showAddEnv = false;
@@ -148,9 +140,9 @@
     const updated = { ...envFile };
     updated[newName] = updated[editingEnv];
     delete updated[editingEnv];
-    dispatch('update', updated);
+    onUpdate?.(updated);
     if (editingEnv === activeEnv) {
-      dispatch('changeEnv', newName);
+      onChangeEnv?.(newName);
     }
     editingEnv = newName;
     renaming = false;
@@ -160,10 +152,10 @@
     if (envNames.length <= 1) return;
     const updated = { ...envFile };
     delete updated[editingEnv];
-    dispatch('update', updated);
+    onUpdate?.(updated);
     const remaining = Object.keys(updated).filter((k) => k !== '$shared');
     if (editingEnv === activeEnv) {
-      dispatch('changeEnv', remaining[0] || null);
+      onChangeEnv?.(remaining[0] || null);
     }
     editingEnv = remaining[0] || '';
   }
@@ -227,33 +219,31 @@
       }
     }
     updated[editingEnv] = envData;
-    dispatch('update', updated);
+    onUpdate?.(updated);
   }
 
   // ─── Key Vault config ───
 
-  $: kvConfig = envFile?.[editingEnv]?.$keyvault ?? null;
-  $: kvConnected =
-    kvConfig && kvState.status === 'loaded' && kvState.cacheKey?.startsWith(editingEnv + '::');
+  let kvConfig = $derived(envFile?.[editingEnv]?.$keyvault ?? null);
+  let kvConnected = $derived(
+    kvConfig && kvState.status === 'loaded' && kvState.cacheKey?.startsWith(editingEnv + '::'),
+  );
 
-  // Sync local inputs when switching envs or when config changes externally
-  let lastKvConfigEnv = editingEnv;
-  $: {
-    if (editingEnv !== lastKvConfigEnv) {
-      const cfg = envFile?.[editingEnv]?.$keyvault;
-      kvVaultUrl = cfg?.vaultUrl ?? '';
-      kvSecretName = cfg?.secretName ?? '';
-      showKvSetup = !!cfg;
-      lastKvConfigEnv = editingEnv;
-    }
-  }
-
-  // Also sync when kvConfig appears externally (e.g. file reload)
-  $: if (kvConfig) {
-    kvVaultUrl = kvConfig.vaultUrl;
-    kvSecretName = kvConfig.secretName;
-    showKvSetup = true;
-  }
+  // KV form state: recomputed from the stored config when switching environments
+  // or when the config changes externally (writable $derived: user input and the
+  // cancel button assign to these directly until the next recompute).
+  let kvVaultUrl = $derived.by(() => {
+    void editingEnv; // reset the field when switching environment tabs
+    return kvConfig?.vaultUrl ?? '';
+  });
+  let kvSecretName = $derived.by(() => {
+    void editingEnv; // reset the field when switching environment tabs
+    return kvConfig?.secretName ?? '';
+  });
+  let showKvSetup = $derived.by(() => {
+    void editingEnv; // collapse the panel when switching environment tabs
+    return kvConfig !== null;
+  });
 
   function saveKvConfig() {
     const url = kvVaultUrl.trim();
@@ -267,8 +257,8 @@
     };
     const updated = { ...envFile };
     updated[editingEnv] = { ...updated[editingEnv], $keyvault: config };
-    dispatch('update', updated);
-    dispatch('refreshKv', editingEnv);
+    onUpdate?.(updated);
+    onRefreshKv?.(editingEnv);
   }
 
   function removeKvConfig() {
@@ -279,11 +269,7 @@
     showKvSetup = false;
     kvVaultUrl = '';
     kvSecretName = '';
-    dispatch('update', updated);
-  }
-
-  function close() {
-    dispatch('close');
+    onUpdate?.(updated);
   }
 </script>
 
@@ -291,26 +277,25 @@
   <!-- Header -->
   <div class="editor-header">
     <div class="header-left">
-      <span class="env-dot" class:active-dot={editingEnv === activeEnv}></span>
+      <span class={['env-dot', { 'active-dot': editingEnv === activeEnv }]}></span>
       {#if renaming}
         <!-- svelte-ignore a11y_autofocus -->
         <input
           class="rename-input"
           bind:value={renameValue}
-          on:keydown={(e) => {
+          onkeydown={(e) => {
             if (e.key === 'Enter') confirmRename();
             if (e.key === 'Escape') {
               renaming = false;
             }
           }}
-          on:blur={confirmRename}
+          onblur={confirmRename}
           autofocus
         />
       {:else if editingEnv === '$shared'}
         <span class="env-name-static">{editingEnv}</span>
       {:else}
-        <button class="env-name" on:click={startRename} title="Click to rename">{editingEnv}</button
-        >
+        <button class="env-name" onclick={startRename} title="Click to rename">{editingEnv}</button>
       {/if}
       <span class="var-count">{envVars.length} variable{envVars.length !== 1 ? 's' : ''}</span>
       {#if editingEnv === activeEnv}
@@ -321,12 +306,12 @@
       {#if kvConfig && (kvState.status === 'loaded' || kvState.status === 'error')}
         <button
           class="btn-toggle-secrets"
-          on:click={() => (showSecrets = !showSecrets)}
+          onclick={() => (showSecrets = !showSecrets)}
           title={showSecrets ? 'Hide secret values' : 'Show secret values'}
           >{showSecrets ? '[Hide secrets]' : '[Show secrets]'}</button
         >
       {/if}
-      <button class="btn-done" on:click={close}>Close</button>
+      <button class="btn-done" onclick={() => onClose?.()}>Close</button>
     </div>
   </div>
 
@@ -334,11 +319,15 @@
   <div class="env-tabs">
     {#each allTabs as env}
       <button
-        class="env-tab"
-        class:active={env === editingEnv}
-        class:shared-tab={env === '$shared'}
-        class:user-only-tab={userOnlyEnvs.has(env)}
-        on:click={() => {
+        class={[
+          'env-tab',
+          {
+            active: env === editingEnv,
+            'shared-tab': env === '$shared',
+            'user-only-tab': userOnlyEnvs.has(env),
+          },
+        ]}
+        onclick={() => {
           editingEnv = env;
           confirmingDelete = false;
         }}
@@ -350,16 +339,15 @@
       <div class="add-env-inline">
         <!-- svelte-ignore a11y_autofocus -->
         <input
-          bind:this={addEnvInputEl}
           bind:value={newEnvName}
-          on:keydown={(e) => {
+          onkeydown={(e) => {
             if (e.key === 'Enter') addEnvironment();
             if (e.key === 'Escape') {
               showAddEnv = false;
               newEnvName = '';
             }
           }}
-          on:blur={() => {
+          onblur={() => {
             if (!newEnvName.trim()) {
               showAddEnv = false;
             }
@@ -368,12 +356,12 @@
           class="add-env-inline-input"
           autofocus
         />
-        <button class="btn-confirm-add-env" on:click={addEnvironment}>Add</button>
+        <button class="btn-confirm-add-env" onclick={addEnvironment}>Add</button>
       </div>
     {:else}
       <button
         class="btn-add-env-tab"
-        on:click={() => {
+        onclick={() => {
           showAddEnv = true;
         }}
         title="Add environment">+ Add environment</button
@@ -394,7 +382,7 @@
   {:else if kvState.status === 'error'}
     <div class="kv-status kv-error">
       Key Vault error: {kvState.error}
-      <button class="btn-kv-retry" on:click={() => dispatch('refreshKv', editingEnv)}>Retry</button>
+      <button class="btn-kv-retry" onclick={() => onRefreshKv?.(editingEnv)}>Retry</button>
     </div>
   {/if}
 
@@ -415,18 +403,18 @@
       {@const hasLocal = v.sources.some((s) => s.source === 'local')}
       <div class="var-row-wrapper">
         <!-- Main row: shows the active source's value -->
-        <div class="var-row" class:disabled={!v.enabled} class:grouped-row={isGrouped}>
+        <div class={['var-row', { disabled: !v.enabled, 'grouped-row': isGrouped }]}>
           <input
             type="checkbox"
             class="var-check"
             checked={v.enabled}
-            on:change={() => toggleVariable(i)}
+            onchange={() => toggleVariable(i)}
           />
 
           <input
             class="var-key"
             value={v.key}
-            on:input={(e) => updateLocalValue(i, 'key', e.currentTarget.value)}
+            oninput={(e) => updateLocalValue(i, 'key', e.currentTarget.value)}
             placeholder="variableName"
             spellcheck="false"
             disabled={!hasLocal}
@@ -441,7 +429,7 @@
                     ? activeValue(v)
                     : masked(activeValue(v))
                   : activeValue(v)}
-                on:input={(e) => {
+                oninput={(e) => {
                   if (isLocalActive && hasLocal)
                     updateLocalValue(i, 'value', e.currentTarget.value);
                 }}
@@ -454,9 +442,8 @@
               >
               {#if isGrouped}
                 <button
-                  class="btn-group-chevron"
-                  class:open={isExpanded}
-                  on:click={() => toggleGroupExpand(v.key)}
+                  class={['btn-group-chevron', { open: isExpanded }]}
+                  onclick={() => toggleGroupExpand(v.key)}
                   title="{v.sources.length} sources"
                 >
                   <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
@@ -474,7 +461,7 @@
           </div>
 
           {#if hasLocal && !isGrouped}
-            <button class="btn-remove" on:click={() => removeVariable(i)}>x</button>
+            <button class="btn-remove" onclick={() => removeVariable(i)}>x</button>
           {:else}
             <div class="btn-remove-placeholder"></div>
           {/if}
@@ -490,7 +477,7 @@
                     type="checkbox"
                     class="var-check"
                     checked={false}
-                    on:change={() => setActiveSource(i, entry.source)}
+                    onchange={() => setActiveSource(i, entry.source)}
                     title="Switch to {sourceLabel(entry.source)} value"
                   />
                   <span class="source-tag source-tag-{entry.source}"
@@ -503,7 +490,7 @@
                         ? entry.value
                         : masked(entry.value)
                       : entry.value}
-                    on:input={(e) => {
+                    oninput={(e) => {
                       if (entry.source === 'local') {
                         envVars = envVars.map((item, idx) => {
                           if (idx !== i) return item;
@@ -528,7 +515,7 @@
       </div>
     {/each}
 
-    <button class="btn-add-var" on:click={addVariable}> + Add variable </button>
+    <button class="btn-add-var" onclick={addVariable}> + Add variable </button>
   </div>
 
   <!-- Key Vault config -->
@@ -569,16 +556,16 @@
       <div class="kv-setup-actions">
         <button
           class="btn-kv-connect"
-          on:click={saveKvConfig}
+          onclick={saveKvConfig}
           disabled={!kvVaultUrl.trim() || !kvSecretName.trim()}
           >{kvConfig ? 'Save & refresh' : 'Connect'}</button
         >
         {#if kvConfig}
-          <button class="btn-kv-disconnect" on:click={removeKvConfig}>Disconnect</button>
+          <button class="btn-kv-disconnect" onclick={removeKvConfig}>Disconnect</button>
         {:else}
           <button
             class="btn-kv-cancel"
-            on:click={() => {
+            onclick={() => {
               showKvSetup = false;
               kvVaultUrl = '';
               kvSecretName = '';
@@ -588,7 +575,7 @@
       </div>
     </div>
   {:else}
-    <button class="btn-kv-add" on:click={() => (showKvSetup = true)}>
+    <button class="btn-kv-add" onclick={() => (showKvSetup = true)}>
       + Connect to Azure Key Vault
     </button>
   {/if}
@@ -601,16 +588,16 @@
           <span class="confirm-text">Delete "{editingEnv}"?</span>
           <button
             class="btn-confirm-delete"
-            on:click={() => {
+            onclick={() => {
               deleteEnvironment();
               confirmingDelete = false;
             }}>Yes, delete</button
           >
-          <button class="btn-cancel-delete" on:click={() => (confirmingDelete = false)}
+          <button class="btn-cancel-delete" onclick={() => (confirmingDelete = false)}
             >Cancel</button
           >
         {:else}
-          <button class="btn-delete-env" on:click={() => (confirmingDelete = true)}
+          <button class="btn-delete-env" onclick={() => (confirmingDelete = true)}
             >Delete environment</button
           >
         {/if}

--- a/src/components/EnvironmentEditor.svelte
+++ b/src/components/EnvironmentEditor.svelte
@@ -9,7 +9,7 @@
     VarSource,
   } from '../lib/types';
   import { buildVarList, type EnvVar } from '../lib/envVarModel';
-  import HelpTip from './HelpTip.svelte';
+  import KeyVaultPanel from './KeyVaultPanel.svelte';
 
   interface Props {
     envFile: EnvironmentFile;
@@ -226,35 +226,12 @@
 
   let kvConfig = $derived(envFile?.[editingEnv]?.$keyvault ?? null);
   let kvConnected = $derived(
-    kvConfig && kvState.status === 'loaded' && kvState.cacheKey?.startsWith(editingEnv + '::'),
+    Boolean(
+      kvConfig && kvState.status === 'loaded' && kvState.cacheKey?.startsWith(editingEnv + '::'),
+    ),
   );
 
-  // KV form state: recomputed from the stored config when switching environments
-  // or when the config changes externally (writable $derived: user input and the
-  // cancel button assign to these directly until the next recompute).
-  let kvVaultUrl = $derived.by(() => {
-    void editingEnv; // reset the field when switching environment tabs
-    return kvConfig?.vaultUrl ?? '';
-  });
-  let kvSecretName = $derived.by(() => {
-    void editingEnv; // reset the field when switching environment tabs
-    return kvConfig?.secretName ?? '';
-  });
-  let showKvSetup = $derived.by(() => {
-    void editingEnv; // collapse the panel when switching environment tabs
-    return kvConfig !== null;
-  });
-
-  function saveKvConfig() {
-    const url = kvVaultUrl.trim();
-    const name = kvSecretName.trim();
-    if (!url || !name) return;
-
-    const config: KeyVaultConfig = {
-      provider: 'AzureKeyVault',
-      vaultUrl: url,
-      secretName: name,
-    };
+  function saveKvConfig(config: KeyVaultConfig) {
     const updated = { ...envFile };
     updated[editingEnv] = { ...updated[editingEnv], $keyvault: config };
     onUpdate?.(updated);
@@ -266,9 +243,6 @@
     const env = { ...updated[editingEnv] };
     delete env.$keyvault;
     updated[editingEnv] = env;
-    showKvSetup = false;
-    kvVaultUrl = '';
-    kvSecretName = '';
     onUpdate?.(updated);
   }
 </script>
@@ -519,66 +493,14 @@
   </div>
 
   <!-- Key Vault config -->
-  {#if showKvSetup || kvConfig}
-    <div class="kv-setup">
-      <div class="kv-setup-header">
-        <span class="kv-setup-title">Azure Key Vault</span>
-        <HelpTip
-          label="Azure Key Vault"
-          text="Requires Azure CLI (az login) or Azure Developer CLI (azd auth login). The vault URL should point to an existing Key Vault instance that your account has Secret read permissions on."
-        />
-        {#if kvConnected}
-          <span class="kv-connected-badge">connected</span>
-        {:else if kvConfig}
-          <span class="kv-configured-badge">configured</span>
-        {/if}
-      </div>
-      <div class="kv-setup-fields">
-        <label class="kv-field">
-          <span class="kv-field-label">Vault URL</span>
-          <input
-            class="kv-field-input"
-            bind:value={kvVaultUrl}
-            placeholder="https://my-vault.vault.azure.net"
-            spellcheck="false"
-          />
-        </label>
-        <label class="kv-field">
-          <span class="kv-field-label">Secret name</span>
-          <input
-            class="kv-field-input"
-            bind:value={kvSecretName}
-            placeholder="my-secret"
-            spellcheck="false"
-          />
-        </label>
-      </div>
-      <div class="kv-setup-actions">
-        <button
-          class="btn-kv-connect"
-          onclick={saveKvConfig}
-          disabled={!kvVaultUrl.trim() || !kvSecretName.trim()}
-          >{kvConfig ? 'Save & refresh' : 'Connect'}</button
-        >
-        {#if kvConfig}
-          <button class="btn-kv-disconnect" onclick={removeKvConfig}>Disconnect</button>
-        {:else}
-          <button
-            class="btn-kv-cancel"
-            onclick={() => {
-              showKvSetup = false;
-              kvVaultUrl = '';
-              kvSecretName = '';
-            }}>Cancel</button
-          >
-        {/if}
-      </div>
-    </div>
-  {:else}
-    <button class="btn-kv-add" onclick={() => (showKvSetup = true)}>
-      + Connect to Azure Key Vault
-    </button>
-  {/if}
+  {#key editingEnv}
+    <KeyVaultPanel
+      {kvConfig}
+      connected={kvConnected}
+      onSave={saveKvConfig}
+      onRemove={removeKvConfig}
+    />
+  {/key}
 
   <!-- Footer -->
   <div class="editor-footer">
@@ -795,146 +717,6 @@
   }
   .btn-confirm-add-env:hover {
     background: color-mix(in srgb, var(--color-success) 10%, transparent);
-  }
-
-  /* Key Vault setup */
-  .btn-kv-add {
-    padding: var(--space-2) var(--space-3\.5);
-    border: 1px dashed var(--color-border);
-    border-radius: var(--radius-default);
-    background: transparent;
-    color: var(--color-text-faint);
-    font-family: inherit;
-    font-size: var(--text-sm);
-    cursor: pointer;
-    transition: all var(--duration-normal);
-    align-self: flex-start;
-    margin-bottom: var(--space-4);
-  }
-  .btn-kv-add:hover {
-    border-color: var(--color-primary);
-    color: var(--color-primary);
-  }
-
-  .kv-setup {
-    border: 1px solid var(--color-divider);
-    border-radius: var(--radius-default);
-    padding: var(--space-3) var(--space-4);
-    margin-bottom: var(--space-4);
-    background: color-mix(in srgb, var(--color-primary) 3%, transparent);
-  }
-  .kv-setup-header {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    margin-bottom: var(--space-3);
-  }
-  .kv-setup-title {
-    font-size: var(--text-sm);
-    font-weight: var(--weight-semibold);
-    color: var(--color-text-secondary);
-    letter-spacing: 0.3px;
-  }
-  .kv-connected-badge {
-    font-size: var(--text-xs);
-    color: var(--color-success);
-    background: color-mix(in srgb, var(--color-success) 8%, transparent);
-    padding: 1px var(--space-2);
-    border-radius: var(--radius-xl);
-  }
-  .kv-configured-badge {
-    font-size: var(--text-xs);
-    color: var(--color-text-faint);
-    background: color-mix(in srgb, var(--color-text-faint) 8%, transparent);
-    padding: 1px var(--space-2);
-    border-radius: var(--radius-xl);
-  }
-  .kv-setup-fields {
-    display: flex;
-    gap: var(--space-3);
-    margin-bottom: var(--space-3);
-  }
-  .kv-field {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-  .kv-field-label {
-    font-size: var(--text-xs);
-    color: var(--color-text-faint);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-  .kv-field-input {
-    padding: var(--space-2) var(--space-2\.5);
-    border: 1px solid var(--color-divider);
-    border-radius: var(--radius-default);
-    background: var(--color-bg-surface);
-    color: var(--color-text);
-    font-family: inherit;
-    font-size: var(--text-md);
-    outline: none;
-    transition: border-color var(--duration-normal);
-  }
-  .kv-field-input:focus {
-    border-color: var(--color-primary);
-  }
-  .kv-field-input::placeholder {
-    color: var(--color-text-placeholder);
-  }
-  .kv-setup-actions {
-    display: flex;
-    gap: var(--space-2);
-  }
-  .btn-kv-connect {
-    padding: 5px var(--space-3);
-    border: 1px solid var(--color-primary);
-    border-radius: var(--radius-default);
-    background: color-mix(in srgb, var(--color-primary) 10%, transparent);
-    color: var(--color-primary);
-    font-family: inherit;
-    font-size: var(--text-sm);
-    font-weight: var(--weight-semibold);
-    cursor: pointer;
-    transition: all var(--duration-normal);
-  }
-  .btn-kv-connect:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--color-primary) 18%, transparent);
-  }
-  .btn-kv-connect:disabled {
-    opacity: 0.4;
-    cursor: default;
-  }
-  .btn-kv-disconnect {
-    padding: 5px var(--space-3);
-    border: 1px solid var(--color-divider);
-    border-radius: var(--radius-default);
-    background: transparent;
-    color: var(--color-error);
-    font-family: inherit;
-    font-size: var(--text-sm);
-    cursor: pointer;
-    transition: all var(--duration-normal);
-  }
-  .btn-kv-disconnect:hover {
-    border-color: var(--color-error);
-    background: color-mix(in srgb, var(--color-error) 8%, transparent);
-  }
-  .btn-kv-cancel {
-    padding: 5px var(--space-3);
-    border: 1px solid var(--color-divider);
-    border-radius: var(--radius-default);
-    background: transparent;
-    color: var(--color-text-faint);
-    font-family: inherit;
-    font-size: var(--text-sm);
-    cursor: pointer;
-    transition: all var(--duration-normal);
-  }
-  .btn-kv-cancel:hover {
-    border-color: var(--color-text-faint);
-    color: var(--color-text);
   }
 
   /* Column headers */

--- a/src/components/KeyVaultPanel.svelte
+++ b/src/components/KeyVaultPanel.svelte
@@ -1,0 +1,240 @@
+<script lang="ts">
+  import type { KeyVaultConfig } from '../lib/types';
+  import HelpTip from './HelpTip.svelte';
+
+  interface Props {
+    /** Stored Key Vault config for the environment being edited, if any. */
+    kvConfig: KeyVaultConfig | null;
+    /** Whether the loaded KV cache belongs to this environment. */
+    connected: boolean;
+    onSave?: (config: KeyVaultConfig) => void;
+    onRemove?: () => void;
+  }
+
+  let { kvConfig, connected, onSave, onRemove }: Props = $props();
+
+  // Form state: recomputed from the stored config when it changes externally
+  // (writable $derived: user input and the cancel button assign to these
+  // directly until the next recompute). The parent re-creates this component
+  // per environment tab ({#key editingEnv}), which resets the form on tab
+  // switches.
+  let vaultUrl = $derived(kvConfig?.vaultUrl ?? '');
+  let secretName = $derived(kvConfig?.secretName ?? '');
+  let showSetup = $derived(kvConfig !== null);
+
+  function save() {
+    const url = vaultUrl.trim();
+    const name = secretName.trim();
+    if (!url || !name) return;
+    onSave?.({ provider: 'AzureKeyVault', vaultUrl: url, secretName: name });
+  }
+
+  function remove() {
+    showSetup = false;
+    vaultUrl = '';
+    secretName = '';
+    onRemove?.();
+  }
+</script>
+
+{#if showSetup || kvConfig}
+  <div class="kv-setup">
+    <div class="kv-setup-header">
+      <span class="kv-setup-title">Azure Key Vault</span>
+      <HelpTip
+        label="Azure Key Vault"
+        text="Requires Azure CLI (az login) or Azure Developer CLI (azd auth login). The vault URL should point to an existing Key Vault instance that your account has Secret read permissions on."
+      />
+      {#if connected}
+        <span class="kv-connected-badge">connected</span>
+      {:else if kvConfig}
+        <span class="kv-configured-badge">configured</span>
+      {/if}
+    </div>
+    <div class="kv-setup-fields">
+      <label class="kv-field">
+        <span class="kv-field-label">Vault URL</span>
+        <input
+          class="kv-field-input"
+          bind:value={vaultUrl}
+          placeholder="https://my-vault.vault.azure.net"
+          spellcheck="false"
+        />
+      </label>
+      <label class="kv-field">
+        <span class="kv-field-label">Secret name</span>
+        <input
+          class="kv-field-input"
+          bind:value={secretName}
+          placeholder="my-secret"
+          spellcheck="false"
+        />
+      </label>
+    </div>
+    <div class="kv-setup-actions">
+      <button
+        class="btn-kv-connect"
+        onclick={save}
+        disabled={!vaultUrl.trim() || !secretName.trim()}
+        >{kvConfig ? 'Save & refresh' : 'Connect'}</button
+      >
+      {#if kvConfig}
+        <button class="btn-kv-disconnect" onclick={remove}>Disconnect</button>
+      {:else}
+        <button
+          class="btn-kv-cancel"
+          onclick={() => {
+            showSetup = false;
+            vaultUrl = '';
+            secretName = '';
+          }}>Cancel</button
+        >
+      {/if}
+    </div>
+  </div>
+{:else}
+  <button class="btn-kv-add" onclick={() => (showSetup = true)}>
+    + Connect to Azure Key Vault
+  </button>
+{/if}
+
+<style>
+  .btn-kv-add {
+    padding: var(--space-2) var(--space-3\.5);
+    border: 1px dashed var(--color-border);
+    border-radius: var(--radius-default);
+    background: transparent;
+    color: var(--color-text-faint);
+    font-family: inherit;
+    font-size: var(--text-sm);
+    cursor: pointer;
+    transition: all var(--duration-normal);
+    align-self: flex-start;
+    margin-bottom: var(--space-4);
+  }
+  .btn-kv-add:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+  }
+
+  .kv-setup {
+    border: 1px solid var(--color-divider);
+    border-radius: var(--radius-default);
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-4);
+    background: color-mix(in srgb, var(--color-primary) 3%, transparent);
+  }
+  .kv-setup-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-3);
+  }
+  .kv-setup-title {
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    color: var(--color-text-secondary);
+    letter-spacing: 0.3px;
+  }
+  .kv-connected-badge {
+    font-size: var(--text-xs);
+    color: var(--color-success);
+    background: color-mix(in srgb, var(--color-success) 8%, transparent);
+    padding: 1px var(--space-2);
+    border-radius: var(--radius-xl);
+  }
+  .kv-configured-badge {
+    font-size: var(--text-xs);
+    color: var(--color-text-faint);
+    background: color-mix(in srgb, var(--color-text-faint) 8%, transparent);
+    padding: 1px var(--space-2);
+    border-radius: var(--radius-xl);
+  }
+  .kv-setup-fields {
+    display: flex;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+  }
+  .kv-field {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .kv-field-label {
+    font-size: var(--text-xs);
+    color: var(--color-text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .kv-field-input {
+    padding: var(--space-2) var(--space-2\.5);
+    border: 1px solid var(--color-divider);
+    border-radius: var(--radius-default);
+    background: var(--color-bg-surface);
+    color: var(--color-text);
+    font-family: inherit;
+    font-size: var(--text-md);
+    outline: none;
+    transition: border-color var(--duration-normal);
+  }
+  .kv-field-input:focus {
+    border-color: var(--color-primary);
+  }
+  .kv-field-input::placeholder {
+    color: var(--color-text-placeholder);
+  }
+  .kv-setup-actions {
+    display: flex;
+    gap: var(--space-2);
+  }
+  .btn-kv-connect {
+    padding: 5px var(--space-3);
+    border: 1px solid var(--color-primary);
+    border-radius: var(--radius-default);
+    background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+    color: var(--color-primary);
+    font-family: inherit;
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    cursor: pointer;
+    transition: all var(--duration-normal);
+  }
+  .btn-kv-connect:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--color-primary) 18%, transparent);
+  }
+  .btn-kv-connect:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .btn-kv-disconnect {
+    padding: 5px var(--space-3);
+    border: 1px solid var(--color-divider);
+    border-radius: var(--radius-default);
+    background: transparent;
+    color: var(--color-error);
+    font-family: inherit;
+    font-size: var(--text-sm);
+    cursor: pointer;
+    transition: all var(--duration-normal);
+  }
+  .btn-kv-disconnect:hover {
+    border-color: var(--color-error);
+    background: color-mix(in srgb, var(--color-error) 8%, transparent);
+  }
+  .btn-kv-cancel {
+    padding: 5px var(--space-3);
+    border: 1px solid var(--color-divider);
+    border-radius: var(--radius-default);
+    background: transparent;
+    color: var(--color-text-faint);
+    font-family: inherit;
+    font-size: var(--text-sm);
+    cursor: pointer;
+    transition: all var(--duration-normal);
+  }
+  .btn-kv-cancel:hover {
+    border-color: var(--color-text-faint);
+    color: var(--color-text);
+  }
+</style>


### PR DESCRIPTION
## Summary

Phase 4 (item 6) Svelte 5 runes migration for EnvironmentEditor, plus item 25's Key Vault panel extraction. No behavior change, no visual change.

### Commit 1: runes migration

- `export let` -> `$props()` with a `Props` interface
- `createEventDispatcher` -> callback props (`onUpdate`, `onChangeEnv`, `onClose`, `onSourcePref`, `onRefreshKv`); App.svelte wiring updated in the same commit (only the EnvironmentEditor element block was touched)
- `on:x` -> `onx`, `class:x` -> class array/object syntax
- local state -> `$state`, `$:` -> `$derived`
- The `lastEditingEnv`/fingerprint change-detection mechanism is replaced with a writable `$derived` for `envVars`: it recomputes from the env files, selected tab, and KV state, while local edits assign to it directly and round-trip through the parent via `saveVars()`. The manual fingerprint/`lastX` bookkeeping is gone.
- KV form fields became writable `$derived` keyed on the editing env, replacing the `lastKvConfigEnv` sync block
- `expandedGroups` uses `SvelteSet` instead of the `expandedGroups = expandedGroups` self-assignment trick
- Dropped the unused `addEnvInputEl` `bind:this`

### Commit 2: KeyVaultPanel extraction (item 25)

- New runes-native `src/components/KeyVaultPanel.svelte` (240 lines) owns the setup form (vault URL, secret name, connect/disconnect/cancel) and its styles
- EnvironmentEditor re-creates the panel per environment tab via `{#key editingEnv}`, preserving the reset-on-tab-switch behavior; it keeps the env-file mutations (`saveKvConfig`, `removeKvConfig`) and the KV status/retry banner
- EnvironmentEditor: 1349 -> 1117 lines

### Notes on semantics

The writable-`$derived` replacement preserves the legacy rebuild triggers (env tab switch, KV status change, env file content change via the save round-trip). One micro-difference: in-progress typing in the KV fields is no longer clobbered when an unrelated variable edit updates the env file with an unchanged `$keyvault` reference - the legacy `$:` sync re-ran on every file update.

## Verification

- `pnpm check`: 0 errors, 0 warnings
- `pnpm test`: 367 passed (20 files)
- `pnpm lint`: 0 errors (66 pre-existing warnings on untouched files)
- `pnpm exec prettier --check` clean on all three touched files
- `grep -nE "createEventDispatcher|export let|\$:|on:[a-z]|class:"` on both components: no legacy patterns

Part of the phase 4 big-four batch; TreeSidebar/TreeNode, RequestEditor, and FlowEditor are migrating on parallel branches, so this PR deliberately touches only the EnvironmentEditor call site in App.svelte.