### PR TITLE
refactor: migrate App.svelte to Svelte 5 runes (completes phase 4)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -91,22 +91,20 @@
   import { onDestroy } from 'svelte';
   import { get } from 'svelte/store';
 
-  let showEnvEditor = false;
-  let showVarInspector = false;
+  let showEnvEditor = $state(false);
+  let showVarInspector = $state(false);
 
-  let showHelp = false;
+  let showHelp = $state(false);
 
   // ─── Theme / Settings ───
-  let currentTheme: ThemeId = 'default';
-  let showSettings = false;
+  let currentTheme: ThemeId = $state('default');
+  let showSettings = $state(false);
   loadTheme().then((t) => (currentTheme = t));
   loadFavorites().then((f) => favorites.set(f));
 
   // ─── MCP status (titlebar pill) ───
-  // Plain legacy `let` (not $state) so App.svelte stays in legacy mode and
-  // the `$:` reactive statements elsewhere in this file keep working.
-  let mcpRunning = false;
-  let mcpPort = 3742;
+  let mcpRunning = $state(false);
+  let mcpPort = $state(3742);
 
   async function refreshMcpStatus() {
     try {
@@ -119,11 +117,11 @@
   }
 
   // ─── Import Collection Modal ───
-  let showImportCollectionModal = false;
+  let showImportCollectionModal = $state(false);
 
   // ─── Import Environment Modal ───
-  let showImportEnvModal = false;
-  let pendingImportVars: import('./lib/types').Variable[] = [];
+  let showImportEnvModal = $state(false);
+  let pendingImportVars: import('./lib/types').Variable[] = $state([]);
 
   async function handleImportEnvConfirm(target: string) {
     showImportEnvModal = false;
@@ -165,9 +163,9 @@
 
   // ─── Resizable Panes ───
 
-  let editorWidthPercent = loadLayoutNumber(LAYOUT_KEY_EDITOR_PCT, 50);
-  let dragging = false;
-  let mainPanelsEl: HTMLDivElement;
+  let editorWidthPercent = $state(loadLayoutNumber(LAYOUT_KEY_EDITOR_PCT, 50));
+  let dragging = $state(false);
+  let mainPanelsEl: HTMLDivElement | undefined = $state();
 
   function onDividerDown(e: MouseEvent) {
     e.preventDefault();
@@ -193,9 +191,9 @@
 
   // ─── Resizable Sidebar ───
 
-  let sidebarWidth = loadLayoutNumber(LAYOUT_KEY_SIDEBAR_PX, 260);
-  let sidebarDragging = false;
-  let layoutEl: HTMLDivElement;
+  let sidebarWidth = $state(loadLayoutNumber(LAYOUT_KEY_SIDEBAR_PX, 260));
+  let sidebarDragging = $state(false);
+  let layoutEl: HTMLDivElement | undefined = $state();
 
   function onSidebarDividerDown(e: MouseEvent) {
     e.preventDefault();
@@ -254,19 +252,24 @@
     };
   }
 
-  // Clear stale named results and response when environment changes
+  // Clear stale named results and response when environment changes.
+  // lastEnv is intentionally a plain (untracked) variable: the effect must
+  // re-run only when $activeEnvironment changes, and the first run (which
+  // sees lastEnv === null) records the initial environment without clearing.
   let lastEnv: string | null = null;
-  $: if ($activeEnvironment !== lastEnv) {
-    if (lastEnv !== null) {
-      namedResults.set({});
-      currentResponse.set(null);
-      currentSentRequest.set(null);
+  $effect(() => {
+    if ($activeEnvironment !== lastEnv) {
+      if (lastEnv !== null) {
+        namedResults.set({});
+        currentResponse.set(null);
+        currentSentRequest.set(null);
+      }
+      lastEnv = $activeEnvironment;
     }
-    lastEnv = $activeEnvironment;
-  }
+  });
 
   // Active tab's section tab (Body/Assertions) for pinned tabs
-  $: activeBottomTab = (() => {
+  let activeBottomTab: BottomTab = $derived.by(() => {
     const key =
       $tabs.length > 0 && $selectedLocation
         ? `${$selectedLocation.filePath}::${$selectedLocation.requestIndex}`
@@ -274,7 +277,7 @@
     if (!key) return 'body' as BottomTab;
     const tab = $tabs.find((t) => `${t.location.filePath}::${t.location.requestIndex}` === key);
     return tab?.bottomTab ?? ('body' as BottomTab);
-  })();
+  });
 
   function handleBottomTabChange(tab: BottomTab) {
     if ($selectedLocation) {
@@ -283,7 +286,7 @@
   }
 
   // Active response tab (Body/Headers/Request/Assertions) for pinned tabs
-  $: activeResponseTab = (() => {
+  let activeResponseTab: ResponseTab = $derived.by(() => {
     const key =
       $tabs.length > 0 && $selectedLocation
         ? `${$selectedLocation.filePath}::${$selectedLocation.requestIndex}`
@@ -291,7 +294,7 @@
     if (!key) return 'body' as ResponseTab;
     const tab = $tabs.find((t) => `${t.location.filePath}::${t.location.requestIndex}` === key);
     return tab?.responseTab ?? ('body' as ResponseTab);
-  })();
+  });
 
   function handleResponseTabChange(tab: ResponseTab) {
     if ($selectedLocation) {
@@ -300,7 +303,7 @@
   }
 
   // Reactive resolved URL - all store dependencies are explicit so Svelte tracks them
-  $: computedResolvedUrl = (() => {
+  let computedResolvedUrl = $derived.by(() => {
     if (!$activeRequest || !$activeRequest.url.includes('{{')) return '';
     const resolved = substituteAll($activeRequest.url, {
       fileVariables: $activeFileVariables,
@@ -310,7 +313,7 @@
     });
     // Only show if substitution actually changed something
     return resolved !== $activeRequest.url ? resolved : '';
-  })();
+  });
 
   // ─── Open Folder (scan for .http files) ───
   // Scanning and opening live in src/lib/workspaceIO.ts; the Key Vault hooks
@@ -337,9 +340,9 @@
 
   // ─── Favorites ───
 
-  let showAddFavoriteModal = false;
-  let pendingFavoritePath = '';
-  let pendingFavoriteName = '';
+  let showAddFavoriteModal = $state(false);
+  let pendingFavoritePath = $state('');
+  let pendingFavoriteName = $state('');
 
   /**
    * Toggle the currently open workspace folder in/out of the favorites list.
@@ -559,9 +562,10 @@
 
   // ─── Flow Handlers ───
 
+  // Not $state: only read inside handlers, never by the template.
   let flowAbortController: AbortController | null = null;
-  let lastFlowRunRecords: Record<string, FlowRunRecord> = {};
-  let runningFlowPath: string | null = null;
+  let lastFlowRunRecords: Record<string, FlowRunRecord> = $state({});
+  let runningFlowPath: string | null = $state(null);
 
   /** Persisted UI state for flow editors, keyed by flow path. */
   let flowUIState: Record<
@@ -571,7 +575,7 @@
       collapsedKeys: Record<string, boolean>;
       activeOverrideTabs: Record<string, string>;
     }
-  > = {};
+  > = $state({});
 
   async function handleRunFlow() {
     const flow = $activeFlow;
@@ -631,7 +635,6 @@
 
     record.flowFilePath = flowPathVal;
     lastFlowRunRecords[flowPathVal] = record;
-    lastFlowRunRecords = lastFlowRunRecords; // trigger reactivity
     flowRunState.set({ status: record.status, stepResults: record.stepResults });
     runningFlowPath = null;
 
@@ -809,7 +812,6 @@
             uiState={flowUIState[$activeFlowTabPath] ?? null}
             onUiStateChange={(state) => {
               flowUIState[$activeFlowTabPath] = state;
-              flowUIState = flowUIState;
             }}
             onSave={(detail) => saveFlow(detail.flowPath, detail.flow)}
             onRun={handleRunFlow}
@@ -819,7 +821,6 @@
                 $flowRunHistory.filter((r) => r.flowFilePath !== $activeFlowTabPath),
               );
               delete lastFlowRunRecords[$activeFlowTabPath];
-              lastFlowRunRecords = lastFlowRunRecords;
               if ($workspace.rootPath && $activeFlow) {
                 clearFlowRunHistory($workspace.rootPath, $activeFlow.name);
               }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -564,11 +564,11 @@
 
   // Not $state: only read inside handlers, never by the template.
   let flowAbortController: AbortController | null = null;
-  let lastFlowRunRecords: Record<string, FlowRunRecord> = $state({});
+  const lastFlowRunRecords: Record<string, FlowRunRecord> = $state({});
   let runningFlowPath: string | null = $state(null);
 
   /** Persisted UI state for flow editors, keyed by flow path. */
-  let flowUIState: Record<
+  const flowUIState: Record<
     string,
     {
       expandedStepId: string | null;
@@ -724,14 +724,14 @@
   onCancel={cancelAddFavorite}
 />
 
-<svelte:window on:dragover|preventDefault={() => {}} on:drop|preventDefault={() => {}} />
+<svelte:window ondragover={(e) => e.preventDefault()} ondrop={(e) => e.preventDefault()} />
 
 <main class="app">
   <div class="titlebar" data-tauri-drag-region>
     {#if mcpRunning}
       <button
         class="mcp-pill"
-        on:click={() => (showSettings = true)}
+        onclick={() => (showSettings = true)}
         title="MCP server running on port {mcpPort}"
       >
         <span class="mcp-dot"></span>
@@ -740,7 +740,7 @@
     {/if}
   </div>
 
-  <div class="layout" bind:this={layoutEl} class:sidebar-dragging={sidebarDragging}>
+  <div class={['layout', { 'sidebar-dragging': sidebarDragging }]} bind:this={layoutEl}>
     <div class="sidebar-container" style="width: {sidebarWidth}px; min-width: {sidebarWidth}px">
       <TreeSidebar
         selected={$selectedLocation}
@@ -762,7 +762,7 @@
       />
     </div>
     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-    <div class="sidebar-divider" on:mousedown={onSidebarDividerDown} role="separator"></div>
+    <div class="sidebar-divider" onmousedown={onSidebarDividerDown} role="separator"></div>
 
     <div class="main-area">
       <TabBar
@@ -780,7 +780,7 @@
           closeFlowTab(flowPath);
         }}
       />
-      <div class="main-panels" bind:this={mainPanelsEl} class:dragging>
+      <div class={['main-panels', { dragging }]} bind:this={mainPanelsEl}>
         {#if showEnvEditor}
           <div class="env-editor-pane">
             <EnvironmentEditor
@@ -845,7 +845,7 @@
             />
           </div>
           <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-          <div class="divider" on:mousedown={onDividerDown} role="separator"></div>
+          <div class="divider" onmousedown={onDividerDown} role="separator"></div>
           <div class="response-pane">
             <ResponseViewer
               response={$currentResponse}


### PR DESCRIPTION
## Summary

Migrates `src/App.svelte`, the last legacy-mode component, to Svelte 5 runes and removes the legacy-mode pin comment. This completes item 6 (phase 4) of the review remediation plan - the whole codebase is now runes-native.

- Local mutable state converted to `$state` (modals, theme, MCP pill, pane/sidebar sizes and drag flags, favorites, import vars, flow run bookkeeping)
- The three IIFE-based `$:` computations (`activeBottomTab`, `activeResponseTab`, `computedResolvedUrl`) converted to `$derived.by`
- The environment-change watcher converted to `$effect`; `lastEnv` stays a deliberately untracked plain variable so the effect re-runs only on `$activeEnvironment` changes and the first run records the initial environment without clearing (same skip-first-run semantics as the old `$:` block)
- `lastFlowRunRecords` / `flowUIState` self-assignment reactivity hacks removed - deep `$state` reactivity covers in-place mutation; both are now `const` (never reassigned)
- `flowAbortController` intentionally left as a plain variable (handler-only, never read by the template)
- `bind:this` element refs (`layoutEl`, `mainPanelsEl`) now `$state<HTMLDivElement | undefined>` as runes mode requires; existing null guards in the drag handlers already cover the undefined case
- Template: `on:click`/`on:mousedown` -> `onclick`/`onmousedown`; `svelte:window` `|preventDefault` modifiers -> explicit `e.preventDefault()` handlers; `class:sidebar-dragging`/`class:dragging` -> clsx-style class arrays per repo style
- No behavior change: pane resizing and layout persistence (localStorage keys unchanged, save-on-mouseup unchanged - the fix from 3d7c4b4 is intact), tab management, environment switching, request sending, flow running, imports, dialogs all as before

## Repo-wide acceptance (from the plan)

- `grep -rn "createEventDispatcher\|export let" src/` - no matches
- `grep -n "\$:\|on:\|class:" src/App.svelte` - no matches (remaining `on:`/`class:` hits elsewhere in src are CSS pseudo-selectors only)
- Legacy-mode pin comment removed from App.svelte

## Verification

- `pnpm check` - 0 errors, 0 warnings
- `pnpm test` - 382 passed
- `pnpm lint` - 0 errors (59 pre-existing warnings, unchanged)
- `pnpm exec prettier --check src/App.svelte` - clean

Manual smoke test recommended before merge: drag both dividers and restart the app (layout persistence), pin/close tabs, switch environment (stale results clear), send a request, run a flow, import a collection.